### PR TITLE
Prevent race where devSettings property is called before bridge is do…

### DIFF
--- a/React/Modules/RCTDevSettings.mm
+++ b/React/Modules/RCTDevSettings.mm
@@ -509,9 +509,9 @@ RCT_EXPORT_METHOD(toggleElementInspector)
 {
 #if RCT_DEV
   RCTDevSettings *devSettings = nil; // [TODO(OSS Candidate ISS#2710739)
-  Class klass = [RCTDevSettings class];
-  if ([self moduleIsInitialized:klass]) {
-    devSettings = [self moduleForClass:klass];
+  Class devSettingsClass = [RCTDevSettings class];
+  if ([self moduleIsInitialized:devSettingsClass]) {
+    devSettings = [self moduleForClass:devSettingsClass];
   }
   return devSettings; // ]TODO(OSS Candidate ISS#2710739)
 #else

--- a/React/Modules/RCTDevSettings.mm
+++ b/React/Modules/RCTDevSettings.mm
@@ -508,7 +508,12 @@ RCT_EXPORT_METHOD(toggleElementInspector)
 - (RCTDevSettings *)devSettings
 {
 #if RCT_DEV
-  return [self moduleForClass:[RCTDevSettings class]];
+  RCTDevSettings *devSettings = nil; // [TODO(OSS Candidate ISS#2710739)
+  Class klass = [RCTDevSettings class];
+  if ([self moduleIsInitialized:klass]) {
+    devSettings = [self moduleForClass:klass];
+  }
+  return devSettings; // ]TODO(OSS Candidate ISS#2710739)
 #else
   return nil;
 #endif


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

The devSettings property can cause a second bridge to be created if called during the initialization of the "real" bridge.   Test that the RCTDevSettings modules has already been initialized before fetching it.

/azp run

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/35)