### PR TITLE
Workaround crash during layout on macOS

### DIFF
--- a/Libraries/Text/Text/RCTTextView.m
+++ b/Libraries/Text/Text/RCTTextView.m
@@ -115,6 +115,20 @@
           contentFrame:(CGRect)contentFrame
        descendantViews:(NSArray<UIView *> *)descendantViews
 {
+#if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
+  // On macOS when a large number of flex layouts are being performed, such
+  // as when a window is being resized, AppKit can throw an uncaught exception
+  // (-[NSConcretePointerArray pointerAtIndex:]: attempt to access pointer at index ...)
+  // during the dealloc of NSLayoutManager.  The _textStorage and its
+  // associated NSLayoutManager dealloc later in an autorelease pool.
+  // Manually removing the layout manager from _textStorage prior to release
+  // works around this issue in AppKit.
+  NSArray<NSLayoutManager *> *managers = [_textStorage layoutManagers];
+  for (NSLayoutManager *manager in managers) {
+    [_textStorage removeLayoutManager:manager];
+  }
+#endif // ]TODO(macOS ISS#2323203)
+
   _textStorage = textStorage;
   _contentFrame = contentFrame;
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

On macOS when a large number of flex layouts are being performed, such as when a window is being resized, AppKit can throw an uncaught exception (-[NSConcretePointerArray pointerAtIndex:]: attempt to access pointer at index ...) during the dealloc of NSLayoutManager.  The _textStorage and its associated NSLayoutManager dealloc later from the time the ivar pointer is overwritten in an autorelease pool.

Manually removing the layout manager from _textStorage prior to release works around this issue in AppKit.

The same issue does not appear to impact the iOS version of NSLayoutManager.

#### Focus areas to test

A low risk fix: the _textStorage is only ever assigned via the [RCTTextView setTextStorage:contentFrame:descendantView:] method, and that method is only every called by RCTTextShadowView.m where it retrieved the textStorage via [self textStorageAndLayoutManagerThatFitsSize:self.contentFrame.size exclusiveOwnership:YES]

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/69)