### PR TITLE
Yoga Text Truncation bug fix 

### DIFF
--- a/ReactCommon/yoga/yoga/YGNode.h
+++ b/ReactCommon/yoga/yoga/YGNode.h
@@ -18,7 +18,7 @@ private:
   bool hasNewLayout_ : 1;
   bool isReferenceBaseline_ : 1;
   bool isDirty_ : 1;
-  YGNodeType nodeType_ : 1;
+  YGNodeType nodeType_ = {};
   YGMeasureFunc measure_ = nullptr;
   YGBaselineFunc baseline_ = nullptr;
   YGDirtiedFunc dirtied_ = nullptr;


### PR DESCRIPTION
## Summary
Fix failing textRounding flag by changing YGNodeType field in YGNode struct. Top 7 bits will now be in agreement with enum value allowing for comparisions without masking bit values.
By fixing the textRounding flag in Yoga.cpp's RoundToPixelGrid method, Text components will no longer attempt to round their width value to align with a whole pixel value. This flag being broken caused issues when the text was scaled leading to truncation of the text at certain scaled sizes of view with fractional width values.

## Changelog
[General][Changed] - YGNode's nodeType_ field to work with comparisons with the YGNodeType enums.

## Test Plan

Eliminates Text Clipping bug in the react-native-windows sample apps. Tested with this and custom apps.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/104)