### PR TITLE
For Windows Desktop, pass close code and reason to WebSocket.close()

### DIFF
--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -224,7 +224,7 @@ class WebSocket extends EventTarget(...WEBSOCKET_EVENTS) {
   }
 
   _close(code?: number, reason?: string): void {
-    if (Platform.OS === 'android') {
+    if (Platform.OS === 'android' || Platform.OS === 'win32' || Platform.OS == 'windesktop') {
       // See https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
       const statusCode = typeof code === 'number' ? code : CLOSE_NORMAL;
       const closeReason = typeof reason === 'string' ? reason : '';


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

See `WebSocket.js`, near [line 227](https://github.com/Microsoft/react-native/blob/master/Libraries/WebSocket/WebSocket.js#L227):
```
if (Platform.OS === 'android') {
  WebSocketModule.close(statusCode, closeReason, this._socketId);
```

Currently, only Android ReactNative instances pass `closeReason` and `statusCode`.
For non-Android platforms, default values are hard-coded.
Windows Desktop (`win32`) has no reason to use these default values.

This change ensures those parameters are passed on from the JavaScript side.




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/16)