### PR TITLE
Cleanup dead files from cmake script

### DIFF
--- a/React/CMakeLists.txt
+++ b/React/CMakeLists.txt
@@ -71,7 +71,6 @@ set(REACT_SRC_HEADERS
   Modules/RCTExceptionsManager.h
   Modules/RCTI18nManager.h
   Modules/RCTI18nUtil.h
-  Modules/RCTJSCSamplingProfiler.h
   Modules/RCTKeyboardObserver.h
   Modules/RCTLayoutAnimation.h
   Modules/RCTLayoutAnimationGroup.h
@@ -100,10 +99,6 @@ set(REACT_SRC_HEADERS
   Views/RCTModalHostView.h
   Views/RCTModalHostViewController.h
   Views/RCTModalHostViewManager.h
-  Views/RCTNavigator.h
-  Views/RCTNavigatorManager.h
-  Views/RCTNavItem.h
-  Views/RCTNavItemManager.h
   Views/RCTPicker.h
   Views/RCTPickerManager.h
   Views/RCTPointerEvents.h


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our Microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

With RN58 some files were removed that are still references in the CMake builds.  This removes those references.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/39)