### PR TITLE
Fix C4293 warning in sysmman.cpp

### DIFF
--- a/Folly/folly/portability/SysMman.cpp
+++ b/Folly/folly/portability/SysMman.cpp
@@ -126,7 +126,11 @@ void* mmap(void* addr, size_t length, int prot, int flags, int fd, off_t off) {
         h,
         nullptr,
         newProt,
+#ifdef _WIN64
         (DWORD)((length >> 32) & 0xFFFFFFFF),
+#else
+        0,
+#endif
         (DWORD)(length & 0xFFFFFFFF),
         nullptr);
     if (fmh == nullptr) {


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our Microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

#### Description of changes

(* pedantry alert! *)

Right-shifting a 32-bit value by 32 is, strictly, undefined behavior,
although every compiler worth its salt will understand that this is
just a funny way to generate 0. But anyways, this code causes VC++ to
emit warning C4293, which, per Office policy, may not be disabled.


#### Focus areas to test

Make sure that x64 and x86 both compile.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/45)