### PR TITLE
Include built binaries in droid nuget

### DIFF
--- a/ReactAndroid/ReactAndroid.nuspec
+++ b/ReactAndroid/ReactAndroid.nuspec
@@ -10,53 +10,53 @@
   </metadata>
   <files>
 
-    <file src="build\react-ndk\all\x86_64\libfb.so" target="lib\droidx64">
-    <file src="build\react-ndk\all\armeabi-v7a\libfb.so" target="lib\droidarm">
-    <file src="build\react-ndk\all\x86\libfb.so" target="lib\droidx86">
-    <file src="build\react-ndk\all\arm64-v8a\libfb.so" target="lib\droidarm64">
+    <file src="build\react-ndk\all\x86_64\libfb.so" target="lib\droidx64"/>
+    <file src="build\react-ndk\all\armeabi-v7a\libfb.so" target="lib\droidarm"/>
+    <file src="build\react-ndk\all\x86\libfb.so" target="lib\droidx86"/>
+    <file src="build\react-ndk\all\arm64-v8a\libfb.so" target="lib\droidarm64"/>
 
-    <file src="build\react-ndk\all\x86_64\libfolly_json.so" target="lib\droidx64">
-    <file src="build\react-ndk\all\armeabi-v7a\libfolly_json.so" target="lib\droidarm">
-    <file src="build\react-ndk\all\x86\libfolly_json.so" target="lib\droidx86">
-    <file src="build\react-ndk\all\arm64-v8a\libfolly_json.so" target="lib\droidarm64">
+    <file src="build\react-ndk\all\x86_64\libfolly_json.so" target="lib\droidx64"/>
+    <file src="build\react-ndk\all\armeabi-v7a\libfolly_json.so" target="lib\droidarm"/>
+    <file src="build\react-ndk\all\x86\libfolly_json.so" target="lib\droidx86"/>
+    <file src="build\react-ndk\all\arm64-v8a\libfolly_json.so" target="lib\droidarm64"/>
 
-    <file src="build\react-ndk\all\x86_64\libglog.so" target="lib\droidx64">
-    <file src="build\react-ndk\all\armeabi-v7a\libglog.so" target="lib\droidarm">
-    <file src="build\react-ndk\all\x86\libglog.so" target="lib\droidx86">
-    <file src="build\react-ndk\all\arm64-v8a\libglog.so" target="lib\droidarm64">
+    <file src="build\react-ndk\all\x86_64\libglog.so" target="lib\droidx64"/>
+    <file src="build\react-ndk\all\armeabi-v7a\libglog.so" target="lib\droidarm"/>
+    <file src="build\react-ndk\all\x86\libglog.so" target="lib\droidx86"/>
+    <file src="build\react-ndk\all\arm64-v8a\libglog.so" target="lib\droidarm64"/>
 
-    <file src="build\react-ndk\all\x86_64\libglog_init.so" target="lib\droidx64">
-    <file src="build\react-ndk\all\armeabi-v7a\libglog_init.so" target="lib\droidarm">
-    <file src="build\react-ndk\all\x86\libglog_init.so" target="lib\droidx86">
-    <file src="build\react-ndk\all\arm64-v8a\libglog_init.so" target="lib\droidarm64">
+    <file src="build\react-ndk\all\x86_64\libglog_init.so" target="lib\droidx64"/>
+    <file src="build\react-ndk\all\armeabi-v7a\libglog_init.so" target="lib\droidarm"/>
+    <file src="build\react-ndk\all\x86\libglog_init.so" target="lib\droidx86"/>
+    <file src="build\react-ndk\all\arm64-v8a\libglog_init.so" target="lib\droidarm64"/>
 
-    <file src="build\react-ndk\all\x86_64\libprivatedata.so" target="lib\droidx64">
-    <file src="build\react-ndk\all\armeabi-v7a\libprivatedata.so" target="lib\droidarm">
-    <file src="build\react-ndk\all\x86\libprivatedata.so" target="lib\droidx86">
-    <file src="build\react-ndk\all\arm64-v8a\libprivatedata.so" target="lib\droidarm64">
+    <file src="build\react-ndk\all\x86_64\libprivatedata.so" target="lib\droidx64"/>
+    <file src="build\react-ndk\all\armeabi-v7a\libprivatedata.so" target="lib\droidarm"/>
+    <file src="build\react-ndk\all\x86\libprivatedata.so" target="lib\droidx86"/>
+    <file src="build\react-ndk\all\arm64-v8a\libprivatedata.so" target="lib\droidarm64"/>
 
