### PR TITLE
Separate V8 code from the core JSI library

### DIFF
--- a/ReactCommon/jsi/V8Runtime_droid.cpp
+++ b/ReactCommon/jsi/V8Runtime_droid.cpp
@@ -149,4 +149,8 @@ namespace facebook { namespace v8runtime {
 
     return script;
   }
+
+  std::unique_ptr<jsi::Runtime> makeV8Runtime(const folly::dynamic& v8Config) {
+    return std::make_unique<V8Runtime>(v8Config);
+  }
 }} // namespace facebook::v8runtime

--- a/ReactCommon/jsi/V8Runtime_shared.cpp
+++ b/ReactCommon/jsi/V8Runtime_shared.cpp
@@ -739,8 +739,4 @@ namespace facebook { namespace v8runtime {
   std::unique_ptr<jsi::Runtime> makeV8Runtime() {
     return std::make_unique<V8Runtime>();
   }
-
-  std::unique_ptr<jsi::Runtime> makeV8Runtime(const folly::dynamic& v8Config) {
-    return std::make_unique<V8Runtime>(v8Config);
-  }
 }} // namespace facebook::v8runtime

--- a/ReactCommon/jsi/V8Runtime_win.cpp
+++ b/ReactCommon/jsi/V8Runtime_win.cpp
@@ -23,4 +23,7 @@ namespace facebook { namespace v8runtime {
     std::abort();
   }
 
+  std::unique_ptr<jsi::Runtime> makeV8Runtime(const folly::dynamic& v8Config) {
+    return std::make_unique<V8Runtime>(v8Config);
+  }
 }} // namespace facebook::v8runtime

--- a/ReactCommon/jsi/dirs
+++ b/ReactCommon/jsi/dirs
@@ -1,5 +1,6 @@
 DIRS = \
     android{droidarm,droidarm64,droidx64,droidx86} \
     jsicore{apple,chpe,x64,x86} \
+    jsiv8{apple,chpe,x64,x86} \
     win32{apple,chpe,x64,x86} \
     winrt{arm,x64,x86} \

--- a/ReactCommon/jsi/jsicore/sources
+++ b/ReactCommon/jsi/jsicore/sources
@@ -2,19 +2,6 @@ LIBLET_WIN32 = 1
 LIBLET_DEF_NOEXPORTS = 1
 LIBLET_SUFFIX = core
 
-C_DEFINES=$(C_DEFINES) -DJSI_CORE
-
-V8_ENABLED = 1
-
-# Currently this nuget package is windows only.
-!LISTFILES -recursive V8_HEADERS = $(PKGOFFICE_GOOGLE_V8_1_6_0_0)\build\include *.h
-
-HEADERS = $(HEADERS) \
-    $(V8_HEADERS) \
-
-INCLUDES = $(INCLUDES); \
-    $(PKGOFFICE_GOOGLE_V8_1_6_0_0)\build\include; \
-
 !include ..\sources.inc
 
 SOURCES = $(SOURCES_JSICORE)

--- a/ReactCommon/jsi/jsiv8/sources
+++ b/ReactCommon/jsi/jsiv8/sources
@@ -1,0 +1,18 @@
+LIBLET_WIN32 = 1
+LIBLET_DEF_NOEXPORTS = 1
+LIBLET_SUFFIX = v8
+
+C_DEFINES=$(C_DEFINES) -DJSI_CORE
+
+# Currently this nuget package is windows only.
+!LISTFILES -recursive V8_HEADERS = $(PKGOFFICE_GOOGLE_V8_1_6_0_0)\build\include *.h
+
+HEADERS = $(HEADERS) \
+    $(V8_HEADERS) \
+
+INCLUDES = $(INCLUDES); \
+    $(PKGOFFICE_GOOGLE_V8_1_6_0_0)\build\include; \
+
+!include ..\sources.inc
+
+SOURCES = $(SOURCES_JSIV8)

--- a/ReactCommon/jsi/sources.inc
+++ b/ReactCommon/jsi/sources.inc
@@ -28,6 +28,7 @@ SOURCES_ANDROID = \
 SOURCES_ANDROID = \
   $(SOURCES_SHARED);\
   $(SOURCES_JSC_FILES); \
+
 !endif
 
 SOURCES_WIN32 = \
@@ -41,6 +42,8 @@ SOURCES_WINRT = \
 
 SOURCES_JSICORE = \
   ..\jsi.cpp \
+  
+SOURCES_JSIV8 = \
   ..\V8Platform.cpp \
   ..\V8Runtime_basic.cpp \
   ..\V8Runtime_shared.cpp \


### PR DESCRIPTION

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

Separate V8 code from the core JSI library (for internal Office linking purposes). Also move the folly:dynamic dependent constructor out of the shared runtime impl.

#### Focus areas to test

N/A

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/64)