### PR TITLE
Enable ARM64.

### DIFF
--- a/Folly/folly/portability/Builtins.h
+++ b/Folly/folly/portability/Builtins.h
@@ -50,7 +50,7 @@ FOLLY_ALWAYS_INLINE int __builtin_clzl(unsigned long x) {
   return __builtin_clz((unsigned int)x);
 }
 
-#if defined(_M_IX86) || defined(_M_ARM)
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
 FOLLY_ALWAYS_INLINE int __builtin_clzll(unsigned long long x) {
   if (x == 0)
     return 64;
@@ -74,7 +74,7 @@ FOLLY_ALWAYS_INLINE int __builtin_ctzl(unsigned long x) {
   return __builtin_ctz((unsigned int)x);
 }
 
-#if defined(_M_IX86) || defined(_M_ARM)
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
 FOLLY_ALWAYS_INLINE int __builtin_ctzll(unsigned long long x) {
   unsigned long index;
   unsigned int msb = (unsigned int)(x >> 32);
@@ -100,7 +100,7 @@ FOLLY_ALWAYS_INLINE int __builtin_ffsl(long x) {
   return __builtin_ffs(int(x));
 }
 
-#if defined(_M_IX86) || defined(_M_ARM)
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
 FOLLY_ALWAYS_INLINE int __builtin_ffsll(long long x) {
   int ctzll = __builtin_ctzll((unsigned long long)x);
   return ctzll != 64 ? ctzll + 1 : 0;

--- a/Folly/folly/portability/Builtins.h
+++ b/Folly/folly/portability/Builtins.h
@@ -50,7 +50,7 @@ FOLLY_ALWAYS_INLINE int __builtin_clzl(unsigned long x) {
   return __builtin_clz((unsigned int)x);
 }
 
-#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64) // Non-amd64 platforms
 FOLLY_ALWAYS_INLINE int __builtin_clzll(unsigned long long x) {
   if (x == 0)
     return 64;
@@ -74,7 +74,7 @@ FOLLY_ALWAYS_INLINE int __builtin_ctzl(unsigned long x) {
   return __builtin_ctz((unsigned int)x);
 }
 
-#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64) // Non-amd64 platforms
 FOLLY_ALWAYS_INLINE int __builtin_ctzll(unsigned long long x) {
   unsigned long index;
   unsigned int msb = (unsigned int)(x >> 32);
@@ -100,7 +100,7 @@ FOLLY_ALWAYS_INLINE int __builtin_ffsl(long x) {
   return __builtin_ffs(int(x));
 }
 
-#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64) // Non-amd64 platforms
 FOLLY_ALWAYS_INLINE int __builtin_ffsll(long long x) {
   int ctzll = __builtin_ctzll((unsigned long long)x);
   return ctzll != 64 ? ctzll + 1 : 0;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

Adds macros to enable ARM64 compilation.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/113)