### PR TITLE
Adding logging support for droid and logging failure message

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/v8executor/OnLoad.cpp
+++ b/ReactAndroid/src/main/java/com/facebook/react/v8executor/OnLoad.cpp
@@ -13,12 +13,6 @@
 #include <react/jni/ReadableNativeMap.h>
 
 namespace facebook {
-namespace v8runtime {
-      std::unique_ptr<jsi::Runtime> makeV8Runtime();
-} // namespace v8runtime
-} // namespace facebook
-
-namespace facebook {
 namespace react {
 
 namespace {
@@ -32,12 +26,15 @@ public:
   std::unique_ptr<JSExecutor> createJSExecutor(
       std::shared_ptr<ExecutorDelegate> delegate,
       std::shared_ptr<MessageQueueThread> jsQueue) override {
+
+    auto logger = std::make_shared<JSIExecutor::Logger>([](const std::string& message, unsigned int logLevel) {
+                    reactAndroidLoggingHook(message, logLevel);
+    });
+
     return folly::make_unique<JSIExecutor>(
-      facebook::v8runtime::makeV8Runtime(m_v8Config),
+      facebook::v8runtime::makeV8Runtime(m_v8Config, logger),
       delegate,
-      [](const std::string& message, unsigned int logLevel) {
-        reactAndroidLoggingHook(message, logLevel);
-      },
+      *logger,
       JSIExecutor::defaultTimeoutInvoker,
       nullptr);
   }

--- a/ReactCommon/jsi/V8Runtime.h
+++ b/ReactCommon/jsi/V8Runtime.h
@@ -60,7 +60,7 @@ namespace v8runtime {
     std::unique_ptr<const jsi::Buffer> custom_snapshot = nullptr); /*Optional*/
 
   std::unique_ptr<jsi::Runtime> makeV8Runtime();
-  std::unique_ptr<jsi::Runtime> makeV8Runtime(const folly::dynamic& v8Config);
+  std::unique_ptr<jsi::Runtime> makeV8Runtime(const folly::dynamic& v8Config, const std::shared_ptr<Logger>& logger);
 
 } // namespace v8runtime
 } // namespace facebook

--- a/ReactCommon/jsi/V8Runtime_droid.cpp
+++ b/ReactCommon/jsi/V8Runtime_droid.cpp
@@ -50,7 +50,8 @@ namespace facebook { namespace v8runtime {
     }
   }
 
-  V8Runtime::V8Runtime(const folly::dynamic& v8Config) : V8Runtime() {
+  V8Runtime::V8Runtime(const folly::dynamic& v8Config, const std::shared_ptr<Logger>& logger) : V8Runtime() {
+    logger_ = logger;
     isCacheEnabled_  = IsCacheEnabled(v8Config);
     shouldProduceFullCache_ = ShouldProduceFullCache(v8Config);
     shouldSetNoLazyFlag_ = ShouldSetNoLazyFlag(v8Config);
@@ -150,7 +151,7 @@ namespace facebook { namespace v8runtime {
     return script;
   }
 
-  std::unique_ptr<jsi::Runtime> makeV8Runtime(const folly::dynamic& v8Config) {
-    return std::make_unique<V8Runtime>(v8Config);
+  std::unique_ptr<jsi::Runtime> makeV8Runtime(const folly::dynamic& v8Config, const std::shared_ptr<Logger>& logger) {
+    return std::make_unique<V8Runtime>(v8Config, logger);
   }
 }} // namespace facebook::v8runtime

--- a/ReactCommon/jsi/V8Runtime_impl.h
+++ b/ReactCommon/jsi/V8Runtime_impl.h
@@ -43,7 +43,7 @@ namespace facebook { namespace v8runtime {
   class V8Runtime : public jsi::Runtime {
   public:
     V8Runtime();
-    V8Runtime(const folly::dynamic& v8Config);
+    V8Runtime(const folly::dynamic& v8Config, const std::shared_ptr<Logger>& logger);
 
     V8Runtime(const v8::Platform* platform, std::shared_ptr<Logger>&& logger,
       std::shared_ptr<facebook::react::MessageQueueThread>&& jsQueue, std::shared_ptr<CacheProvider>&& cacheProvider,
@@ -373,6 +373,12 @@ namespace facebook { namespace v8runtime {
 
     bool ExecuteString(v8::Local<v8::String> source, const jsi::Buffer* cache, v8::Local<v8::Value> name, bool report_exceptions);
     bool ExecuteString(const v8::Local<v8::String>& source, const std::string& sourceURL);
+
+    void Log(const std::string& message, const unsigned int logLevel) {
+      if (logger_) {
+        (*logger_)("V8Runtime:: " + message, logLevel);
+      }
+    }
 
     void ReportException(v8::TryCatch* try_catch);
 

--- a/ReactCommon/jsi/V8Runtime_shared.cpp
+++ b/ReactCommon/jsi/V8Runtime_shared.cpp
@@ -247,7 +247,9 @@ namespace facebook { namespace v8runtime {
     if (message.IsEmpty()) {
       // V8 didn't provide any extra information about this error; just
       // throw the exception.
-      throw jsi::JSError(*this, "<Unknown exception>");
+      std::string errorMessage{ "<Unknown exception>" };
+      Log(errorMessage, 3 /*logLevel error*/);
+      throw jsi::JSError(*this, errorMessage);
     }
     else {
       // Print (filename):(line number): (message).
@@ -283,7 +285,10 @@ namespace facebook { namespace v8runtime {
         sstr << stack_trace_string2 << std::endl;
       }
 
-      throw jsi::JSError(*this, sstr.str());
+      std::string errorMessage{ sstr.str() };
+      Log(errorMessage, 3 /*logLevel error*/);
+
+      throw jsi::JSError(*this, errorMessage);
     }
   }
 

--- a/ReactCommon/jsi/V8Runtime_win.cpp
+++ b/ReactCommon/jsi/V8Runtime_win.cpp
@@ -13,7 +13,7 @@ namespace facebook { namespace v8runtime {
     std::abort();
   }
 
-  V8Runtime::V8Runtime(const folly::dynamic& v8Config) : V8Runtime() {
+  V8Runtime::V8Runtime(const folly::dynamic& v8Config, const std::shared_ptr<Logger>& logger) : V8Runtime() {
     // Not to be called on Windows.
     std::abort();
   }
@@ -23,7 +23,7 @@ namespace facebook { namespace v8runtime {
     std::abort();
   }
 
-  std::unique_ptr<jsi::Runtime> makeV8Runtime(const folly::dynamic& v8Config) {
-    return std::make_unique<V8Runtime>(v8Config);
+  std::unique_ptr<jsi::Runtime> makeV8Runtime(const folly::dynamic& v8Config, const std::shared_ptr<Logger>& logger) {
+    return std::make_unique<V8Runtime>(v8Config, logger);
   }
 }} // namespace facebook::v8runtime


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes
Adding logging support for droid and logging failure message


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/87)