### PR TITLE
Add windowsbrush support

### DIFF
--- a/Libraries/Color/normalizeColor.js
+++ b/Libraries/Color/normalizeColor.js
@@ -13,11 +13,11 @@
 
 const Platform = require('Platform'); // [TODO(macOS ISS#2323203)
 
-export type SemanticOrDynamicColorType = {
+export type NativeOrDynamicColorType = {
   semantic?: string,
   dynamic?: {
-    light: ?(string | number | SemanticOrDynamicColorType),
-    dark: ?(string | number | SemanticOrDynamicColorType),
+    light: ?(string | number | NativeOrDynamicColorType),
+    dark: ?(string | number | NativeOrDynamicColorType),
   },
 }; // ]TODO(macOS ISS#2323203)
 
@@ -25,9 +25,9 @@ function normalizeColor(
   color: ?(
     | string
     | number
-    | SemanticOrDynamicColorType
+    | NativeOrDynamicColorType
   ) /* TODO(macOS ISS#2323203) */,
-): ?(number | SemanticOrDynamicColorType) /* TODO(macOS ISS#2323203) */ {
+): ?(number | NativeOrDynamicColorType) /* TODO(macOS ISS#2323203) */ {
   const matchers = getMatchers();
   let match;
 
@@ -38,15 +38,16 @@ function normalizeColor(
     return null;
   }
 
-  if (typeof color === 'object' && color !== null && Platform.OS === 'macos') {
+  if (typeof color === 'object' && color !== null && 
+    (Platform.OS === 'macos' || Platform.OS === 'uwp')) {
     // [TODO(macOS ISS#2323203)
-    if ('semantic' in color) {
-      // a macos semantic color
+    if ('semantic' in color || 'windowsbrush' in color) {
+      // a macos semantic color or a XAML brush
       return color;
     } else if ('dynamic' in color && color.dynamic !== undefined) {
       // a dynamic, appearance aware color
       const dynamic = color.dynamic;
-      const dynamicColor: SemanticOrDynamicColorType = {
+      const dynamicColor: NativeOrDynamicColorType = {
         dynamic: {
           light: normalizeColor(dynamic.light),
           dark: normalizeColor(dynamic.dark),

--- a/Libraries/Color/normalizeColor.js
+++ b/Libraries/Color/normalizeColor.js
@@ -41,7 +41,8 @@ function normalizeColor(
   if (typeof color === 'object' && color !== null && 
     (Platform.OS === 'macos' || Platform.OS === 'uwp')) {
     // [TODO(macOS ISS#2323203)
-    if ('semantic' in color || 'windowsbrush' in color) {
+    if ((Platform.OS === 'macos' && 'semantic' in color) ||
+      (Platform.OS === 'uwp' && 'windowsbrush' in color)) {
       // a macos semantic color or a XAML brush
       return color;
     } else if ('dynamic' in color && color.dynamic !== undefined) {

--- a/Libraries/Color/normalizeColor.js
+++ b/Libraries/Color/normalizeColor.js
@@ -38,11 +38,16 @@ function normalizeColor(
     return null;
   }
 
-  if (typeof color === 'object' && color !== null && 
-    (Platform.OS === 'macos' || Platform.OS === 'uwp')) {
+  if (
+    typeof color === 'object' &&
+    color !== null &&
+    (Platform.OS === 'macos' || Platform.OS === 'uwp')
+  ) {
     // [TODO(macOS ISS#2323203)
-    if ((Platform.OS === 'macos' && 'semantic' in color) ||
-      (Platform.OS === 'uwp' && 'windowsbrush' in color)) {
+    if (
+      (Platform.OS === 'macos' && 'semantic' in color) ||
+      (Platform.OS === 'uwp' && 'windowsbrush' in color)
+    ) {
       // a macos semantic color or a XAML brush
       return color;
     } else if ('dynamic' in color && color.dynamic !== undefined) {

--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -19,7 +19,7 @@ const RCTActivityIndicatorViewNativeComponent = require('RCTActivityIndicatorVie
 
 import type {NativeComponent} from 'ReactNative';
 import type {ViewProps} from 'ViewPropTypes';
-import type {SemanticOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
 
 const RCTActivityIndicator =
   Platform.OS === 'android'
@@ -54,7 +54,7 @@ type Props = $ReadOnly<{|
    *
    * See http://facebook.github.io/react-native/docs/activityindicator.html#color
    */
-  color?: ?(string | SemanticOrDynamicColorType), // ]TODO(macOS ISS#2323203)
+  color?: ?(string | NativeOrDynamicColorType), // ]TODO(macOS ISS#2323203)
 
   /**
    * Size of the indicator (default is 'small').

--- a/Libraries/Components/ActivityIndicator/RCTActivityIndicatorViewNativeComponent.js
+++ b/Libraries/Components/ActivityIndicator/RCTActivityIndicatorViewNativeComponent.js
@@ -15,7 +15,7 @@ const requireNativeComponent = require('requireNativeComponent');
 import type {ViewProps} from 'ViewPropTypes';
 import type {ViewStyleProp} from 'StyleSheet';
 import type {NativeComponent} from 'ReactNative';
-import type {SemanticOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
 
 type NativeProps = $ReadOnly<{|
   ...ViewProps,
@@ -39,7 +39,7 @@ type NativeProps = $ReadOnly<{|
    *
    * See http://facebook.github.io/react-native/docs/activityindicator.html#color
    */
-  color?: ?(string | SemanticOrDynamicColorType),
+  color?: ?(string | NativeOrDynamicColorType),
 
   /**
    * Size of the indicator (default is 'small').

--- a/Libraries/Components/DrawerAndroid/AndroidDrawerLayoutNativeComponent.js
+++ b/Libraries/Components/DrawerAndroid/AndroidDrawerLayoutNativeComponent.js
@@ -16,9 +16,9 @@ import type {NativeComponent} from 'ReactNative';
 import type {SyntheticEvent} from 'CoreEventTypes';
 import type {ViewStyleProp} from 'StyleSheet';
 import type React from 'React';
-import type {SemanticOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
 
-type ColorValue = null | string | SemanticOrDynamicColorType;
+type ColorValue = null | string | NativeOrDynamicColorType;
 
 type DrawerStates = 'Idle' | 'Dragging' | 'Settling';
 

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -24,7 +24,7 @@ import type {SyntheticEvent} from 'CoreEventTypes';
 import type {ColorValue} from 'StyleSheetTypes';
 import type {ViewProps} from 'ViewPropTypes';
 import type {TextStyleProp} from 'StyleSheet';
-import type {SemanticOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
 
 type PickerIOSChangeEvent = SyntheticEvent<
   $ReadOnly<{|
@@ -36,7 +36,7 @@ type PickerIOSChangeEvent = SyntheticEvent<
 type RCTPickerIOSItemType = $ReadOnly<{|
   label: ?Label,
   value: ?(number | string),
-  textColor: ?(number | SemanticOrDynamicColorType), // ]TODO(macOS ISS#2323203)
+  textColor: ?(number | NativeOrDynamicColorType), // ]TODO(macOS ISS#2323203)
 |}>;
 
 type RCTPickerIOSType = Class<

--- a/Libraries/Components/Picker/RCTPickerNativeComponent.js
+++ b/Libraries/Components/Picker/RCTPickerNativeComponent.js
@@ -14,7 +14,7 @@ const requireNativeComponent = require('requireNativeComponent');
 import type {SyntheticEvent} from 'CoreEventTypes';
 import type {TextStyleProp} from 'StyleSheet';
 import type {NativeComponent} from 'ReactNative';
-import type {SemanticOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
 
 type PickerIOSChangeEvent = SyntheticEvent<
   $ReadOnly<{|
@@ -26,7 +26,7 @@ type PickerIOSChangeEvent = SyntheticEvent<
 type RCTPickerIOSItemType = $ReadOnly<{|
   label: ?Label,
   value: ?(number | string),
-  textColor: ?(number | SemanticOrDynamicColorType),
+  textColor: ?(number | NativeOrDynamicColorType),
 |}>;
 
 type Label = Stringish | number;

--- a/Libraries/Components/Switch/SwitchNativeComponent.js
+++ b/Libraries/Components/Switch/SwitchNativeComponent.js
@@ -17,7 +17,7 @@ const requireNativeComponent = require('requireNativeComponent');
 
 import type {SwitchChangeEvent} from 'CoreEventTypes';
 import type {ViewProps} from 'ViewPropTypes';
-import type {SemanticOrDynamicColorType} from 'normalizeColor'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'normalizeColor'; // TODO(macOS ISS#2323203)
 
 type SwitchProps = $ReadOnly<{|
   ...ViewProps,
@@ -35,17 +35,17 @@ export type NativeAndroidProps = $ReadOnly<{|
 
   enabled?: ?boolean,
   on?: ?boolean,
-  thumbTintColor?: ?(string | SemanticOrDynamicColorType),
-  trackTintColor?: ?(string | SemanticOrDynamicColorType),
+  thumbTintColor?: ?(string | NativeOrDynamicColorType),
+  trackTintColor?: ?(string | NativeOrDynamicColorType),
 |}>;
 
 // @see RCTSwitchManager.m
 export type NativeIOSProps = $ReadOnly<{|
   ...SwitchProps,
 
-  onTintColor?: ?(string | SemanticOrDynamicColorType),
-  thumbTintColor?: ?(string | SemanticOrDynamicColorType),
-  tintColor?: ?(string | SemanticOrDynamicColorType),
+  onTintColor?: ?(string | NativeOrDynamicColorType),
+  thumbTintColor?: ?(string | NativeOrDynamicColorType),
+  tintColor?: ?(string | NativeOrDynamicColorType),
 |}>;
 
 type SwitchNativeComponentType = Class<

--- a/Libraries/Components/ToolbarAndroid/ToolbarAndroidNativeComponent.js
+++ b/Libraries/Components/ToolbarAndroid/ToolbarAndroidNativeComponent.js
@@ -16,7 +16,7 @@ import type {SyntheticEvent} from 'CoreEventTypes';
 import type {ImageSource} from 'ImageSource';
 import type {ViewProps} from 'ViewPropTypes';
 import type {NativeComponent} from 'ReactNative';
-import type {SemanticOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
 
 type Action = $ReadOnly<{|
   title: string,
@@ -36,7 +36,7 @@ type NativeProps = $ReadOnly<{|
   nativeActions?: Array<Action>,
 |}>;
 
-type ColorValue = null | string | SemanticOrDynamicColorType;
+type ColorValue = null | string | NativeOrDynamicColorType;
 
 type ToolbarAndroidProps = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
@@ -24,7 +24,7 @@ const ensurePositiveDelayProps = require('ensurePositiveDelayProps');
 const processColor = require('processColor');
 
 import type {PressEvent} from 'CoreEventTypes';
-import type {SemanticOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
 
 const rippleBackgroundPropType = PropTypes.shape({
   type: PropTypes.oneOf(['RippleAndroid']),
@@ -146,7 +146,7 @@ const TouchableNativeFeedback = createReactClass({
       borderless: boolean,
     ): {
       type: 'RippleAndroid',
-      color: ?(number | SemanticOrDynamicColorType),
+      color: ?(number | NativeOrDynamicColorType),
       borderless: boolean,
     } {
       return {

--- a/Libraries/ReactNative/getNativeComponentAttributes.js
+++ b/Libraries/ReactNative/getNativeComponentAttributes.js
@@ -21,7 +21,7 @@ const resolveAssetSource = require('resolveAssetSource');
 const sizesDiffer = require('sizesDiffer');
 const invariant = require('invariant');
 const warning = require('fbjs/lib/warning');
-import type {SemanticOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
 
 function getNativeComponentAttributes(uiViewClassName: string) {
   const viewConfig = UIManager.getViewManagerConfig(uiViewClassName);
@@ -184,7 +184,7 @@ function getProcessorForType(typeName: string): ?(nextProp: any) => any {
 
 function processColorArray(
   colors: ?Array<any>,
-): ?Array<?(number | SemanticOrDynamicColorType)> {
+): ?Array<?(number | NativeOrDynamicColorType)> {
   // ]TODO(macOS ISS#2323203)
   return colors == null ? null : colors.map(processColor);
 }

--- a/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/Libraries/StyleSheet/StyleSheetTypes.js
@@ -11,9 +11,9 @@
 'use strict';
 
 const AnimatedNode = require('AnimatedNode');
-import type {SemanticOrDynamicColorType} from 'normalizeColor'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'normalizeColor'; // TODO(macOS ISS#2323203)
 
-export type ColorValue = null | string | SemanticOrDynamicColorType; // TODO(macOS ISS#2323203)
+export type ColorValue = null | string | NativeOrDynamicColorType; // TODO(macOS ISS#2323203)
 export type DimensionValue = null | number | string | AnimatedNode;
 
 /**

--- a/Libraries/StyleSheet/processColor.js
+++ b/Libraries/StyleSheet/processColor.js
@@ -13,12 +13,12 @@
 const Platform = require('Platform');
 
 const normalizeColor = require('normalizeColor');
-import type {SemanticOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'normalizeColor'; // ]TODO(macOS ISS#2323203)
 
 /* eslint no-bitwise: 0 */
 function processColor(
-  color?: ?(string | number | SemanticOrDynamicColorType),
-): ?(number | SemanticOrDynamicColorType) /* TODO(macOS ISS#2323203) */ {
+  color?: ?(string | number | NativeOrDynamicColorType),
+): ?(number | NativeOrDynamicColorType) /* TODO(macOS ISS#2323203) */ {
   if (color === undefined || color === null) {
     return color;
   }
@@ -30,7 +30,7 @@ function processColor(
 
   if (
     typeof int32Color === 'object' &&
-    Platform.OS === 'macos' /* [TODO(macOS ISS#2323203) */
+    (Platform.OS === 'uwp' || Platform.OS === 'macos') /* [TODO(macOS ISS#2323203) */
   ) {
     if ('dynamic' in int32Color && int32Color.dynamic !== undefined) {
       const dynamic = int32Color.dynamic;

--- a/Libraries/StyleSheet/processColor.js
+++ b/Libraries/StyleSheet/processColor.js
@@ -30,7 +30,8 @@ function processColor(
 
   if (
     typeof int32Color === 'object' &&
-    (Platform.OS === 'uwp' || Platform.OS === 'macos') /* [TODO(macOS ISS#2323203) */
+    (Platform.OS === 'uwp' ||
+      Platform.OS === 'macos') /* [TODO(macOS ISS#2323203) */
   ) {
     if ('dynamic' in int32Color && int32Color.dynamic !== undefined) {
       const dynamic = int32Color.dynamic;
@@ -42,8 +43,10 @@ function processColor(
       };
       return dynamicColor;
     }
-    if ((Platform.OS === 'macos' && 'semantic' in int32Color) ||
-      (Platform.OS === 'uwp' && 'windowsbrush' in int32Color)) {
+    if (
+      (Platform.OS === 'macos' && 'semantic' in int32Color) ||
+      (Platform.OS === 'uwp' && 'windowsbrush' in int32Color)
+    ) {
       return int32Color;
     }
   }

--- a/Libraries/StyleSheet/processColor.js
+++ b/Libraries/StyleSheet/processColor.js
@@ -42,7 +42,10 @@ function processColor(
       };
       return dynamicColor;
     }
-    return int32Color;
+    if ((Platform.OS === 'macos' && 'semantic' in int32Color) ||
+      (Platform.OS === 'uwp' && 'windowsbrush' in int32Color)) {
+      return int32Color;
+    }
   }
   if (typeof int32Color !== 'number') {
     return null;


### PR DESCRIPTION
# :warning: Make sure you are targeting microsoft/react-native for your PR :warning:
(then delete these lines)

<!--
We are working on reducing the diff between Facebook's public version of react-native, and our microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

- Renamed "SemanticOrDynamicColorType" to "NativeOrDynamicColorType"
- Give access to 'dynamic' to uwp
- Add 'windowsbrush' for uwp

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/102)