### PR TITLE
Updated folly path.

### DIFF
--- a/ReactApple/ReactApple.nuspec
+++ b/ReactApple/ReactApple.nuspec
@@ -27,7 +27,7 @@
     <!-- headers -->
     <file src="__OUTPUTDIR__/iphonesimulator/Debug/build.sym/Debug-iphonesimulator/include/**" target="include"/>
 
-    <file src="../third-party/folly-2016.10.31.00/**/*.h" target="include"/>
+    <file src="../third-party/folly-2018.10.22.00/**/*.h" target="include"/>
     <file src="../third-party/glog-0.3.5/src/glog/*.h" target="include/glog"/>
   </files>
 </package>


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

After merging with facebook react-native .58, the folly path in AppleReact.nuspec is out-of-date.  Update the path.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/42)