### PR TITLE
Adding back the Accessibility Actions that were mistakenly remove in …

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -822,6 +822,14 @@ public class UIImplementation {
     mOperationsQueue.enqueueSendAccessibilityEvent(tag, eventType);
   }
 
+   public void performAccessibilityAction(int tag, int action) {
+    mOperationsQueue.enqueuePerformAccessibilityAction(tag, action);
+  }
+
+  public void announceForAccessibility(int tag, String announcement) {
+    mOperationsQueue.enqueueAnnounceForAccessibility(tag, announcement);
+  }
+
   public void onHostResume() {
     mOperationsQueue.resumeFrameCallback();
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -765,6 +765,16 @@ public class UIManagerModule extends ReactContextBaseJavaModule
     mUIImplementation.sendAccessibilityEvent(tag, eventType);
   }
 
+  @ReactMethod
+  public void performAccessibilityAction(int tag, int action) {
+    mUIImplementation.performAccessibilityAction(tag, action);
+  }
+
+  @ReactMethod
+  public void announceForAccessibility(int tag, String announcement) {
+    mUIImplementation.announceForAccessibility(tag, announcement);
+  }
+
   /**
    * Schedule a block to be executed on the UI thread. Useful if you need to execute view logic
    * after all currently queued view updates have completed.

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
@@ -876,6 +876,14 @@ public class UIViewOperationQueue {
     mOperations.add(new SendAccessibilityEvent(tag, eventType));
   }
 
+  public void enqueuePerformAccessibilityAction(int tag, int action) {
+    mOperations.add(new PerformAccessibilityAction(tag, action));
+  }
+
+  public void enqueueAnnounceForAccessibility(int tag, String announcement) {
+    mOperations.add(new AnnounceForAccessibility(tag, announcement));
+  }
+
   public void enqueueLayoutUpdateFinished(ReactShadowNode node, UIImplementation.LayoutUpdateListener listener) {
     mOperations.add(new LayoutUpdateFinishedOperation(node, listener));
   }


### PR DESCRIPTION
…the last merge - RN57

<!--
We are working on reducing the diff between Facebook's public version of react-native, and our microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/81)