### PR TITLE
Accessibility extensions for lists

### DIFF
--- a/Libraries/Components/View/ViewAccessibility.js
+++ b/Libraries/Components/View/ViewAccessibility.js
@@ -74,7 +74,9 @@ export type AccessibilityRole =
   | 'tab'
   | 'tablist'
   | 'timer'
-  | 'toolbar';
+  | 'toolbar'
+  | 'list' // RNW-only
+  | 'listitem'; // RNW-only
 
 export type AccessibilityState =
   | 'selected'
@@ -145,6 +147,8 @@ module.exports = {
     'tablist',
     'timer',
     'toolbar',
+    'list', // RNW-only
+    'listitem', // RNW-only
   ],
   AccessibilityStates: [
     'selected',

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -465,6 +465,20 @@ export type ViewProps = $ReadOnly<{|
   accessibilityStates?: ?AccessibilityStates,
 
   /**
+   * Indicates to accessibility services that the UI Component is within a set and has the given numbered position.
+   * 
+   * See https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
+   */
+  accessibilityPosInSet?: ?number,
+
+  /**
+   * Indicates to accessibility services that the UI Component is within a set with the given size.
+   * 
+   * See https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
+   */
+  accessibilitySetSize?: ?number,
+
+  /**
    * Used to locate this view in end-to-end tests.
    *
    * > This disables the 'layout-only view removal' optimization for this view!

--- a/Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js
@@ -65,6 +65,8 @@ module.exports = {
     'tablist',
     'timer',
     'toolbar',
+    'list', // RNW-only
+    'listitem', // RNW-only
   ],
   // This must be kept in sync with the AccessibilityStatesMask in RCTViewManager.m
   DeprecatedAccessibilityStates: [

--- a/Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedViewPropTypes.js
@@ -92,6 +92,21 @@ module.exports = {
   accessibilityStates: PropTypes.arrayOf(
     PropTypes.oneOf(DeprecatedAccessibilityStates),
   ),
+
+  /**
+   * Indicates to accessibility services that the UI Component is within a set and has the given numbered position.
+   * 
+   * See https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
+   */
+  accessibilityPosInSet: PropTypes.number,
+
+  /**
+   * Indicates to accessibility services that the UI Component is within a set with the given size.
+   * 
+   * See https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
+   */
+  accessibilitySetSize: PropTypes.number,
+
   /**
    * Indicates to accessibility services whether the user should be notified
    * when this view changes. Works for Android API >= 19 only.


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

Adding RNW accessibility extensions for lists, as per https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md

* Adding the `list` and `listitem` accessibilityRoles values
* Adding the `accessibilityPosInSet` and `accessibilitySetSize` ViewProps

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/106)