### PR TITLE
Fix macOS ActivityIndicator to color properly in different themes

### DIFF
--- a/RNTester/js/ActivityIndicatorExample.js
+++ b/RNTester/js/ActivityIndicatorExample.js
@@ -12,6 +12,7 @@
 
 import React, {Component} from 'react';
 import {ActivityIndicator, StyleSheet, View} from 'react-native';
+const Platform = require('Platform');
 
 /**
  * Optional Flowtype state and timer types definition
@@ -99,8 +100,18 @@ exports.examples = [
     render() {
       return (
         <View style={styles.horizontal}>
-          <ActivityIndicator color="#0000ff" />
-          <ActivityIndicator color="#aa00aa" />
+          <ActivityIndicator
+            color={
+              Platform.OS === 'macos'
+                ? {dynamic: {light: 'black', dark: 'white'}}
+                : '#0000ff'
+            }
+          />
+          <ActivityIndicator
+            color={
+              Platform.OS === 'macos' ? {semantic: 'textColor'} : '#aa00aa'
+            }
+          />
           <ActivityIndicator color="#aa3300" />
           <ActivityIndicator color="#00aa00" />
         </View>
@@ -148,7 +159,7 @@ exports.examples = [
           size="large"
         />
       );
-    }
+    },
   },
   {
     platform: 'android',
@@ -184,5 +195,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-around',
     padding: 8,
+    ...Platform.select({
+      macos: {
+        backgroundColor: {semantic: 'windowBackgroundColor'},
+      },
+      default: {
+        backgroundColor: undefined,
+      },
+    }),
   },
 });

--- a/React/Views/RCTActivityIndicatorView.m
+++ b/React/Views/RCTActivityIndicatorView.m
@@ -66,11 +66,6 @@
   }
 }
 
-- (void)setColor:(UIColor*)color
-{
-  _color = color;
-}
-
 - (void)updateLayer
 {
   [super updateLayer];

--- a/React/Views/RCTActivityIndicatorView.m
+++ b/React/Views/RCTActivityIndicatorView.m
@@ -68,16 +68,26 @@
 
 - (void)setColor:(UIColor*)color
 {
-  _color = [color colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
-  CIFilter *colorPoly = [CIFilter filterWithName:@"CIColorPolynomial"];
-  [colorPoly setDefaults];
-  CIVector *redVector = [CIVector vectorWithX:color.redComponent Y:0 Z:0 W:0];
-  CIVector *greenVector = [CIVector vectorWithX:color.greenComponent Y:0 Z:0 W:0];
-  CIVector *blueVector = [CIVector vectorWithX:color.blueComponent Y:0 Z:0 W:0];
-  [colorPoly setValue:redVector forKey:@"inputRedCoefficients"];
-  [colorPoly setValue:greenVector forKey:@"inputGreenCoefficients"];
-  [colorPoly setValue:blueVector forKey:@"inputBlueCoefficients"];
-  self.contentFilters = @[colorPoly];
+  _color = color;
+}
+
+- (void)updateLayer
+{
+  [super updateLayer];
+  if (_color) {
+    CGFloat r, g, b, a;
+    [[_color colorUsingColorSpaceName:NSCalibratedRGBColorSpace] getRed:&r green:&g blue:&b alpha:&a];
+
+    CIFilter *colorPoly = [CIFilter filterWithName:@"CIColorPolynomial"];
+    [colorPoly setDefaults];
+    CIVector *redVector = [CIVector vectorWithX:r Y:0 Z:0 W:0];
+    CIVector *greenVector = [CIVector vectorWithX:g Y:0 Z:0 W:0];
+    CIVector *blueVector = [CIVector vectorWithX:b Y:0 Z:0 W:0];
+    [colorPoly setValue:redVector forKey:@"inputRedCoefficients"];
+    [colorPoly setValue:greenVector forKey:@"inputGreenCoefficients"];
+    [colorPoly setValue:blueVector forKey:@"inputBlueCoefficients"];
+    self.contentFilters = @[colorPoly];
+  }
 }
 
 - (void)setHidesWhenStopped:(BOOL)hidesWhenStopped

--- a/React/Views/RCTActivityIndicatorView.m
+++ b/React/Views/RCTActivityIndicatorView.m
@@ -66,6 +66,14 @@
   }
 }
 
+- (void)setColor: (UIColor*)color
+{
+  if (_color != color) {
+    _color = color;
+    [self setNeedsDisplay:YES];
+  }
+}
+
 - (void)updateLayer
 {
   [super updateLayer];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

PROBLEM
ISS#3218502: LPC in Dark Mode: progress spinner doesn't spin/animate
The RCTActivityIndicatorView.m was flattening an NSColor and using its components to create layer contentFilter at the time that the `color` prop was being set.   In Mojave, NSColors should only ever be converted to colorspaces in one of four methods: updateLayer, drawRect:, layout, updateConstraints.  Since it was not performing the operation in any of these methods, the contentFilter was not responding to theme changes.

FIX
Override the updateLayer method and there flatten the _color prop to its components only if it exists, and then set the contentFilter.

PRODUCT IMPACT
Impacts any macOS SDX that uses the ActivityIndicator (LPC) and makes it render properly in all themes.

VERIFICATION 
Added semantic and dynamic colors in the ActivityIndicatorExample in RNTester to validate.

@markavitale ; @HeyImChris 

/azp run