### PR TITLE
Verify android nuget during pr

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -117,6 +117,22 @@ jobs:
           #findBugsRunAnalysis: false # Optional
           #pmdRunAnalysis: false # Optional
 
+      - task: PowerShell@2
+        displayName: Extract version from package.json, and put it in nuspec
+        inputs:
+          targetType: inline # filePath | inline
+          script: |
+            $lines = Get-Content package.json | Where {$_ -match '^\s*"version":.*'} 
+            $npmVersion = $lines.Trim().Split()[1].Trim('",');
+            (Get-Content ReactAndroid/ReactAndroid.nuspec).replace('__BuildBuildNumber__', $npmVersion) | Set-Content ReactAndroid/ReactAndroid.nuspec
+
+      - task: NuGetCommand@2
+        displayName: 'Verify NuGet can be packed'
+        inputs:
+          command: pack
+          packagesToPack: 'ReactAndroid/ReactAndroid.nuspec'
+          packDestination: '$(System.DefaultWorkingDirectory)'
+
       - task: Gradle@1
         displayName: gradlew clean
         inputs:

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -110,5 +110,5 @@ jobs:
         displayName: 'NuGet push'
         inputs:
           command: push
-          packagesToPush: '$(System.DefaultWorkingDirectory)/ReactAndroid*.nupkg'
+          packagesToPush: '$(System.DefaultWorkingDirectory)/OfficeReact.Android*.nupkg'
           publishVstsFeed: '86ec7889-a365-4cd1-90df-6e18cc2ea59f'


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

This adds verification to PRs that the android nuget is build able, so that we don't hit failures to pack it post check in.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/72)