### PR TITLE
Fixing devmain build break for droid 64 bit platforms

### DIFF
--- a/ReactCommon/yoga/yoga/sources.inc
+++ b/ReactCommon/yoga/yoga/sources.inc
@@ -3,7 +3,7 @@ LIBLET_NO_PRECOMP = 1
 
 !include $(WAREHOUSEIMPORTDIR)\libletmake\x-none\nmake\make.inc
 
-!IF ("$(PLATFORM)" != "droidarm") && ("$(PLATFORM)" != "droidx86")
+!IF "$(IS_DROID)" != "1"
 C_DEFINES = $(C_DEFINES) /D _WINDLL
 !ENDIF
 


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our Microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

#### Description of changes

Fixing devmain build break for droid 64 bit platforms

#### Focus areas to test

Ensure arm64 and x64 flavor builds pass for droid

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/Microsoft/react-native/pull/56)