### PR TITLE
Remove Chakra specific conditional compilation hack from JSIExecutor 

### DIFF
--- a/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
+++ b/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
@@ -97,15 +97,11 @@ void JSIExecutor::loadApplicationScript(
 
   // TODO: check for and use precompiled HBC
 
-// ChakraCore implementation of JSI don't yet support HostObjects.
-// https://office.visualstudio.com/OC/_workitems/edit/2801906
-#if !defined(CHAKRA_JSI)
   runtime_->global().setProperty(
       *runtime_,
       "nativeModuleProxy",
       Object::createFromHostObject(
           *runtime_, std::make_shared<NativeModuleProxy>(*this)));
-#endif
 
   runtime_->global().setProperty(
       *runtime_,


### PR DESCRIPTION
#### Please select one of the following
- [X] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

We introduced a hack in JSIExecutor to conditionally compile the creation of NativeModuleProxy as a JSI HostObject. This was needed in the days where the Chakra based JSI runtimes didn't support JSI HostObjects. We are now removing the conditional compilation as the Chakra based JSI runtimes do support HostObjects.

#### Focus areas to test
Tested that the native module dispatch is happening with ChakraJSIRuntime without pushing the native modules config upfront.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/66)