### PR TITLE
Adding logging support on droid and logging failure message

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/v8executor/OnLoad.cpp
+++ b/ReactAndroid/src/main/java/com/facebook/react/v8executor/OnLoad.cpp
@@ -13,12 +13,6 @@
 #include <react/jni/ReadableNativeMap.h>
 
 namespace facebook {
-namespace v8runtime {
-      std::unique_ptr<jsi::Runtime> makeV8Runtime();
-} // namespace v8runtime
-} // namespace facebook
-
-namespace facebook {
 namespace react {
 
 namespace {
@@ -31,13 +25,16 @@ public:
 
   std::unique_ptr<JSExecutor> createJSExecutor(
       std::shared_ptr<ExecutorDelegate> delegate,
-      std::shared_ptr<MessageQueueThread> jsQueue) override {
+      std::shared_ptr<MessageQueueThread> jsQueue) override {    
+    
+    auto logger = std::make_shared<JSIExecutor::Logger>([](const std::string& message, unsigned int logLevel) {
+                    reactAndroidLoggingHook(message, logLevel);
+    });
+
     return folly::make_unique<JSIExecutor>(
-      facebook::v8runtime::makeV8Runtime(m_v8Config),
+      facebook::v8runtime::makeV8Runtime(m_v8Config, logger),
       delegate,
-      [](const std::string& message, unsigned int logLevel) {
-        reactAndroidLoggingHook(message, logLevel);
-      },
+      *logger,
       JSIExecutor::defaultTimeoutInvoker,
       nullptr);
   }

--- a/ReactCommon/jsi/V8Runtime.h
+++ b/ReactCommon/jsi/V8Runtime.h
@@ -60,7 +60,7 @@ namespace v8runtime {
     std::unique_ptr<const jsi::Buffer> custom_snapshot = nullptr); /*Optional*/
 
   std::unique_ptr<jsi::Runtime> makeV8Runtime();
-  std::unique_ptr<jsi::Runtime> makeV8Runtime(const folly::dynamic& v8Config);
+  std::unique_ptr<jsi::Runtime> makeV8Runtime(const folly::dynamic& v8Config, const std::shared_ptr<Logger>& logger);
 
 } // namespace v8runtime
 } // namespace facebook

--- a/ReactCommon/jsi/V8Runtime_droid.cpp
+++ b/ReactCommon/jsi/V8Runtime_droid.cpp
@@ -50,7 +50,8 @@ namespace facebook { namespace v8runtime {
     }
   }
 
-  V8Runtime::V8Runtime(const folly::dynamic& v8Config) : V8Runtime() {
+  V8Runtime::V8Runtime(const folly::dynamic& v8Config, const std::shared_ptr<Logger>& logger) : V8Runtime() {
+    logger_ = logger;
     isCacheEnabled_  = IsCacheEnabled(v8Config);
     shouldProduceFullCache_ = ShouldProduceFullCache(v8Config);
     shouldSetNoLazyFlag_ = ShouldSetNoLazyFlag(v8Config);

--- a/ReactCommon/jsi/V8Runtime_impl.h
+++ b/ReactCommon/jsi/V8Runtime_impl.h
@@ -43,7 +43,7 @@ namespace facebook { namespace v8runtime {
   class V8Runtime : public jsi::Runtime {
   public:
     V8Runtime();
-    V8Runtime(const folly::dynamic& v8Config);
+    V8Runtime(const folly::dynamic& v8Config, const std::shared_ptr<Logger>& logger);
 
     V8Runtime(const v8::Platform* platform, std::shared_ptr<Logger>&& logger,
       std::shared_ptr<facebook::react::MessageQueueThread>&& jsQueue, std::shared_ptr<CacheProvider>&& cacheProvider,
@@ -373,6 +373,12 @@ namespace facebook { namespace v8runtime {
 
     bool ExecuteString(v8::Local<v8::String> source, const jsi::Buffer* cache, v8::Local<v8::Value> name, bool report_exceptions);
     bool ExecuteString(const v8::Local<v8::String>& source, const std::string& sourceURL);
+
+    void Log(const std::string& message, const unsigned int logLevel) {
+      if (logger_) {
+        (*logger_)("V8Runtime:: " + message, logLevel);
+      }
+    }
 
     void ReportException(v8::TryCatch* try_catch);
 

--- a/ReactCommon/jsi/V8Runtime_shared.cpp
+++ b/ReactCommon/jsi/V8Runtime_shared.cpp
@@ -247,7 +247,9 @@ namespace facebook { namespace v8runtime {
     if (message.IsEmpty()) {
       // V8 didn't provide any extra information about this error; just
       // throw the exception.
-      throw jsi::JSError(*this, "<Unknown exception>");
+      std::string errorMessage{ "<Unknown exception>" };
+      Log(errorMessage, 3 /*LogLevel error*/);
+      throw jsi::JSError(*this, errorMessage);
     }
     else {
       // Print (filename):(line number): (message).
@@ -283,7 +285,9 @@ namespace facebook { namespace v8runtime {
         sstr << stack_trace_string2 << std::endl;
       }
 
-      throw jsi::JSError(*this, sstr.str());
+      std::string errorMessage{ sstr.str() };
+      Log(errorMessage, 3 /*LogLevel error*/);
+      throw jsi::JSError(*this, errorMessage);
     }
   }
 
@@ -740,7 +744,7 @@ namespace facebook { namespace v8runtime {
     return std::make_unique<V8Runtime>();
   }
 
-  std::unique_ptr<jsi::Runtime> makeV8Runtime(const folly::dynamic& v8Config) {
-    return std::make_unique<V8Runtime>(v8Config);
+  std::unique_ptr<jsi::Runtime> makeV8Runtime(const folly::dynamic& v8Config, const std::shared_ptr<Logger>& logger) {
+    return std::make_unique<V8Runtime>(v8Config, logger);
   }
 }} // namespace facebook::v8runtime


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our Microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

#### Description of changes

Adding logging support in V8Runtime for droid and logging failure message during exception.

#### Focus areas to test

Verified that V8Runtime is emitting error logs during V8 related exceptions.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/31)