### PR TITLE
Fix so that onfocus events are fired on single and multiline TextInpu…

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -145,7 +145,16 @@ static UIColor *defaultPlaceholderColor()
 
 - (BOOL)becomeFirstResponder
 {
-  return [self.window makeFirstResponder:self];
+  BOOL success =  [[self window] makeFirstResponder:self];
+
+  if (success) {
+    id<RCTBackedTextInputDelegate> textInputDelegate = [self textInputDelegate];
+    if ([textInputDelegate respondsToSelector:@selector(textInputDidBeginEditing)]) {
+      [textInputDelegate textInputDidBeginEditing];
+    }
+  }
+
+  return success;
 }
 
 #endif // ]TODO(macOS ISS#2323203)

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -305,15 +305,6 @@ static UIColor *defaultPlaceholderTextColor()
   
 #pragma mark - NSTextViewDelegate methods
 
-- (void)textDidBeginEditing:(NSNotification *)notification
-{
-  [super textDidBeginEditing:notification];
-  id<RCTUITextFieldDelegate> delegate = self.delegate;
-  if ([delegate respondsToSelector:@selector(textFieldBeginEditing:)]) {
-    [delegate textFieldBeginEditing:self];
-  }
-}
-  
 - (void)textDidChange:(NSNotification *)notification
 {
   [super textDidChange:notification];
@@ -358,6 +349,15 @@ static UIColor *defaultPlaceholderTextColor()
 {
   BOOL isFirstResponder = [super becomeFirstResponder];
   if (isFirstResponder) {
+    id<RCTUITextFieldDelegate> delegate = self.delegate;
+    if ([delegate respondsToSelector:@selector(textFieldBeginEditing:)]) {
+      // The AppKit -[NSTextField textDidBeginEditing:] notification is only called when the user
+      // makes the first change to the text in the text field.
+      // The react-native -[RCTUITextFieldDelegate textFieldBeginEditing:] is intended to be
+      // called when the text field is focused so call it here in becomeFirstResponder.
+      [delegate textFieldBeginEditing:self];
+    }
+
     NSScrollView *scrollView = [self enclosingScrollView];
     if (scrollView != nil) {
       NSRect visibleRect = [[scrollView documentView] convertRect:self.frame fromView:self];

--- a/RNTester/js/FocusEventsExample.js
+++ b/RNTester/js/FocusEventsExample.js
@@ -16,7 +16,7 @@ var Platform = require('Platform');
 var {StyleSheet, Text, View, TextInput} = ReactNative;
 
 type State = {
-  eventStream: string;
+  eventStream: string,
 };
 
 class FocusEventExample extends React.Component<{}, State> {
@@ -28,38 +28,158 @@ class FocusEventExample extends React.Component<{}, State> {
     return (
       <View>
         <Text>
-          Focus events are called when a component receives or loses focus.
-          This can be acquired by manually focusing components {Platform.OS === 'macos' ? ' or using tab-based nav' : '' }
+          Focus events are called when a component receives or loses focus. This
+          can be acquired by manually focusing components
+          {Platform.OS === 'macos' ? ' or using tab-based nav' : ''}
         </Text>
         <View>
           <TextInput
             onFocus={() => {
-              this.setState((prevState) => ({ eventStream: prevState.eventStream + '\nTextInput Focus' }));
+              this.setState(prevState => ({
+                eventStream: prevState.eventStream + '\nTextInput Focus',
+              }));
             }}
             onBlur={() => {
-              this.setState((prevState) => ({ eventStream: prevState.eventStream + '\nTextInput Blur' }));
+              this.setState(prevState => ({
+                eventStream: prevState.eventStream + '\nTextInput Blur',
+              }));
             }}
-            style={styles.default}
+            placeholder={'TextInput'}
+            placeholderTextColor={
+              Platform.OS === 'macos' ? {semantic: 'textColor'} : 'black'
+            }
+            style={styles.textInput}
           />
-          
+
           {// Only test View on MacOS, since canBecomeFirstResponder is false on all iOS, therefore we can't focus
-            Platform.OS === 'macos' ?
-            <View style={styles.default}
-              acceptsKeyboardFocus={true}onFocus={() => {
-                this.setState((prevState) => ({ eventStream: prevState.eventStream + '\nView Focus' }));
+          Platform.OS === 'macos' ? (
+            <View
+              acceptsKeyboardFocus={true}
+              enableFocusRing={true}
+              onFocus={() => {
+                this.setState(prevState => ({
+                  eventStream: prevState.eventStream + '\nView Focus',
+                }));
               }}
               onBlur={() => {
-                this.setState((prevState) => ({ eventStream: prevState.eventStream + '\nView Blur' }));
-              }}
-            >
-              <Text>
-                Focusable View
-              </Text>
+                this.setState(prevState => ({
+                  eventStream: prevState.eventStream + '\nView Blur',
+                }));
+              }}>
+              <Text>Focusable View</Text>
             </View>
-            : null}
-          <Text>
-            {'Events: ' + this.state.eventStream + '\n\n'}
-          </Text>
+          ) : null}
+
+          <View
+            onFocus={() => {
+              this.setState(prevState => ({
+                eventStream:
+                  prevState.eventStream +
+                  '\nNested Singleline TextInput Parent Focus',
+              }));
+            }}
+            onBlur={() => {
+              this.setState(prevState => ({
+                eventStream:
+                  prevState.eventStream +
+                  '\nNested Singleline TextInput Parent Blur',
+              }));
+            }}>
+            <TextInput
+              onFocus={() => {
+                this.setState(prevState => ({
+                  eventStream:
+                    prevState.eventStream +
+                    '\nNested Singleline TextInput Focus',
+                }));
+              }}
+              onBlur={() => {
+                this.setState(prevState => ({
+                  eventStream:
+                    prevState.eventStream +
+                    '\nNested Singleline TextInput Blur',
+                }));
+              }}
+              style={styles.textInput}
+              placeholder={'Nested Singleline TextInput'}
+              placeholderTextColor={
+                Platform.OS === 'macos' ? {semantic: 'textColor'} : 'black'
+              }
+            />
+          </View>
+
+          {// Only test View on MacOS, since canBecomeFirstResponder is false on all iOS, therefore we can't focus
+          Platform.OS === 'macos' ? (
+            <View
+              onFocus={() => {
+                this.setState(prevState => ({
+                  eventStream:
+                    prevState.eventStream + '\nNested View Parent Focus',
+                }));
+              }}
+              onBlur={() => {
+                this.setState(prevState => ({
+                  eventStream:
+                    prevState.eventStream + '\nNested View Parent Blur',
+                }));
+              }}>
+              <View
+                acceptsKeyboardFocus={true}
+                enableFocusRing={true}
+                onFocus={() => {
+                  this.setState(prevState => ({
+                    eventStream: prevState.eventStream + '\nNested View Focus',
+                  }));
+                }}
+                onBlur={() => {
+                  this.setState(prevState => ({
+                    eventStream: prevState.eventStream + '\nNested View Blur',
+                  }));
+                }}>
+                <Text>Nested Focusable View</Text>
+              </View>
+            </View>
+          ) : null}
+
+          <View
+            onFocus={() => {
+              this.setState(prevState => ({
+                eventStream:
+                  prevState.eventStream +
+                  '\nNested Multiline TextInput Parent Focus',
+              }));
+            }}
+            onBlur={() => {
+              this.setState(prevState => ({
+                eventStream:
+                  prevState.eventStream +
+                  '\nNested Multiline TextInput Parent Blur',
+              }));
+            }}>
+            <TextInput
+              onFocus={() => {
+                this.setState(prevState => ({
+                  eventStream:
+                    prevState.eventStream +
+                    '\nNested Multiline TextInput Focus',
+                }));
+              }}
+              onBlur={() => {
+                this.setState(prevState => ({
+                  eventStream:
+                    prevState.eventStream + '\nNested Multiline TextInput Blur',
+                }));
+              }}
+              style={styles.textInput}
+              multiline={true}
+              placeholder={'Nested Multiline TextInput'}
+              placeholderTextColor={
+                Platform.OS === 'macos' ? {semantic: 'textColor'} : 'black'
+              }
+            />
+          </View>
+
+          <Text>{'Events: ' + this.state.eventStream + '\n\n'}</Text>
         </View>
       </View>
     );
@@ -67,9 +187,18 @@ class FocusEventExample extends React.Component<{}, State> {
 }
 
 var styles = StyleSheet.create({
-  default: {
+  textInput: {
+    ...Platform.select({
+      macos: {
+        color: {semantic: 'textColor'},
+        backgroundColor: {semantic: 'textBackgroundColor'},
+        borderColor: {semantic: 'gridColor'},
+      },
+      default: {
+        borderColor: '#0f0f0f',
+      },
+    }),
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: '#0f0f0f',
     flex: 1,
     fontSize: 13,
     padding: 4,
@@ -77,8 +206,7 @@ var styles = StyleSheet.create({
 });
 
 exports.title = 'Focus Events';
-exports.description =
-  'Examples that show how Focus events can be used.';
+exports.description = 'Examples that show how Focus events can be used.';
 exports.examples = [
   {
     title: 'FocusEventExample',


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our Microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

# PROBLEM
In macOS, the onFocus events on TextInput components are never being fired.  onBlur events are working.

# FIX
The TextInput component has two alternate implementations depending on if the multiline prop is true or false: either a RCTUITextView or RCTUITextField.  Both have a RCTBackedTextInputDelegate which combines and normalizes the events of UITextView, UITextField, NSTextView and NSTextField.   

The RCTUITextField (which is a subclass of NSTextField on macOS) was relying on the -[NSTextField textDidBeginEditing:] notification for focus events and then called the -[RCTUITextFieldDelegate textFieldBeginEditing:] delegate method.   But this event is fired only when the user first makes a change to the text of the field.   Changed the implementation to call -[RCTUITextFieldDelegate textFieldBeginEditing:] in the becomeFirstResponder override instead.

The RCTUITextView (which is a sublcass of NSTextView) wasn't calling the -[RCTUITextFieldDelegate textFieldBeginEditing:] delegate method at all.   Similar to RCTUITextField we now call the delegate in its becomeFirstResponder override.

# PRODUCT IMPACT
macOS TextInputs will now receive the onFocus events.

# VERIFICATION
Extended the existing RNTester FocusEventsExample.js test panel.   In its original form it had a single TextInput and a View that both can receive focus.   Extended it to also have a TextInput and View nested within Views that also have onFocus/onBlur callbacks to test the event bubbling.   Also made a third TextInput with multiline={true} to verify that both single and multiline TextInputs property trigger the events.

@acoates-ms ; @HeyImChris ; @markavitale