### PR TITLE
Adding option to exclude all libs while building ReactAndroid aar

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -96,7 +96,7 @@ jobs:
         inputs:
           gradleWrapperFile: gradlew
           # workingDirectory: src\react-native\
-          #options: # Optional
+          options: -Pparam='excludeLibs'
           tasks: installArchives
           publishJUnitResults: false
           #testResultsFiles: '**/TEST-*.xml' # Required when publishJUnitResults == True

--- a/.ado/publish.js
+++ b/.ado/publish.js
@@ -61,7 +61,8 @@ function doPublish() {
 
   if (!onlyTagSource) {
     // -------- Generating Android Artifacts with JavaDoc
-    exec("gradlew installArchives");
+    // -Pparam='excludeLibs' - This argument will not package the DSOs in ReactAndroid aar
+    exec("gradlew -Pparam='excludeLibs' installArchives");
 
     // undo uncommenting javadoc setting
     exec("git checkout ReactAndroid/gradle.properties");

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -233,9 +233,15 @@ task cleanReactNdkLib(type: Exec) {
             'clean'
 }
 
+// usage : gradlew -Pparam="excludeLibs" <taskname>
 task packageReactNdkLibs(dependsOn: buildReactNdkLib, type: Copy) {
+    def arg = project.hasProperty('param') ? project.property('param') : 'noArg'
     from "$buildDir/react-ndk/all"
-    exclude '**/libjsc.so'
+    if(arg.equals("excludeLibs")) {
+        exclude '**/*.so'
+    } else {
+        exclude '**/libjsc.so'
+    }
     into "$buildDir/react-ndk/exported"
 }
 


### PR DESCRIPTION
#### Please select one of the following
- I am making a change required for Microsoft usage of react-native

#### Description of changes
Giving an option to exclude all libs (using parameter "excludeLibs") from gets packaged inside ReactAndroid aar file.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/79)