### PR TITLE
Fix a crash that can occur in UIGraphicsEndImageContext if UIGraphics…

### DIFF
--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -34,6 +34,14 @@ void UIGraphicsBeginImageContextWithOptions(CGSize size, __unused BOOL opaque, C
 		scale = 1.0;
 	}
 
+  // Ensure that the width and height are at least 1 otherwise
+  // CGBitmapContextCreate will fail preventing the new
+  // NSGraphicsContext from being created.  If NSGraphicsContext
+  // is not created with a the RCTGraphicsContextSizeKey ivar,
+  // then balanced UIGraphicsEndImageContext calls will RCTAssert
+  // and crash the app.
+  // On iOS it is legal to call UIGraphicsBeginImageContextWithOptions with
+  // 0 width and/or height and it doesn't crash in UIGraphicsEndImageContext.
 	size_t width = fmax(ceilf(size.width * scale), 1);
 	size_t height = fmax(ceilf(size.height * scale), 1);
 

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -34,13 +34,14 @@ void UIGraphicsBeginImageContextWithOptions(CGSize size, __unused BOOL opaque, C
 		scale = 1.0;
 	}
 
-	size_t width = ceilf(size.width * scale);
-	size_t height = ceilf(size.height * scale);
+	size_t width = fmax(ceilf(size.width * scale), 1);
+	size_t height = fmax(ceilf(size.height * scale), 1);
 
 	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
 	CGContextRef ctx = CGBitmapContextCreate(NULL, width, height, 8/*bitsPerComponent*/, width * 4/*bytesPerRow*/, colorSpace, kCGImageAlphaPremultipliedFirst);
 	CGColorSpaceRelease(colorSpace);
 
+	RCTAssert(ctx != NULL, @"CGBitmapContextCreate failed.");
 	if (ctx != NULL)
 	{
 		// flip the context (top left at 0, 0) and scale it

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -34,22 +34,13 @@ void UIGraphicsBeginImageContextWithOptions(CGSize size, __unused BOOL opaque, C
 		scale = 1.0;
 	}
 
-  // Ensure that the width and height are at least 1 otherwise
-  // CGBitmapContextCreate will fail preventing the new
-  // NSGraphicsContext from being created.  If NSGraphicsContext
-  // is not created with a the RCTGraphicsContextSizeKey ivar,
-  // then balanced UIGraphicsEndImageContext calls will RCTAssert
-  // and crash the app.
-  // On iOS it is legal to call UIGraphicsBeginImageContextWithOptions with
-  // 0 width and/or height and it doesn't crash in UIGraphicsEndImageContext.
-	size_t width = fmax(ceilf(size.width * scale), 1);
-	size_t height = fmax(ceilf(size.height * scale), 1);
+	size_t width = ceilf(size.width * scale);
+	size_t height = ceilf(size.height * scale);
 
 	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
 	CGContextRef ctx = CGBitmapContextCreate(NULL, width, height, 8/*bitsPerComponent*/, width * 4/*bytesPerRow*/, colorSpace, kCGImageAlphaPremultipliedFirst);
 	CGColorSpaceRelease(colorSpace);
 
-	RCTAssert(ctx != NULL, @"CGBitmapContextCreate failed.");
 	if (ctx != NULL)
 	{
 		// flip the context (top left at 0, 0) and scale it

--- a/React/Views/RCTBorderDrawing.m
+++ b/React/Views/RCTBorderDrawing.m
@@ -245,6 +245,11 @@ static UIImage *RCTGetSolidBorderImage(RCTCornerRadii cornerRadii,
     edgeInsets.top + 1 + edgeInsets.bottom
   } : viewSize;
 
+  // [TODO(OSS Candidate ISS#2710739): size must nonzero
+  if (size.width <= 0 || size.height <= 0) {
+    return nil;
+  } // ]TODO(OSS Candidate ISS#2710739)
+
   CGContextRef ctx = RCTUIGraphicsBeginImageContext(size, backgroundColor, hasCornerRadii, drawToEdge, scaleFactor); // TODO(macOS ISS#2323203)
   const CGRect rect = {.size = size};
   CGPathRef path = RCTPathCreateOuterOutline(drawToEdge, rect, cornerRadii);
@@ -490,6 +495,11 @@ static UIImage *RCTGetDashedOrDottedBorderImage(RCTBorderStyle borderStyle,
   if (lineWidth <= 0.0) {
     return nil;
   }
+
+  // [TODO(OSS Candidate ISS#2710739): viewSize must nonzero
+  if (viewSize.width <= 0 || viewSize.height <= 0) {
+    return nil;
+  } // ]TODO(OSS Candidate ISS#2710739)
 
   const BOOL hasCornerRadii = RCTCornerRadiiAreAboveThreshold(cornerRadii);
   CGContextRef ctx = RCTUIGraphicsBeginImageContext(viewSize, backgroundColor, hasCornerRadii, drawToEdge, scaleFactor); // TODO(macOS ISS#2323203)


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and Microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into Microsoft/react-native :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

If a react component renders with a zero width or zero height, an RCTAssert can fire in RCTUIKit.m UIGraphicsEndImageContext() which halts the app.   The same scenarios when running on iOS where UIGraphicsBeginImageContextWithOptions() is called with a zero width or height does not crash.

UIGraphicsBeginImageContextWithOptions creates a CGBitmapContextCreate and then uses that context when creating the NSGraphicsContext.   objc_setAssociatedObject is called on the new context setting an ivar with the key RCTGraphicsContextSizeKey.   Later in UIGraphicsEndImageContext an RCTAssert asserts that RCTGraphicsContextSizeKey is present which crashes.

The fix is to normalize the width and height to be at least 1x1 when calling CGBitmapContextCreate.   Also add a new RCTAssert that the bitmap context is created.

#### Focus areas to test

This is a rare case but was being hit in a not yet released app internal to Microsoft.   Verified that it is fixed in that app.   For testing purposes I also temporarily changed code in RNTester to force some views to be zero width or height.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/71)