### PR TITLE
Various fixes to get react-native-windows building with updated folly

### DIFF
--- a/Folly/CMakeLists.txt
+++ b/Folly/CMakeLists.txt
@@ -11,7 +11,6 @@ set(SOURCES
 	folly/lang/ColdClass.cpp
 	folly/lang/SafeAssert.cpp
 	folly/memory/detail/MallocImpl.cpp
-	folly/portability/fcntl.cpp
 	folly/ScopeGuard.cpp
 	folly/String.cpp
 	folly/Unicode.cpp
@@ -25,6 +24,7 @@ endif(WIN32 AND NOT WINRT)
 add_library(folly ${SOURCES})
 
 if(WIN32)
+	set(SOURCES ${SOURCES} folly/portability/string.cpp)
 	target_include_directories(folly PUBLIC ${REACT_DEP_STUBS})
 endif(WIN32)
 
@@ -45,6 +45,9 @@ endif(IOS OR APPLE OR ANDROID)
 if(ANDROID)
 	target_compile_definitions(folly PUBLIC FOLLY_HAVE_XSI_STRERROR_R=1 FOLLY_HAVE_MEMRCHR=1)
 endif(ANDROID)
+if(WIN32)
+	target_compile_definitions(folly PUBLIC FOLLY_HAVE_MEMRCHR=0)
+endif(WIN32)
 
 find_package(Boost REQUIRED)
 target_link_libraries(folly PUBLIC Boost::boost)

--- a/Folly/folly/Format.cpp
+++ b/Folly/folly/Format.cpp
@@ -49,7 +49,7 @@ struct format_table_conv_make_item {
     std::size_t index{};
     constexpr explicit make_item(std::size_t index_) : index(index_) {} // gcc49
     constexpr char alpha(std::size_t ord) const {
-      return ord < 10 ? '0' + ord : (Upper ? 'A' : 'a') + (ord - 10);
+      return (char)(ord < 10 ? '0' + ord : (Upper ? 'A' : 'a') + (ord - 10));
     }
     constexpr char operator()(std::size_t offset) const {
       return alpha(index / constexpr_pow(Base, Size - offset - 1) % Base);
@@ -206,7 +206,7 @@ void FormatValue<double>::formatHelper(
       arg.error("invalid specifier '", arg.presentation, "'");
   }
 
-  int len = builder.position();
+  auto len = builder.position();
   builder.Finalize();
   DCHECK_GT(len, 0);
 

--- a/Folly/folly/String.cpp
+++ b/Folly/folly/String.cpp
@@ -81,11 +81,11 @@ struct string_table_c_unescape_make_item {
 struct string_table_hex_make_item {
   constexpr unsigned char operator()(std::size_t index) const {
     // clang-format off
-    return
+    return (char) (
         index >= '0' && index <= '9' ? index - '0' :
         index >= 'a' && index <= 'f' ? index - 'a' + 10 :
         index >= 'A' && index <= 'F' ? index - 'A' + 10 :
-        16;
+        16);
     // clang-format on
   }
 };
@@ -98,7 +98,7 @@ struct string_table_uri_escape_make_item {
   //  4 = always percent-encode
   constexpr unsigned char operator()(std::size_t index) const {
     // clang-format off
-    return
+    return (char) (
         index >= '0' && index <= '9' ? 0 :
         index >= 'A' && index <= 'Z' ? 0 :
         index >= 'a' && index <= 'z' ? 0 :
@@ -108,7 +108,7 @@ struct string_table_uri_escape_make_item {
         index == '~' ? 0 :
         index == '/' ? 2 :
         index == ' ' ? 3 :
-        4;
+        4);
     // clang-format on
   }
 };

--- a/Folly/folly/Utility.h
+++ b/Folly/folly/Utility.h
@@ -391,7 +391,7 @@ constexpr auto to_signed(T const& t) -> typename std::make_signed<T>::type {
   // note: static_cast<S>(t) would be more straightforward, but it would also be
   // implementation-defined behavior and that is typically to be avoided; the
   // following code optimized into the same thing, though
-  return std::numeric_limits<S>::max() < t ? -static_cast<S>(~t) + S{-1}
+  return static_cast<T>(std::numeric_limits<S>::max()) < t ? -static_cast<S>(~t) + S{-1}
                                            : static_cast<S>(t);
 }
 

--- a/Folly/folly/container/detail/F14IntrinsicsAvailability.h
+++ b/Folly/folly/container/detail/F14IntrinsicsAvailability.h
@@ -32,10 +32,19 @@
 // If FOLLY_F14_VECTOR_INTRINSICS_AVAILABLE differs across compilation
 // units the program will fail to link due to a missing definition of
 // folly::container::detail::F14LinkCheck<X>::check() for some X.
+#if WINAPI_FAMILY == WINAPI_FAMILY_APP || defined(_WIN32)
+#define FOLLY_F14_VECTOR_INTRINSICS_AVAILABLE 0
+#else
+#if (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+#error WINAPI_FAMILY is WINAPI_FAMILY_APP
+#else
+#error FOLLY_F14_VECTOR_INTRINSICS_AVAILABLE should be false ##WINAPI_FAMILY
+#endif
 #if (FOLLY_SSE >= 2 || (FOLLY_NEON && FOLLY_AARCH64)) && !FOLLY_MOBILE
 #define FOLLY_F14_VECTOR_INTRINSICS_AVAILABLE 1
 #else
 #define FOLLY_F14_VECTOR_INTRINSICS_AVAILABLE 0
+#endif
 #endif
 
 #if FOLLY_SSE_PREREQ(4, 2) || __ARM_FEATURE_CRC32

--- a/Folly/folly/dynamic.cpp
+++ b/Folly/folly/dynamic.cpp
@@ -307,7 +307,7 @@ std::size_t dynamic::hash() const {
           [&](auto acc, auto item) { return acc + h(item); });
     }
     case ARRAY:
-      return folly::hash::hash_range(begin(), end());
+      return static_cast<size_t>(folly::hash::hash_range(begin(), end()));
     case INT64:
       return std::hash<int64_t>()(getInt());
     case DOUBLE:

--- a/Folly/folly/json.cpp
+++ b/Folly/folly/json.cpp
@@ -666,7 +666,7 @@ size_t firstEscapableInWord(T s, const serialization_opts& opts) {
           (i == 0 ? uint64_t(-1) << 32 : ~0UL);
       while (bitmap) {
         auto bit = folly::findFirstSet(bitmap);
-        needsEscape |= isChar(offset + bit - 1);
+        needsEscape |= isChar(static_cast<uint8_t>(offset + bit - 1));
         bitmap &= bitmap - 1;
       }
     }

--- a/Folly/folly/memory/detail/MallocImpl.h
+++ b/Folly/folly/memory/detail/MallocImpl.h
@@ -50,6 +50,18 @@ extern int (
 #ifdef _MSC_VER
 // We emulate weak linkage for MSVC. The symbols we're
 // aliasing to are hiding in MallocImpl.cpp
+#if defined(_M_IX86)
+#pragma comment(linker, "/alternatename:_mallocx=_mallocxWeak")
+#pragma comment(linker, "/alternatename:_rallocx=_rallocxWeak")
+#pragma comment(linker, "/alternatename:_xallocx=_xallocxWeak")
+#pragma comment(linker, "/alternatename:_sallocx=_sallocxWeak")
+#pragma comment(linker, "/alternatename:_dallocx=_dallocxWeak")
+#pragma comment(linker, "/alternatename:_sdallocx=_sdallocxWeak")
+#pragma comment(linker, "/alternatename:_nallocx=_nallocxWeak")
+#pragma comment(linker, "/alternatename:_mallctl=_mallctlWeak")
+#pragma comment(linker, "/alternatename:_mallctlnametomib=_mallctlnametomibWeak")
+#pragma comment(linker, "/alternatename:_mallctlbymib=_mallctlbymibWeak")
+#else
 #pragma comment(linker, "/alternatename:mallocx=mallocxWeak")
 #pragma comment(linker, "/alternatename:rallocx=rallocxWeak")
 #pragma comment(linker, "/alternatename:xallocx=xallocxWeak")
@@ -60,6 +72,7 @@ extern int (
 #pragma comment(linker, "/alternatename:mallctl=mallctlWeak")
 #pragma comment(linker, "/alternatename:mallctlnametomib=mallctlnametomibWeak")
 #pragma comment(linker, "/alternatename:mallctlbymib=mallctlbymibWeak")
+#endif
 #endif
 #endif
 }

--- a/Folly/folly/portability/String.h
+++ b/Folly/folly/portability/String.h
@@ -26,7 +26,7 @@
 #endif
 
 #if !FOLLY_HAVE_MEMRCHR
-//extern "C" void* memrchr(const void* s, int c, size_t n);
+extern "C" void* memrchr(const void* s, int c, size_t n);
 #endif
 
 #if defined(_WIN32) || defined(__FreeBSD__)

--- a/Folly/folly/portability/SysMman.cpp
+++ b/Folly/folly/portability/SysMman.cpp
@@ -120,7 +120,11 @@ void* mmap(void* addr, size_t length, int prot, int flags, int fd, off_t off) {
         h,
         nullptr,
         newProt,
+#ifdef _WIN64
         (DWORD)((length >> 32) & 0xFFFFFFFF),
+#else
+        0,
+#endif
         (DWORD)(length & 0xFFFFFFFF),
         nullptr);
     if (fmh == nullptr) {


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our Microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/52)