### PR TITLE
Remove default color value for mac ActivityIndicator so that it uses

### DIFF
--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -116,7 +116,7 @@ const ActivityIndicatorWithRef = React.forwardRef(ActivityIndicator);
 
 ActivityIndicatorWithRef.defaultProps = {
   animating: true,
-  color: Platform.OS === 'ios' || Platform.OS === 'macos' ? GRAY : null, // TODO(macOS ISS#2323203)
+  color: Platform.OS === 'ios' ? GRAY : null,
   hidesWhenStopped: true,
   size: 'small',
 };


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

The `<ActivityIndicator>` for macOS was setting the `color` prop to a default grey color if the prop was absent in the JS.  This means that on macOS its never possible to have the default system color for the Activity Indicator because in the RCTActivityIndicator.m native implementation the setColor: method sets an NSColor ivar that if non-nil will set a contentFilter using that color.   So, even if the `color` prop was not set, the NSActivityIndicator would get a grey colored contentFilter applied.

The change essentially removes a delta from the original facebook ActivityIndicator.js file making it so that only the ios platform will ever default to grey.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/23)