-    <file src="build\react-ndk\all\x86_64\libreactnativejni.so" target="lib\droidx64">
-    <file src="build\react-ndk\all\armeabi-v7a\libreactnativejni.so" target="lib\droidarm">
-    <file src="build\react-ndk\all\x86\libreactnativejni.so" target="lib\droidx86">
-    <file src="build\react-ndk\all\arm64-v8a\libreactnativejni.so" target="lib\droidarm64">
+    <file src="build\react-ndk\all\x86_64\libreactnativejni.so" target="lib\droidx64"/>
+    <file src="build\react-ndk\all\armeabi-v7a\libreactnativejni.so" target="lib\droidarm"/>
+    <file src="build\react-ndk\all\x86\libreactnativejni.so" target="lib\droidx86"/>
+    <file src="build\react-ndk\all\arm64-v8a\libreactnativejni.so" target="lib\droidarm64"/>
 
-    <file src="build\react-ndk\all\x86_64\libv8executor.so" target="lib\droidx64">
-    <file src="build\react-ndk\all\armeabi-v7a\libv8executor.so" target="lib\droidarm">
-    <file src="build\react-ndk\all\x86\libv8executor.so" target="lib\droidx86">
-    <file src="build\react-ndk\all\arm64-v8a\libv8executor.so" target="lib\droidarm64">
+    <file src="build\react-ndk\all\x86_64\libv8executor.so" target="lib\droidx64"/>
+    <file src="build\react-ndk\all\armeabi-v7a\libv8executor.so" target="lib\droidarm"/>
+    <file src="build\react-ndk\all\x86\libv8executor.so" target="lib\droidx86"/>
+    <file src="build\react-ndk\all\arm64-v8a\libv8executor.so" target="lib\droidarm64"/>
 
-    <file src="build\react-ndk\all\x86_64\libyoga.so" target="lib\droidx64">
-    <file src="build\react-ndk\all\armeabi-v7a\libyoga.so" target="lib\droidarm">
-    <file src="build\react-ndk\all\x86\libyoga.so" target="lib\droidx86">
-    <file src="build\react-ndk\all\arm64-v8a\libyoga.so" target="lib\droidarm64">
+    <file src="build\react-ndk\all\x86_64\libyoga.so" target="lib\droidx64"/>
+    <file src="build\react-ndk\all\armeabi-v7a\libyoga.so" target="lib\droidarm"/>
+    <file src="build\react-ndk\all\x86\libyoga.so" target="lib\droidx86"/>
+    <file src="build\react-ndk\all\arm64-v8a\libyoga.so" target="lib\droidarm64"/>
 
-    <file src="build\react-ndk\all\x86_64\libyoga.so" target="lib\droidx64">
-    <file src="build\react-ndk\all\armeabi-v7a\libyoga.so" target="lib\droidarm">
-    <file src="build\react-ndk\all\x86\libyoga.so" target="lib\droidx86">
-    <file src="build\react-ndk\all\arm64-v8a\libyoga.so" target="lib\droidarm64">
+    <file src="build\react-ndk\all\x86_64\libyoga.so" target="lib\droidx64"/>
+    <file src="build\react-ndk\all\armeabi-v7a\libyoga.so" target="lib\droidarm"/>
+    <file src="build\react-ndk\all\x86\libyoga.so" target="lib\droidx86"/>
+    <file src="build\react-ndk\all\arm64-v8a\libyoga.so" target="lib\droidarm64"/>
 
-    <file src="..\android\com\facebook\react\react-native\*\react-native-*.aar" target="lib">
-    <file src="..\android\com\facebook\react\react-native\*\react-native-*.pom" target="lib">
+    <file src="..\android\com\facebook\react\react-native\*\react-native-*.aar" target="lib"/>
+    <file src="..\android\com\facebook\react\react-native\*\react-native-*.pom" target="lib"/>
 
     <!-- Ideally we'd only exported the needed headers, not the complete list -->
     <file src="..\ReactCommon\cxxreact\**\*.h" target="inc\cxxreact"/>

--- a/ReactAndroid/ReactAndroid.nuspec
+++ b/ReactAndroid/ReactAndroid.nuspec
@@ -10,8 +10,53 @@
   </metadata>
   <files>
 
