### PR TITLE
Yoga: call getMeasure even when YGMeasureModeExactly

### DIFF
--- a/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/ReactCommon/yoga/yoga/Yoga.cpp
@@ -1669,6 +1669,16 @@ static void YGNodeWithMeasureFuncSetMeasuredDimensions(
       : YGFloatMax(
             0, availableHeight - marginAxisColumn - paddingAndBorderAxisColumn);
 
+  // Measure the text under the current constraints.
+  const YGSize measuredSize = marker::MarkerSection<YGMarkerMeasure>::wrap(
+      node,
+      node->getMeasure(),
+      node,
+      innerWidth,
+      widthMeasureMode,
+      innerHeight,
+      heightMeasureMode);
+
   if (widthMeasureMode == YGMeasureModeExactly &&
       heightMeasureMode == YGMeasureModeExactly) {
     // Don't bother sizing the text if both dimensions are already defined.
@@ -1689,16 +1699,6 @@ static void YGNodeWithMeasureFuncSetMeasuredDimensions(
             ownerWidth),
         YGDimensionHeight);
   } else {
-    // Measure the text under the current constraints.
-    const YGSize measuredSize = marker::MarkerSection<YGMarkerMeasure>::wrap(
-        node,
-        node->getMeasure(),
-        node,
-        innerWidth,
-        widthMeasureMode,
-        innerHeight,
-        heightMeasureMode);
-
     node->setLayoutMeasuredDimension(
         YGNodeBoundAxis(
             node,

--- a/ReactCommon/yoga/yoga/Yoga.cpp
+++ b/ReactCommon/yoga/yoga/Yoga.cpp
@@ -1669,16 +1669,6 @@ static void YGNodeWithMeasureFuncSetMeasuredDimensions(
       : YGFloatMax(
             0, availableHeight - marginAxisColumn - paddingAndBorderAxisColumn);
 
-  // Measure the text under the current constraints.
-  const YGSize measuredSize = marker::MarkerSection<YGMarkerMeasure>::wrap(
-      node,
-      node->getMeasure(),
-      node,
-      innerWidth,
-      widthMeasureMode,
-      innerHeight,
-      heightMeasureMode);
-
   if (widthMeasureMode == YGMeasureModeExactly &&
       heightMeasureMode == YGMeasureModeExactly) {
     // Don't bother sizing the text if both dimensions are already defined.
@@ -1699,6 +1689,16 @@ static void YGNodeWithMeasureFuncSetMeasuredDimensions(
             ownerWidth),
         YGDimensionHeight);
   } else {
+    // Measure the text under the current constraints.
+    const YGSize measuredSize = marker::MarkerSection<YGMarkerMeasure>::wrap(
+        node,
+        node->getMeasure(),
+        node,
+        innerWidth,
+        widthMeasureMode,
+        innerHeight,
+        heightMeasureMode);
+
     node->setLayoutMeasuredDimension(
         YGNodeBoundAxis(
             node,


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

Yoga leaf nodes in Win32 can be sub-trees which rely on the measure call (getMeasure) to perform the sub-tree layout passes.

#### Focus areas to test

Yoga layout


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/100)