### PR TITLE
A hacky fix to work around MSVC bug.

### DIFF
--- a/ReactCommon/jsi/jsi/jsi.h
+++ b/ReactCommon/jsi/jsi/jsi.h
@@ -347,7 +347,7 @@ class PropNameID : public Pointer {
   using Pointer::Pointer;
 
   PropNameID(Runtime& runtime, const PropNameID& other)
-      : PropNameID(runtime.clonePropNameID(other.ptr_)) {}
+      : Pointer(runtime.clonePropNameID(other.ptr_)) {}
 
   PropNameID(PropNameID&& other) = default;
   PropNameID& operator=(PropNameID&& other) = default;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

A minor fix in jsi.h to work around an MSVC bug on inheriting constructors . Without this change any file include jsi.h won't compile with MSVC compiler.

From: Yuriy Solodkyy yuriysol@microsoft.com
Sent: Monday, December 3, 2018 3:47:56 PM
To: Andrew Marino; Anandraj Govindan
Cc: Visual C++ Special Interest Group
Subject: RE: Protected base constructor and using
Hi Anandraj,
The fix to this issue should already be available via VS 2019 Preview 2 (possibly even Preview 1, I don’t have it handy to validate, but based on some other commits around that time it should have targeted that train). Let us know if you have any other issues with your port.
Thank you for reporting it to us!
Yuriy
From: Andrew Marino Andrew.Marino@microsoft.com
Sent: Monday, December 3, 2018 3:16 PM
To: Anandraj Govindan anandrag@microsoft.com; Visual C++ Special Interest Group vcsig@microsoft.com; Yuriy Solodkyy yuriysol@microsoft.com
Subject: RE: Protected base constructor and using
Looks like this was a bug under /std:c++17 with the inheriting constructors rewording that @yuriy Solodkyy fixed a few months ago:
commit 72851533a6eba4e83b2079a99c12de66e2e6e68e
Author: Yuriy Solodkyy yuriysol@microsoft.com
Date: Wed Aug 22 01:17:25 2018 +0000
Merged PR 137935: Fix for VSO615866, VSO626813 and VSO666485
This will probably be included in VS 2019 RTW, Yuriy can you confirm?
From: Anandraj Govindan anandrag@microsoft.com
Sent: Monday, December 3, 2018 2:49 PM
To: Visual C++ Special Interest Group vcsig@microsoft.com
Subject: Protected base constructor and using
Hello,
I’m trying to port some open source code into our codebase, and found a piece of code which builds with CLANG (on Android) but not with MSVC. The following is a gist of the code,
class Base {
protected:
explicit Base(int tag) {}
};
class Derived : public Base {
public:
using Base::Base;
Derived() : Derived(1) {}
};
int main() { Derived d; }
[CATEGORY] [TYPE] - Message

#### Focus areas to test

It affects only c++ code compilation.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/124)