### PR TITLE
Fixing few of the warning which come while building ReactAndroid

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -92,12 +92,11 @@ def enableProguardInReleaseBuilds = true
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.1"
 
     defaultConfig {
         applicationId "com.facebook.react.uiapp"
-        minSdkVersion 21
-        targetSdkVersion 28
+        minSdkVersion 16
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
     }
@@ -120,7 +119,7 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.release
-        }
+        } 
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -238,11 +238,10 @@ task packageReactNdkLibsForBuck(dependsOn: packageReactNdkLibs, type: Copy) {
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "28.0.1"
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 28
+        minSdkVersion 16
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
 
@@ -305,8 +304,9 @@ dependencies {
     api "com.squareup.okhttp3:okhttp:${OKHTTP_VERSION}"
     api "com.squareup.okhttp3:okhttp-urlconnection:${OKHTTP_VERSION}"
     api 'com.squareup.okio:okio:1.15.0'
-    compile 'org.webkit:android-jsc:r174650'
-
+    if (!isV8Enabled()) {
+        api 'org.webkit:android-jsc:r174650'
+    }
     testImplementation "junit:junit:${JUNIT_VERSION}"
     testImplementation "org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}"
     testImplementation "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"

--- a/ReactAndroid/src/main/jni/react/jni/Android.mk
+++ b/ReactAndroid/src/main/jni/react/jni/Android.mk
@@ -7,14 +7,34 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
-# Flag to enable V8 in react-native code
-V8_ENABLED := 1
+# Include . in the header search path for all source files in this module.
+LOCAL_C_INCLUDES := $(LOCAL_PATH)
+
+# Include ./../../ in the header search path for modules that depend on
+# reactnativejni. This will allow external modules to require this module's
+# headers using #include <react/jni/<header>.h>, assuming:
+#   .     == jni
+#   ./../ == react
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../..
+
+LOCAL_CFLAGS += -fvisibility=hidden -fexceptions -frtti
+
+LOCAL_LDLIBS += -landroid
+
+# The dynamic libraries (.so files) that this module depends on.
+LOCAL_SHARED_LIBRARIES := libfolly_json libfb libglog_init libyoga libprivatedata
+
+# The static libraries (.a files) that this module depends on.
+LOCAL_STATIC_LIBRARIES := libreactnative
 
 # Name of this module.
 #
 # Other modules can depend on this one by adding libreactnativejni to their
 # LOCAL_SHARED_LIBRARIES variable.
 LOCAL_MODULE := reactnativejni
+
+# Flag to enable V8 in react-native code
+V8_ENABLED := 1
 
 LOCAL_SRC_FILES := \
   CatalystInstanceImpl.cpp \
@@ -39,23 +59,6 @@ LOCAL_SRC_FILES := \
   WritableNativeArray.cpp \
   WritableNativeMap.cpp \
 
-# Include . in the header search path for all source files in this module.
-LOCAL_C_INCLUDES := $(LOCAL_PATH)
-
-# Include ./../../ in the header search path for modules that depend on
-# reactnativejni. This will allow external modules to require this module's
-# headers using #include <react/jni/<header>.h>, assuming:
-#   .     == jni
-#   ./../ == react
-LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../..
-
-LOCAL_CFLAGS += -fvisibility=hidden -fexceptions -frtti
-
-LOCAL_LDLIBS += -landroid
-
-# The dynamic libraries (.so files) that this module depends on.
-LOCAL_SHARED_LIBRARIES := libfolly_json libfb libglog_init libyoga libprivatedata
-
 LOCAL_V8_FILES := \
   AndroidV8Factory.cpp
 
@@ -71,17 +74,6 @@ else
   LOCAL_CFLAGS += -DV8_ENABLED=0
   LOCAL_SHARED_LIBRARIES += libjsc
 endif
-
-# The static libraries (.a files) that this module depends on.
-LOCAL_STATIC_LIBRARIES := libreactnative
-
-# Name of this module.
-#
-# Other modules can depend on this one by adding libreactnativejni to their
-# LOCAL_SHARED_LIBRARIES variable.
-LOCAL_MODULE := reactnativejni
-
-APP_ALLOW_MISSING_DEPS :=true
 
 # Build the files in this directory as a shared library
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our Microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [X] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

Fixing few of the warning which come while building ReactAndroid.

#### Focus areas to test

Ensure project is building and RN Tester is running well.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/47)