### PR TITLE
Correctly bypass sync calls in UIManager during remote debugging

### DIFF
--- a/Libraries/ReactNative/UIManager.js
+++ b/Libraries/ReactNative/UIManager.js
@@ -59,10 +59,8 @@ UIManager.getViewManagerConfig = function(viewManagerName: string) {
 
   // If we're in the Chrome Debugger, let's not even try calling the sync
   // method.
-  if (__DEV__) {
-    if (!global.nativeCallSyncHook) {
-      return config;
-    }
+  if (!global.nativeCallSyncHook) {
+    return config;
   }
 
   if (UIManager.lazilyLoadView && !triedLoadingConfig.has(viewManagerName)) {
@@ -155,7 +153,7 @@ if (
   }
 }
 
-if (__DEV__) {
+if (!global.nativeCallSyncHook) {
   Object.keys(UIManager).forEach(viewManagerName => {
     if (!UIManagerProperties.includes(viewManagerName)) {
       if (!viewManagerConfigs[viewManagerName]) {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

(Mirroring https://github.com/facebook/react-native/pull/25162)

Remote debugging stopped working (since 0.58, according to #23254). See https://github.com/facebook/react-native/issues/23254#issuecomment-474692753 for repro steps.

The root cause is incorrect checks for Chrome debugging environment in `UIManager.js`.
- In one place where sync function `lazilyLoadView` should be avoided, we effectively use `if (__DEV__ && !global.nativeCallSyncHook)` to check remote debugging, which misses ship flavor (i.e. `__DEV__` is false).
- In another place where we want to pre-populate view managers' constants to avoid calling sync function `getConstantsForViewManager`, `if (__DEV__)` is used, also missing ship flavor.

This PR fixes both checks, only using the absense of `global.nativeCallSyncHook` to determine remote debugging environments.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/92)