### PR TITLE
Fixing folly related build failures

### DIFF
--- a/Folly/folly/Traits.h
+++ b/Folly/folly/Traits.h
@@ -573,6 +573,15 @@ struct StrictDisjunction
 
 FOLLY_NAMESPACE_STD_BEGIN
 
+#ifdef __ANDROID__
+#include <string>
+#include <vector>
+#include <set>
+#include <deque>
+#include <map>
+#include <utility>
+#else
+// These references are not required in Android; it is causing conflicts
 template <class T, class U>
 struct pair;
 #ifndef _GLIBCXX_USE_FB
@@ -594,6 +603,7 @@ template <class K, class V, class C, class A>
 class map;
 template <class T>
 class shared_ptr;
+#endif // __ANDROID__
 
 FOLLY_NAMESPACE_STD_END
 

--- a/Folly/folly/Traits.h
+++ b/Folly/folly/Traits.h
@@ -571,7 +571,6 @@ struct StrictDisjunction
  * although that is not guaranteed by the standard.
  */
 
-FOLLY_NAMESPACE_STD_BEGIN
 
 #ifdef __ANDROID__
 #include <string>
@@ -581,6 +580,8 @@ FOLLY_NAMESPACE_STD_BEGIN
 #include <map>
 #include <utility>
 #else
+
+FOLLY_NAMESPACE_STD_BEGIN
 // These references are not required in Android; it is causing conflicts
 template <class T, class U>
 struct pair;
@@ -603,9 +604,9 @@ template <class K, class V, class C, class A>
 class map;
 template <class T>
 class shared_ptr;
-#endif // __ANDROID__
 
 FOLLY_NAMESPACE_STD_END
+#endif // __ANDROID__
 
 namespace folly {
 


### PR DESCRIPTION
# :warning: Make sure you are targeting microsoft/react-native for your PR :warning:
(then delete these lines)

<!--
We are working on reducing the diff between Facebook's public version of react-native, and our microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

This change is same as PR https://github.com/microsoft/react-native/pull/123
Will abandon that PR after merging this.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/125)