### PR TITLE
Building RN droid for 64 bit plats

### DIFF
--- a/RNTester/android/app/build.gradle
+++ b/RNTester/android/app/build.gradle
@@ -113,7 +113,7 @@ android {
             enable enableSeparateBuildPerCPUArchitecture
             universalApk false
             reset()
-            include "armeabi-v7a", "x86"
+            include "armeabi-v7a", "x86", "x86_64", "arm64-v8a"
         }
     }
     buildTypes {
@@ -125,6 +125,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }
+    }
+    packagingOptions {
+        pickFirst '**/armeabi-v7a/libc++_shared.so'
+        pickFirst '**/x86/libc++_shared.so'
+        pickFirst '**/x86_64/libc++_shared.so'
+        pickFirst '**/arm64-v8a/libc++_shared.so'
     }
 }
 

--- a/ReactAndroid/src/main/jni/Application.mk
+++ b/ReactAndroid/src/main/jni/Application.mk
@@ -5,7 +5,7 @@
 
 APP_BUILD_SCRIPT := Android.mk
 
-APP_ABI := armeabi-v7a x86
+APP_ABI := armeabi-v7a x86 arm64-v8a x86_64
 APP_PLATFORM := android-16
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our Microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [X] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

Building RN droid for 64 bit plats

#### Focus areas to test

64 bit builds are passing


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/54)