-    <!-- This is largely a placeholder right now, to get the publishing pipeline to be complete.. we obviously need the built binaries too.. -->
+    <file src="build\react-ndk\all\x86_64\libfb.so" target="lib\droidx64">
+    <file src="build\react-ndk\all\armeabi-v7a\libfb.so" target="lib\droidarm">
+    <file src="build\react-ndk\all\x86\libfb.so" target="lib\droidx86">
+    <file src="build\react-ndk\all\arm64-v8a\libfb.so" target="lib\droidarm64">
 
+    <file src="build\react-ndk\all\x86_64\libfolly_json.so" target="lib\droidx64">
+    <file src="build\react-ndk\all\armeabi-v7a\libfolly_json.so" target="lib\droidarm">
+    <file src="build\react-ndk\all\x86\libfolly_json.so" target="lib\droidx86">
+    <file src="build\react-ndk\all\arm64-v8a\libfolly_json.so" target="lib\droidarm64">
+
+    <file src="build\react-ndk\all\x86_64\libglog.so" target="lib\droidx64">
+    <file src="build\react-ndk\all\armeabi-v7a\libglog.so" target="lib\droidarm">
+    <file src="build\react-ndk\all\x86\libglog.so" target="lib\droidx86">
+    <file src="build\react-ndk\all\arm64-v8a\libglog.so" target="lib\droidarm64">
+
+    <file src="build\react-ndk\all\x86_64\libglog_init.so" target="lib\droidx64">
+    <file src="build\react-ndk\all\armeabi-v7a\libglog_init.so" target="lib\droidarm">
+    <file src="build\react-ndk\all\x86\libglog_init.so" target="lib\droidx86">
+    <file src="build\react-ndk\all\arm64-v8a\libglog_init.so" target="lib\droidarm64">
+
+    <file src="build\react-ndk\all\x86_64\libprivatedata.so" target="lib\droidx64">
+    <file src="build\react-ndk\all\armeabi-v7a\libprivatedata.so" target="lib\droidarm">
+    <file src="build\react-ndk\all\x86\libprivatedata.so" target="lib\droidx86">
+    <file src="build\react-ndk\all\arm64-v8a\libprivatedata.so" target="lib\droidarm64">
+
+    <file src="build\react-ndk\all\x86_64\libreactnativejni.so" target="lib\droidx64">
+    <file src="build\react-ndk\all\armeabi-v7a\libreactnativejni.so" target="lib\droidarm">
+    <file src="build\react-ndk\all\x86\libreactnativejni.so" target="lib\droidx86">
+    <file src="build\react-ndk\all\arm64-v8a\libreactnativejni.so" target="lib\droidarm64">
+
+    <file src="build\react-ndk\all\x86_64\libv8executor.so" target="lib\droidx64">
+    <file src="build\react-ndk\all\armeabi-v7a\libv8executor.so" target="lib\droidarm">
+    <file src="build\react-ndk\all\x86\libv8executor.so" target="lib\droidx86">
+    <file src="build\react-ndk\all\arm64-v8a\libv8executor.so" target="lib\droidarm64">
+
+    <file src="build\react-ndk\all\x86_64\libyoga.so" target="lib\droidx64">
+    <file src="build\react-ndk\all\armeabi-v7a\libyoga.so" target="lib\droidarm">
+    <file src="build\react-ndk\all\x86\libyoga.so" target="lib\droidx86">
+    <file src="build\react-ndk\all\arm64-v8a\libyoga.so" target="lib\droidarm64">
+
+    <file src="build\react-ndk\all\x86_64\libyoga.so" target="lib\droidx64">
+    <file src="build\react-ndk\all\armeabi-v7a\libyoga.so" target="lib\droidarm">
+    <file src="build\react-ndk\all\x86\libyoga.so" target="lib\droidx86">
+    <file src="build\react-ndk\all\arm64-v8a\libyoga.so" target="lib\droidarm64">
+
+    <file src="..\android\com\facebook\react\react-native\*\react-native-*.aar" target="lib">
+    <file src="..\android\com\facebook\react\react-native\*\react-native-*.pom" target="lib">
 
     <!-- Ideally we'd only exported the needed headers, not the complete list -->
     <file src="..\ReactCommon\cxxreact\**\*.h" target="inc\cxxreact"/>


### PR DESCRIPTION
Nuget should include build binaries.
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

Adds various built files to the nuget.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/73)