### PR TITLE
Fixes for internal builds

### DIFF
--- a/Folly/folly/Conv.cpp
+++ b/Folly/folly/Conv.cpp
@@ -488,7 +488,10 @@ class SignedValueHandler<T, true> {
   Expected<T, ConversionCode> finalize(U value) {
     T rv;
     if (negative_) {
+FOLLY_PUSH_WARNING
+FOLLY_MSVC_DISABLE_WARNING(4146) // unary minus operator applied to unsigned type, result still unsigned
       rv = T(-value);
+FOLLY_POP_WARNING
       if (UNLIKELY(rv > 0)) {
         return makeUnexpected(ConversionCode::NEGATIVE_OVERFLOW);
       }
@@ -574,7 +577,10 @@ inline Expected<Tgt, ConversionCode> digits_to(
   UT result = 0;
 
   for (; e - b >= 4; b += 4) {
+FOLLY_PUSH_WARNING
+FOLLY_MSVC_DISABLE_WARNING(4309) // truncation of constant value
     result *= static_cast<UT>(10000);
+FOLLY_POP_WARNING
     const int32_t r0 = shift1000[static_cast<size_t>(b[0])];
     const int32_t r1 = shift100[static_cast<size_t>(b[1])];
     const int32_t r2 = shift10[static_cast<size_t>(b[2])];
@@ -700,7 +706,10 @@ Expected<Tgt, ConversionCode> str_to_integral(StringPiece* src) noexcept {
   if (UNLIKELY(err != ConversionCode::SUCCESS)) {
     return makeUnexpected(err);
   }
+FOLLY_PUSH_WARNING
+FOLLY_MSVC_DISABLE_WARNING(4127) // conditional expression is constant
   if (std::is_signed<Tgt>::value && UNLIKELY(b >= past)) {
+FOLLY_POP_WARNING
     return makeUnexpected(ConversionCode::NO_DIGITS);
   }
   if (UNLIKELY(!isdigit(*b))) {

--- a/Folly/folly/Conv.h
+++ b/Folly/folly/Conv.h
@@ -1276,7 +1276,10 @@ checkConversion(const Src& value) {
         std::numeric_limits<Tgt>::max() - static_cast<Tgt>(mmax)) {
       return false;
     }
+FOLLY_PUSH_WARNING
+FOLLY_MSVC_DISABLE_WARNING(4127) // conditional expression is constant
   } else if (std::is_signed<Tgt>::value && value <= tgtMinAsSrc) {
+FOLLY_POP_WARNING
     if (value < tgtMinAsSrc) {
       return false;
     }

--- a/Folly/folly/String-inl.h
+++ b/Folly/folly/String-inl.h
@@ -298,7 +298,10 @@ void internalSplit(
     }
     return;
   }
+FOLLY_PUSH_WARNING
+FOLLY_MSVC_DISABLE_WARNING(4127) // conditional expression is constant
   if (std::is_same<DelimT, StringPiece>::value && dSize == 1) {
+FOLLY_POP_WARNING
     // Call the char version because it is significantly faster.
     return internalSplit<OutStringT>(delimFront(delim), sp, out, ignoreEmpty);
   }
@@ -454,7 +457,10 @@ void internalJoinAppend(
     Iterator end,
     String& output) {
   assert(begin != end);
+FOLLY_PUSH_WARNING
+FOLLY_MSVC_DISABLE_WARNING(4127) // conditional expression is constant
   if (std::is_same<Delim, StringPiece>::value && delimSize(delimiter) == 1) {
+FOLLY_POP_WARNING
     internalJoinAppend(delimFront(delimiter), begin, end, output);
     return;
   }

--- a/Folly/folly/dirs
+++ b/Folly/folly/dirs
@@ -1,5 +1,9 @@
 DIRS = \
+    container \
     detail \
+    hash \
+    lang \
+    memory \
     portability{!droidarm,!droidarm64,!droidx64,!droidx86} \
     android{droidarm,droidarm64,droidx64,droidx86} \
     win32{apple,chpe,x64,x86} \

--- a/Folly/folly/hash/Hash.h
+++ b/Folly/folly/hash/Hash.h
@@ -642,11 +642,14 @@ size_t hash_combine_generic(
     const Ts&... ts) noexcept(noexcept(detail::c_array_size_t{h(t),
                                                               h(ts)...})) {
   size_t seed = h(t);
+FOLLY_PUSH_WARNING
+FOLLY_MSVC_DISABLE_WARNING(4127) // conditional expression is constant
   if (sizeof...(ts) == 0) {
     return seed;
   }
   size_t remainder = hash_combine_generic(h, ts...);
   if /* constexpr */ (sizeof(size_t) == sizeof(uint32_t)) {
+FOLLY_POP_WARNING
     return twang_32from64((uint64_t(seed) << 32) | remainder);
   } else {
     return static_cast<size_t>(hash_128_to_64(seed, remainder));

--- a/Folly/folly/json.cpp
+++ b/Folly/folly/json.cpp
@@ -712,7 +712,10 @@ void escapeStringImpl(
         word = folly::partialLoadUnaligned<uint64_t>(firstEsc, avail);
       }
       auto prefix = firstEscapableInWord<EnableExtraAsciiEscapes>(word, opts);
+FOLLY_PUSH_WARNING
+FOLLY_MSVC_DISABLE_WARNING(4018) // signed/unsigned mismatch
       DCHECK_LE(prefix, avail);
+FOLLY_POP_WARNING
       firstEsc += prefix;
       if (prefix < 8) {
         break;

--- a/Folly/folly/lang/Align.h
+++ b/Folly/folly/lang/Align.h
@@ -88,7 +88,10 @@ using max_align_v_ = max_align_t_<
 //
 // Apple's allocation reference: http://bit.ly/malloc-small
 constexpr std::size_t max_align_v = detail::max_align_v_::value;
+FOLLY_PUSH_WARNING
+FOLLY_MSVC_DISABLE_WARNING(4324) // structure was padded due to alignment specifier
 struct alignas(max_align_v) max_align_t {};
+FOLLY_POP_WARNING
 
 //  Memory locations within the same cache line are subject to destructive
 //  interference, also known as false sharing, which is when concurrent

--- a/Folly/folly/lang/Bits.h
+++ b/Folly/folly/lang/Bits.h
@@ -324,7 +324,10 @@ inline T partialLoadUnaligned(const void* p, size_t l) {
 
   auto cp = static_cast<const char*>(p);
   T value = 0;
+FOLLY_PUSH_WARNING
+FOLLY_MSVC_DISABLE_WARNING(4324) // structure was padded due to alignment specifier
   if (!kHasUnalignedAccess || !kIsLittleEndian) {
+FOLLY_POP_WARNING
     // Unsupported, use memcpy.
     memcpy(&value, cp, l);
     return value;

--- a/Folly/folly/sources.inc
+++ b/Folly/folly/sources.inc
@@ -3,18 +3,17 @@ LIBLETNAME = Folly
 !include $(OPENSOURCE_REACTNATIVE)\OfficeISS\ReactCommon\make.inc
 
 SOURCES_SHARED = \
-	..\Assume.cpp \
 	..\Conv.cpp \
 	..\Demangle.cpp \
 	..\dynamic.cpp \
+	..\Format.cpp \
 	..\json.cpp \
-	..\StringBase.cpp \
+	..\json_pointer.cpp \
 	..\ScopeGuard.cpp \
+	..\String.cpp \
 	..\Unicode.cpp \
 
-SOURCES_WIN32 = \
-    $(SOURCES_SHARED) \
-	..\SpookyHashV2.cpp \
+SOURCES_WIN32 = $(SOURCES_SHARED) \
 
 SOURCES_ANDROID = $(SOURCES_SHARED) \
 


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our Microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

Updated to build logic used internally, and supressions of some warnings that are treated as errors internally.
