### PR TITLE
Cross platform/engine/storage abstraction for original and prepared s…

### DIFF
--- a/ReactCommon/jsi/RuntimeHolder.h
+++ b/ReactCommon/jsi/RuntimeHolder.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+#include <jsi/jsi.h>
+
+namespace facebook {
+namespace jsi {
+
+// An instance of this interface is expected to 
+// a. lazily create a JSI Runtime on the first call to getRuntime
+// b. subsequent calls to getRuntime should return the Runtime created in (a)
+
+// Note :: All calls to getRuntime() should happen on the same thread unless you are sure that 
+// the underlying Runtime instance is thread safe.
+
+struct RuntimeHolderLazyInit {
+  virtual std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept = 0;
+};
+
+} // namespace jsi
+} // namespace facebook

--- a/ReactCommon/jsi/ScriptStore.h
+++ b/ReactCommon/jsi/ScriptStore.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <memory>
+#include <jsi/jsi.h>
+
+namespace facebook {
+namespace jsi {
+
+// Integer type as it's persist friently.
+using ScriptVersion_t = uint64_t;  // It shouldbe std::optional<uint64_t> once we have c++17 available everywhere. Until then, 0 implies versioning not available.
+using JSRuntimeVersion_t = uint64_t; // 0 implies version can't be computed. We assert whenever that happens.
+
+struct VersionedBuffer {
+  std::unique_ptr<const facebook::jsi::Buffer> buffer;
+  ScriptVersion_t version;
+};
+
+struct ScriptSignature {
+  std::string url;
+  ScriptVersion_t version;
+};
+
+struct JSRuntimeSignature {
+  std::string runtimeName; // e.g. Chakra, V8
+  JSRuntimeVersion_t version;
+};
+
+// Most JSI::Runtime implementation offer some form of prepared JavaScript which offers better performance characteristics when loading comparing to plain JavaScript.
+// Embedders can provide an instance of this interface (through JSI::Runtime implementation's factory method),
+// to enable persistance of the prepared script and retrieval on subsequent evaluation of a script.
+struct PreparedScriptStore {
+  // Try to retrieve the prepared javascript for a given combination of script & runtime.
+  // scriptSignature : Javascript url and version
+  // RuntimeSignature : Javascript engine type and version
+  // prepareTag : Custom tag to uniquely identify JS engine specific preparation schemes. It is usually useful while experimentation and can be null.
+  // It is possible that no prepared script is available for a given script & runtime signature. This method should null if so
+  virtual std::unique_ptr<const facebook::jsi::Buffer> tryGetPreparedScript(
+    const ScriptSignature& scriptSignature,
+    const JSRuntimeSignature& runtimeSignature,
+    const char* prepareTag // Optional tag. For e.g. eagerly evaluated vs lazy cache.
+  ) noexcept = 0;
+
+  // Persist the perpared javascript for a given combination of script & runtime.
+  // scriptSignature : Javascript url and version
+  // RuntimeSignature : Javascript engine type and version
+  // prepareTag : Custom tag to uniquely identify JS engine specific preparation schemes. It is usually useful while experimentation and can be null.
+  // It is possible that no prepared script is available for a given script & runtime signature. This method should null if so
+  // Any failure in persistance should be identified during the subsequent retrieval through the integrity mechanism which must be put into the storage.
+  virtual void persistPreparedScript(
+    std::shared_ptr<const facebook::jsi::Buffer> preparedScript,
+    const ScriptSignature& scriptMetadata,
+    const JSRuntimeSignature& runtimeMetadata,
+    const char* prepareTag  // Optional tag. For e.g. eagerly evaluated vs lazy cache.
+  ) noexcept = 0;
+};
+
+// JSI::Runtime implementation must be provided an instance on this interface to enable version sensitive capabilities such as usage of pre-prepared javascript script.
+// Alternatively, this entity can be used to directly provide the Javascript buffer and rich metadata to the JSI::Runtime instance.
+struct ScriptStore {
+  // Return the Javascript buffer and version corresponding to a given url.
+  virtual VersionedBuffer getVersionedScript(const std::string& url) noexcept = 0;
+
+  // Return the version of the Javascript buffer corresponding to a given url.
+  virtual ScriptVersion_t getScriptVersion(const std::string& url) noexcept = 0;
+};
+
+} // namespace jsi
+} // namespace facebook


### PR DESCRIPTION
…cripts

// ScriptStore manages versioned storage of both source scripts and prepared scripts. We intent to pass a ScriptSTore implementation
// directly into the JSI runtime from host. It will enable the following,
// 1. Pass richer data and metadata on the source scripts from host to JSI runtime without being constrained by the various layers in between.
// 2. Potential performance benefits as it will allow us to directly stream the source script and the prepared scripts from arbitrary storages and encoding without being constrained by intermediate layers.
// 3. Consolidate Source script versioning and storage logic into a single component.
// 4. Consolidate prepared script storage and persistance formats across platforms and aross JS-engines.
// 5. Allow co-existance of multiple Javascript engines, versions, strategies. (Some more work required to support multi-version)
// 6. Allow platform/storage/engine specific extensions for better performance.

# :warning: Make sure you are targeting Microsoft/react-native for your PR :warning:
(then delete these lines)

<!--
We are working on reducing the diff between Facebook's public version of react-native, and our Microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/55)