### PR TITLE
Temporary fix to make win32 yellowbox not use %'s for now

### DIFF
--- a/Libraries/YellowBox/UI/YellowBoxList.js
+++ b/Libraries/YellowBox/UI/YellowBoxList.js
@@ -126,16 +126,16 @@ const styles = StyleSheet.create({
   list: {
     bottom: 0,
     position: 'absolute',
-    width: '100%',
+    width: Platform.OS === 'win32' ? 270: '100%',
   },
   dismissAll: {
-    bottom: '100%',
+    bottom: Platform.OS === 'win32' ? undefined : '100%',
     flexDirection: 'row',
     justifyContent: 'flex-end',
     paddingBottom: 4,
     paddingEnd: 4,
     position: 'absolute',
-    width: '100%',
+    width: Platform.OS === 'win32' ? 350: '100%',
   },
   safeArea: {
     backgroundColor: YellowBoxStyle.getBackgroundColor(0.95),


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our Microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

Until we properly support % sizes in layout for win32, make yellowbox use something other than %'s




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/21)