### PR TITLE
Added canBecomeKeyView override to RCTScrollView

### DIFF
--- a/RNTester/js/FlatListExample.js
+++ b/RNTester/js/FlatListExample.js
@@ -120,6 +120,7 @@ class FlatListExample extends React.PureComponent<{}, $FlowFixMeState> {
             data={this.state.empty ? [] : filteredData}
             debug={this.state.debug}
             disableVirtualization={!this.state.virtualized}
+            acceptsKeyboardFocus={true} // TODO(macOS ISS#2323203)
             enableSelectionOnKeyPress={true}
             onSelectionEntered={this._handleSelectionEntered}
             getItemLayout={

--- a/RNTester/js/ListExampleShared.js
+++ b/RNTester/js/ListExampleShared.js
@@ -74,6 +74,7 @@ class ItemComponent extends React.PureComponent<{
         tvParallaxProperties={{
           pressMagnification: 1.1,
         }}
+        acceptsKeyboardFocus={false} // TODO(macOS ISS#2323203)
         style={horizontal ? styles.horizItem : styles.item}>
         <View
           style={[

--- a/RNTester/js/RNTesterExampleList.js
+++ b/RNTester/js/RNTesterExampleList.js
@@ -112,6 +112,8 @@ class RNTesterExampleList extends React.Component<Props, $FlowFixMeState> {
               enableEmptySections={true}
               itemShouldUpdate={this._itemShouldUpdate}
               keyboardShouldPersistTaps="handled"
+              acceptsKeyboardFocus={true} // TODO(macOS ISS#2323203)
+              enableSelectionOnKeyPress={true} // TODO(macOS ISS#2323203)
               automaticallyAdjustContentInsets={false}
               keyboardDismissMode="on-drag"
               renderSectionHeader={renderSectionHeader}

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -520,6 +520,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 }
 
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
+- (BOOL)canBecomeKeyView
+{
+  return [self acceptsKeyboardFocus];
+}
+
 - (CGRect)focusRingMaskBounds
 {
   return [self bounds];


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

On macOS, when tabbing into a ScrollView the focus is going to the ScrollView itself instead of the first component inside the contents. There is already a JS prop called acceptsKeyboardFocus which is honored on View (RCTView). In macOS NSViews can be key focused if they respond YES to acceptsFirstResponder and YES to canBecomeKeyView. The RCTScrollView is a sublass of RCTView, and RCTView already has an acceptsFirstResponder implementation that regards the acceptsKeyboardFocus prop. But RCTScrollView also needs a canBecomeKeyView override that returns the value of acceptsKeyboardFocus prop.

Now ScrollView will honor the JS prop acceptsKeyboardFocus just as View does. But for Lists, the App may want focus to be settable on the List itself so that the arrow keys can adjust which item is selected. Conversely, the items in the list which are generally a Touchables should not be focusable otherwise focus will first hit the List itself then start cycling through each item. The RNTester itself is such a case so its Lists and ItemComponent are updated with acceptsKeyboardFocus props.