### PR TITLE
Fix to RCTTestRunner so that RedBox errors are logged when piped thru…

### DIFF
--- a/Libraries/RCTTest/RCTTestRunner.m
+++ b/Libraries/RCTTest/RCTTestRunner.m
@@ -199,7 +199,9 @@ expectErrorBlock:(BOOL(^)(NSString *error))expectErrorBlock
     if (expectErrorBlock) {
       RCTAssert(expectErrorBlock(errors[0]), @"Expected an error but the first one was missing or did not match.");
     } else {
-      RCTAssert(errors == nil, @"RedBox errors: %@", errors);
+      // [TODO(OSS Candidate ISS#2710739): xcpretty formats the test failure output to show only one line of the assert string followed by a snippet of source code including the assert statement and the lines just before and after.
+      // Convert the `errors` array into a single line string delimited by \n so that CI logs contain meaningful information.
+      RCTAssert(errors == nil, @"RedBox errors: %@", [[errors valueForKey:@"description"] componentsJoinedByString:@"\\n"]); // ]TODO(OSS Candidate ISS#2710739)
       RCTAssert(testModule.status != RCTTestStatusPending, @"Test didn't finish within %0.f seconds", kTestTimeoutSeconds);
       RCTAssert(testModule.status == RCTTestStatusPassed, @"Test failed");
     }

--- a/Libraries/WebSocket/WebSocket.js
+++ b/Libraries/WebSocket/WebSocket.js
@@ -224,7 +224,11 @@ class WebSocket extends EventTarget(...WEBSOCKET_EVENTS) {
   }
 
   _close(code?: number, reason?: string): void {
-    if (Platform.OS === 'android' || Platform.OS === 'win32' || Platform.OS == 'windesktop') {
+    if (
+      Platform.OS === 'android' ||
+      Platform.OS === 'win32' ||
+      Platform.OS === 'windesktop'
+    ) {
       // See https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
       const statusCode = typeof code === 'number' ? code : CLOSE_NORMAL;
       const closeReason = typeof reason === 'string' ? reason : '';

--- a/RNTester/js/RNTesterApp.ios.js
+++ b/RNTester/js/RNTesterApp.ios.js
@@ -58,13 +58,21 @@ const Header = ({onBack, title}: {onBack?: () => mixed, title: string}) => (
 );
 
 class RNTesterApp extends React.Component<Props, RNTesterNavigationState> {
+  _mounted: boolean; // TODO(OSS Candidate ISS#2710739)
+
   UNSAFE_componentWillMount() {
     BackHandler.addEventListener('hardwareBackPress', this._handleBack);
   }
 
   componentDidMount() {
+    this._mounted = true; // TODO(OSS Candidate ISS#2710739)
     Linking.getInitialURL().then(url => {
       AsyncStorage.getItem(APP_STATE_KEY, (err, storedString) => {
+        // [TODO(OSS Candidate ISS#2710739)
+        if (!this._mounted) {
+          return;
+        }
+        // ]TODO(OSS Candidate ISS#2710739)
         const exampleAction = URIActionMap(
           this.props.exampleFromAppetizeParams,
         );
@@ -88,6 +96,12 @@ class RNTesterApp extends React.Component<Props, RNTesterNavigationState> {
       this._handleAction(URIActionMap(url));
     });
   }
+
+  // [TODO(OSS Candidate ISS#2710739)
+  componentWillUnmount() {
+    this._mounted = false;
+  }
+  // ]TODO(OSS Candidate ISS#2710739)
 
   _handleBack = () => {
     this._handleAction(RNTesterActions.Back());

--- a/RNTester/js/RNTesterApp.macos.js
+++ b/RNTester/js/RNTesterApp.macos.js
@@ -60,13 +60,21 @@ const Header = ({onBack, title}: {onBack?: () => mixed, title: string}) => (
 );
 
 class RNTesterApp extends React.Component<Props, RNTesterNavigationState> {
+  _mounted: boolean; // TODO(OSS Candidate ISS#2710739)
+
   UNSAFE_componentWillMount() {
     //  BackHandler.addEventListener('hardwareBackPress', this._handleBack);
   }
 
   componentDidMount() {
+    this._mounted = true; // TODO(OSS Candidate ISS#2710739)
     Linking.getInitialURL().then(url => {
       AsyncStorage.getItem(APP_STATE_KEY, (err, storedString) => {
+        // [TODO(OSS Candidate ISS#2710739)
+        if (!this._mounted) {
+          return;
+        }
+        // ]TODO(OSS Candidate ISS#2710739)
         const exampleAction = URIActionMap(
           this.props.exampleFromAppetizeParams,
         );
@@ -90,6 +98,12 @@ class RNTesterApp extends React.Component<Props, RNTesterNavigationState> {
       this._handleAction(URIActionMap(url));
     });
   }
+
+  // [TODO(OSS Candidate ISS#2710739)
+  componentWillUnmount() {
+    this._mounted = false;
+  }
+  // ]TODO(OSS Candidate ISS#2710739)
 
   _handleBack = () => {
     this._handleAction(RNTesterActions.Back());


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

The RNTester RNTesterIntegrationTests suite is unreliable when run in Azure DevOps CI loops: only about 86% pass rate.   It was difficult to diagnose the problem because the logs would show that specific integration tests were failing with a RedBox message, but the contents of the RedBox message were not being logged.

The Azure DevOps build definition tests via xcodebuild and the results are piped to xcpretty which formats the xcodebuild output and generates a JUnit xml results file that ADO uses for analytics.   The RCTTestRunner.m file collects the RedBox error messages in an NSMutableArray and then does an RCTAssert using a formatted message string that formats the array using `%@`.  The '%@' format prints an array on multiple lines, but xcpretty will only print the *first* line of a multiline string.   Change the RCTAssert line so that the `errors` array is flattened into a single line string delimited by '\n' characters.

With the above fix to RCTTestRunner.m I was able to see that the integration tests were asserting because of the react warning `'Warning: Can\'t call setState (or forceUpdate) on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.%s', '\n    in RNTesterApp`.   That was happening because a setState call could happen in the AsyncStorage callback *after* the component had unmounted: presumably because the test ran and concluded before AsyncStorage returned.   Changed RNTesterApp.ios.js and RNTesterApp.macos.js to maintain a _mounted field that is set and cleared in componentDidMount() and componentWillUnmount() and refrain from calling setState() if the flag is false.

Also fixed an ESLint error that somehow got committed to Libraries/WebSocket/WebSocket.js.

This will resolve bug [3237057](https://office.visualstudio.com/DefaultCollection/ISS/_workitems/edit/3237057).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/18)