### PR TITLE
Param in gradle command requires double quotes instead of single

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -96,7 +96,7 @@ jobs:
         inputs:
           gradleWrapperFile: gradlew
           # workingDirectory: src\react-native\
-          options: -Pparam='excludeLibs'
+          options: -Pparam="excludeLibs"
           tasks: installArchives
           publishJUnitResults: false
           #testResultsFiles: '**/TEST-*.xml' # Required when publishJUnitResults == True

--- a/.ado/publish.js
+++ b/.ado/publish.js
@@ -61,8 +61,8 @@ function doPublish() {
 
   if (!onlyTagSource) {
     // -------- Generating Android Artifacts with JavaDoc
-    // -Pparam='excludeLibs' - This argument will not package the DSOs in ReactAndroid aar
-    exec("gradlew -Pparam='excludeLibs' installArchives");
+    // -Pparam="excludeLibs" - This argument will not package the DSOs in ReactAndroid aar
+    exec("gradlew -Pparam=\"excludeLibs\" installArchives");
 
     // undo uncommenting javadoc setting
     exec("git checkout ReactAndroid/gradle.properties");


### PR DESCRIPTION
#### Please select one of the following
- I am making a change required for Microsoft usage of react-native

#### Description of changes
When a param is passed in gradle command, it should be passed in double quotes instead of single quotes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/82)