### PR TITLE
Stop defining UIView and UIScrollView on macOS for Xcode 11 compatibility

### DIFF
--- a/Libraries/ART/ARTNode.h
+++ b/Libraries/ART/ARTNode.h
@@ -13,7 +13,7 @@
  * thread.
  */
 
-@interface ARTNode : UIView
+@interface ARTNode : RCTUIView
 
 @property (nonatomic, assign) CGFloat opacity;
 

--- a/Libraries/ART/ARTNode.h
+++ b/Libraries/ART/ARTNode.h
@@ -13,7 +13,7 @@
  * thread.
  */
 
-@interface ARTNode : RCTUIView
+@interface ARTNode : RCTUIView // TODO(macOS ISS#3536887)
 
 @property (nonatomic, assign) CGFloat opacity;
 

--- a/Libraries/ART/ARTNode.m
+++ b/Libraries/ART/ARTNode.m
@@ -11,14 +11,14 @@
 
 @implementation ARTNode
 
-- (void)insertReactSubview:(RCTUIView *)subview atIndex:(NSInteger)atIndex
+- (void)insertReactSubview:(RCTUIView *)subview atIndex:(NSInteger)atIndex // TODO(macOS ISS#3536887)
 {
   [super insertReactSubview:subview atIndex:atIndex];
   [self insertSubview:subview atIndex:atIndex];
   [self invalidate];
 }
 
-- (void)removeReactSubview:(RCTUIView *)subview
+- (void)removeReactSubview:(RCTUIView *)subview // TODO(macOS ISS#3536887)
 {
   [super removeReactSubview:subview];
   [self invalidate];

--- a/Libraries/ART/ARTNode.m
+++ b/Libraries/ART/ARTNode.m
@@ -11,14 +11,14 @@
 
 @implementation ARTNode
 
-- (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
+- (void)insertReactSubview:(RCTUIView *)subview atIndex:(NSInteger)atIndex
 {
   [super insertReactSubview:subview atIndex:atIndex];
   [self insertSubview:subview atIndex:atIndex];
   [self invalidate];
 }
 
-- (void)removeReactSubview:(UIView *)subview
+- (void)removeReactSubview:(RCTUIView *)subview
 {
   [super removeReactSubview:subview];
   [self invalidate];

--- a/Libraries/ART/ARTSurfaceView.h
+++ b/Libraries/ART/ARTSurfaceView.h
@@ -9,6 +9,6 @@
 
 #import "ARTContainer.h"
 
-@interface ARTSurfaceView : UIView <ARTContainer>
+@interface ARTSurfaceView : RCTUIView <ARTContainer>
 
 @end

--- a/Libraries/ART/ARTSurfaceView.h
+++ b/Libraries/ART/ARTSurfaceView.h
@@ -9,6 +9,6 @@
 
 #import "ARTContainer.h"
 
-@interface ARTSurfaceView : RCTUIView <ARTContainer>
+@interface ARTSurfaceView : RCTUIView <ARTContainer> // TODO(macOS ISS#3536887)
 
 @end

--- a/Libraries/ART/ARTSurfaceView.m
+++ b/Libraries/ART/ARTSurfaceView.m
@@ -22,14 +22,14 @@
   return self;
 }
 
-- (void)insertReactSubview:(RCTUIView *)subview atIndex:(NSInteger)atIndex
+- (void)insertReactSubview:(RCTUIView *)subview atIndex:(NSInteger)atIndex // TODO(macOS ISS#3536887)
 {
   [super insertReactSubview:subview atIndex:atIndex];
   [self insertSubview:subview atIndex:atIndex];
   [self invalidate];
 }
 
-- (void)removeReactSubview:(RCTUIView *)subview
+- (void)removeReactSubview:(RCTUIView *)subview // TODO(macOS ISS#3536887)
 {
   [super removeReactSubview:subview];
   [self invalidate];

--- a/Libraries/ART/ARTSurfaceView.m
+++ b/Libraries/ART/ARTSurfaceView.m
@@ -22,14 +22,14 @@
   return self;
 }
 
-- (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
+- (void)insertReactSubview:(RCTUIView *)subview atIndex:(NSInteger)atIndex
 {
   [super insertReactSubview:subview atIndex:atIndex];
   [self insertSubview:subview atIndex:atIndex];
   [self invalidate];
 }
 
-- (void)removeReactSubview:(UIView *)subview
+- (void)removeReactSubview:(RCTUIView *)subview
 {
   [super removeReactSubview:subview];
   [self invalidate];

--- a/Libraries/ART/ViewManagers/ARTNodeManager.m
+++ b/Libraries/ART/ViewManagers/ARTNodeManager.m
@@ -18,7 +18,7 @@ RCT_EXPORT_MODULE()
   return [ARTNode new];
 }
 
-- (UIView *)view
+- (RCTUIView *)view
 {
   return [self node];
 }

--- a/Libraries/ART/ViewManagers/ARTNodeManager.m
+++ b/Libraries/ART/ViewManagers/ARTNodeManager.m
@@ -18,7 +18,7 @@ RCT_EXPORT_MODULE()
   return [ARTNode new];
 }
 
-- (RCTUIView *)view
+- (RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   return [self node];
 }

--- a/Libraries/ART/ViewManagers/ARTSurfaceViewManager.m
+++ b/Libraries/ART/ViewManagers/ARTSurfaceViewManager.m
@@ -13,7 +13,7 @@
 
 RCT_EXPORT_MODULE()
 
-- (RCTUIView *)view
+- (RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   return [ARTSurfaceView new];
 }

--- a/Libraries/ART/ViewManagers/ARTSurfaceViewManager.m
+++ b/Libraries/ART/ViewManagers/ARTSurfaceViewManager.m
@@ -13,7 +13,7 @@
 
 RCT_EXPORT_MODULE()
 
-- (UIView *)view
+- (RCTUIView *)view
 {
   return [ARTSurfaceView new];
 }

--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
@@ -207,13 +207,13 @@ RCT_EXPORT_METHOD(removeAnimatedEventFromView:(nonnull NSNumber *)viewTag
   _preOperations = [NSMutableArray new];
   _operations = [NSMutableArray new];
 
-  [uiManager prependUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+  [uiManager prependUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
     for (AnimatedOperation operation in preOperations) {
       operation(self->_nodesManager);
     }
   }];
 
-  [uiManager addUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+  [uiManager addUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
     for (AnimatedOperation operation in operations) {
       operation(self->_nodesManager);
     }

--- a/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedModule.m
@@ -207,13 +207,13 @@ RCT_EXPORT_METHOD(removeAnimatedEventFromView:(nonnull NSNumber *)viewTag
   _preOperations = [NSMutableArray new];
   _operations = [NSMutableArray new];
 
-  [uiManager prependUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+  [uiManager prependUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
     for (AnimatedOperation operation in preOperations) {
       operation(self->_nodesManager);
     }
   }];
 
-  [uiManager addUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+  [uiManager addUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
     for (AnimatedOperation operation in operations) {
       operation(self->_nodesManager);
     }

--- a/Libraries/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/Libraries/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -59,7 +59,7 @@ extern NSString *const FBReferenceImageFilePathKey;
  @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
  @returns YES if the comparison (or saving of the reference image) succeeded.
  */
-- (BOOL)compareSnapshotOfView:(RCTUIView *)view
+- (BOOL)compareSnapshotOfView:(RCTUIView *)view // TODO(macOS ISS#3536887)
                      selector:(SEL)selector
                    identifier:(NSString *)identifier
                         error:(NSError **)errorPtr;

--- a/Libraries/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/Libraries/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -59,7 +59,7 @@ extern NSString *const FBReferenceImageFilePathKey;
  @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
  @returns YES if the comparison (or saving of the reference image) succeeded.
  */
-- (BOOL)compareSnapshotOfView:(UIView *)view
+- (BOOL)compareSnapshotOfView:(RCTUIView *)view
                      selector:(SEL)selector
                    identifier:(NSString *)identifier
                         error:(NSError **)errorPtr;

--- a/Libraries/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/Libraries/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -296,7 +296,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
 
 #pragma mark - Private API
 
-- (BOOL)_performPixelComparisonWithView:(UIView *)view
+- (BOOL)_performPixelComparisonWithView:(RCTUIView *)view
                                selector:(SEL)selector
                              identifier:(NSString *)identifier
                                   error:(NSError **)errorPtr
@@ -317,7 +317,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   return NO;
 }
 
-- (BOOL)_recordSnapshotOfView:(UIView *)view
+- (BOOL)_recordSnapshotOfView:(RCTUIView *)view
                      selector:(SEL)selector
                    identifier:(NSString *)identifier
                         error:(NSError **)errorPtr
@@ -326,7 +326,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   return [self saveReferenceImage:snapshot selector:selector identifier:identifier error:errorPtr];
 }
 
-- (UIImage *)_snapshotView:(UIView *)view
+- (UIImage *)_snapshotView:(RCTUIView *)view
 {
 #if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
   [view layoutIfNeeded];

--- a/Libraries/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/Libraries/RCTTest/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -296,7 +296,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
 
 #pragma mark - Private API
 
-- (BOOL)_performPixelComparisonWithView:(RCTUIView *)view
+- (BOOL)_performPixelComparisonWithView:(RCTUIView *)view // TODO(macOS ISS#3536887)
                                selector:(SEL)selector
                              identifier:(NSString *)identifier
                                   error:(NSError **)errorPtr
@@ -317,7 +317,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   return NO;
 }
 
-- (BOOL)_recordSnapshotOfView:(RCTUIView *)view
+- (BOOL)_recordSnapshotOfView:(RCTUIView *)view // TODO(macOS ISS#3536887)
                      selector:(SEL)selector
                    identifier:(NSString *)identifier
                         error:(NSError **)errorPtr
@@ -326,7 +326,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   return [self saveReferenceImage:snapshot selector:selector identifier:identifier error:errorPtr];
 }
 
-- (UIImage *)_snapshotView:(RCTUIView *)view
+- (UIImage *)_snapshotView:(RCTUIView *)view // TODO(macOS ISS#3536887)
 {
 #if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
   [view layoutIfNeeded];

--- a/Libraries/RCTTest/RCTSnapshotManager.m
+++ b/Libraries/RCTTest/RCTSnapshotManager.m
@@ -7,7 +7,7 @@
 
 #import "RCTSnapshotManager.h"
 
-@interface RCTSnapshotView : UIView
+@interface RCTSnapshotView : RCTUIView
 
 @property (nonatomic, copy) RCTDirectEventBlock onSnapshotReady;
 @property (nonatomic, copy) NSString *testIdentifier;
@@ -35,7 +35,7 @@
 
 RCT_EXPORT_MODULE()
 
-- (UIView *)view
+- (RCTUIView *)view
 {
   return [RCTSnapshotView new];
 }

--- a/Libraries/RCTTest/RCTSnapshotManager.m
+++ b/Libraries/RCTTest/RCTSnapshotManager.m
@@ -7,7 +7,7 @@
 
 #import "RCTSnapshotManager.h"
 
-@interface RCTSnapshotView : RCTUIView
+@interface RCTSnapshotView : RCTUIView // TODO(macOS ISS#3536887)
 
 @property (nonatomic, copy) RCTDirectEventBlock onSnapshotReady;
 @property (nonatomic, copy) NSString *testIdentifier;
@@ -35,7 +35,7 @@
 
 RCT_EXPORT_MODULE()
 
-- (RCTUIView *)view
+- (RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   return [RCTSnapshotView new];
 }

--- a/Libraries/RCTTest/RCTTestModule.h
+++ b/Libraries/RCTTest/RCTTestModule.h
@@ -28,7 +28,7 @@ typedef NS_ENUM(NSInteger, RCTTestStatus) {
 /**
  * This is the view to be snapshotted.
  */
-@property (nonatomic, strong) RCTUIView *view;
+@property (nonatomic, strong) RCTUIView *view; // TODO(macOS ISS#3536887)
 
 /**
  * This is used to give meaningful names to snapshot image files.

--- a/Libraries/RCTTest/RCTTestModule.h
+++ b/Libraries/RCTTest/RCTTestModule.h
@@ -28,7 +28,7 @@ typedef NS_ENUM(NSInteger, RCTTestStatus) {
 /**
  * This is the view to be snapshotted.
  */
-@property (nonatomic, strong) UIView *view;
+@property (nonatomic, strong) RCTUIView *view;
 
 /**
  * This is used to give meaningful names to snapshot image files.

--- a/Libraries/RCTTest/RCTTestModule.m
+++ b/Libraries/RCTTest/RCTTestModule.m
@@ -31,7 +31,7 @@ RCT_EXPORT_METHOD(verifySnapshot:(RCTResponseSenderBlock)callback)
 {
   RCTAssert(_controller != nil, @"No snapshot controller configured.");
 
-  [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+  [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
     NSString *testName = NSStringFromSelector(self->_testSelector);
     if (!self->_snapshotCounter) {
       self->_snapshotCounter = [NSMutableDictionary new];
@@ -81,7 +81,7 @@ RCT_EXPORT_METHOD(markTestCompleted)
 
 RCT_EXPORT_METHOD(markTestPassed:(BOOL)success)
 {
-  [_bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, __unused NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+  [_bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, __unused NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
     self->_status = success ? RCTTestStatusPassed : RCTTestStatusFailed;
   }];
 }

--- a/Libraries/RCTTest/RCTTestModule.m
+++ b/Libraries/RCTTest/RCTTestModule.m
@@ -31,7 +31,7 @@ RCT_EXPORT_METHOD(verifySnapshot:(RCTResponseSenderBlock)callback)
 {
   RCTAssert(_controller != nil, @"No snapshot controller configured.");
 
-  [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+  [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
     NSString *testName = NSStringFromSelector(self->_testSelector);
     if (!self->_snapshotCounter) {
       self->_snapshotCounter = [NSMutableDictionary new];
@@ -81,7 +81,7 @@ RCT_EXPORT_METHOD(markTestCompleted)
 
 RCT_EXPORT_METHOD(markTestPassed:(BOOL)success)
 {
-  [_bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, __unused NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+  [_bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, __unused NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
     self->_status = success ? RCTTestStatusPassed : RCTTestStatusFailed;
   }];
 }

--- a/Libraries/Text/BaseText/RCTBaseTextViewManager.m
+++ b/Libraries/Text/BaseText/RCTBaseTextViewManager.m
@@ -11,7 +11,7 @@
 
 RCT_EXPORT_MODULE(RCTBaseText)
 
-- (UIView *)view
+- (RCTUIView *)view
 {
   RCTAssert(NO, @"The `-[RCTBaseTextViewManager view]` property must be overridden in subclass.");
   return nil;

--- a/Libraries/Text/BaseText/RCTBaseTextViewManager.m
+++ b/Libraries/Text/BaseText/RCTBaseTextViewManager.m
@@ -11,7 +11,7 @@
 
 RCT_EXPORT_MODULE(RCTBaseText)
 
-- (RCTUIView *)view
+- (RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   RCTAssert(NO, @"The `-[RCTBaseTextViewManager view]` property must be overridden in subclass.");
   return nil;

--- a/Libraries/Text/RawText/RCTRawTextViewManager.m
+++ b/Libraries/Text/RawText/RCTRawTextViewManager.m
@@ -13,9 +13,9 @@
 
 RCT_EXPORT_MODULE(RCTRawText)
 
-- (UIView *)view
+- (RCTUIView *)view
 {
-  return [UIView new];
+  return [RCTUIView new];
 }
 
 - (RCTShadowView *)shadowView

--- a/Libraries/Text/RawText/RCTRawTextViewManager.m
+++ b/Libraries/Text/RawText/RCTRawTextViewManager.m
@@ -13,9 +13,9 @@
 
 RCT_EXPORT_MODULE(RCTRawText)
 
-- (RCTUIView *)view
+- (RCTUIView *)view // TODO(macOS ISS#3536887)
 {
-  return [RCTUIView new];
+  return [RCTUIView new]; // TODO(macOS ISS#3536887)
 }
 
 - (RCTShadowView *)shadowView

--- a/Libraries/Text/Text/RCTTextShadowView.m
+++ b/Libraries/Text/Text/RCTTextShadowView.m
@@ -85,16 +85,16 @@
    }
   ];
 
-  [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+  [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
     RCTTextView *textView = (RCTTextView *)viewRegistry[tag];
     if (!textView) {
       return;
     }
 
-    NSMutableArray<RCTUIView *> *descendantViews =
+    NSMutableArray<RCTUIView *> *descendantViews = // TODO(macOS ISS#3536887)
       [NSMutableArray arrayWithCapacity:descendantViewTags.count];
     [descendantViewTags enumerateObjectsUsingBlock:^(NSNumber *_Nonnull descendantViewTag, NSUInteger index, BOOL *_Nonnull stop) {
-      RCTUIView *descendantView = viewRegistry[descendantViewTag];
+      RCTUIView *descendantView = viewRegistry[descendantViewTag]; // TODO(macOS ISS#3536887)
       if (!descendantView) {
         return;
       }

--- a/Libraries/Text/Text/RCTTextShadowView.m
+++ b/Libraries/Text/Text/RCTTextShadowView.m
@@ -85,16 +85,16 @@
    }
   ];
 
-  [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+  [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
     RCTTextView *textView = (RCTTextView *)viewRegistry[tag];
     if (!textView) {
       return;
     }
 
-    NSMutableArray<UIView *> *descendantViews =
+    NSMutableArray<RCTUIView *> *descendantViews =
       [NSMutableArray arrayWithCapacity:descendantViewTags.count];
     [descendantViewTags enumerateObjectsUsingBlock:^(NSNumber *_Nonnull descendantViewTag, NSUInteger index, BOOL *_Nonnull stop) {
-      UIView *descendantView = viewRegistry[descendantViewTag];
+      RCTUIView *descendantView = viewRegistry[descendantViewTag];
       if (!descendantView) {
         return;
       }

--- a/Libraries/Text/Text/RCTTextView.h
+++ b/Libraries/Text/Text/RCTTextView.h
@@ -11,13 +11,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RCTTextView : RCTUIView
+@interface RCTTextView : RCTUIView // TODO(macOS ISS#3536887)
 
 @property (nonatomic, assign) BOOL selectable;
 
 - (void)setTextStorage:(NSTextStorage *)textStorage
           contentFrame:(CGRect)contentFrame
-       descendantViews:(NSArray<RCTUIView *> *)descendantViews;
+       descendantViews:(NSArray<RCTUIView *> *)descendantViews; // TODO(macOS ISS#3536887)
 
 @end
 

--- a/Libraries/Text/Text/RCTTextView.h
+++ b/Libraries/Text/Text/RCTTextView.h
@@ -11,13 +11,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RCTTextView : UIView
+@interface RCTTextView : RCTUIView
 
 @property (nonatomic, assign) BOOL selectable;
 
 - (void)setTextStorage:(NSTextStorage *)textStorage
           contentFrame:(CGRect)contentFrame
-       descendantViews:(NSArray<UIView *> *)descendantViews;
+       descendantViews:(NSArray<RCTUIView *> *)descendantViews;
 
 @end
 

--- a/Libraries/Text/Text/RCTTextView.m
+++ b/Libraries/Text/Text/RCTTextView.m
@@ -26,7 +26,7 @@
   UILongPressGestureRecognizer *_longPressGestureRecognizer;
 #endif // TODO(macOS ISS#2323203)
 
-  NSArray<RCTUIView *> *_Nullable _descendantViews;
+  NSArray<RCTUIView *> *_Nullable _descendantViews; // TODO(macOS ISS#3536887)
   NSTextStorage *_Nullable _textStorage;
   CGRect _contentFrame;
 }
@@ -41,7 +41,7 @@
     self.accessibilityRole = NSAccessibilityStaticTextRole;
 #endif // ]TODO(macOS ISS#2323203)
     self.opaque = NO;
-    RCTUIViewSetContentModeRedraw(self); // TODO(macOS ISS#2323203)
+    RCTUIViewSetContentModeRedraw(self); // TODO(macOS ISS#2323203) and TODO(macOS ISS#3536887)
   }
   return self;
 }
@@ -113,7 +113,7 @@
 
 - (void)setTextStorage:(NSTextStorage *)textStorage
           contentFrame:(CGRect)contentFrame
-       descendantViews:(NSArray<RCTUIView *> *)descendantViews
+       descendantViews:(NSArray<RCTUIView *> *)descendantViews // TODO(macOS ISS#3536887)
 {
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
   // On macOS when a large number of flex layouts are being performed, such
@@ -133,13 +133,13 @@
   _contentFrame = contentFrame;
 
   // FIXME: Optimize this.
-  for (RCTUIView *view in _descendantViews) {
+  for (RCTUIView *view in _descendantViews) { // TODO(macOS ISS#3536887)
     [view removeFromSuperview];
   }
 
   _descendantViews = descendantViews;
 
-  for (RCTUIView *view in descendantViews) {
+  for (RCTUIView *view in descendantViews) { // TODO(macOS ISS#3536887)
     [self addSubview:view];
   }
 

--- a/Libraries/Text/Text/RCTTextView.m
+++ b/Libraries/Text/Text/RCTTextView.m
@@ -26,7 +26,7 @@
   UILongPressGestureRecognizer *_longPressGestureRecognizer;
 #endif // TODO(macOS ISS#2323203)
 
-  NSArray<UIView *> *_Nullable _descendantViews;
+  NSArray<RCTUIView *> *_Nullable _descendantViews;
   NSTextStorage *_Nullable _textStorage;
   CGRect _contentFrame;
 }
@@ -113,7 +113,7 @@
 
 - (void)setTextStorage:(NSTextStorage *)textStorage
           contentFrame:(CGRect)contentFrame
-       descendantViews:(NSArray<UIView *> *)descendantViews
+       descendantViews:(NSArray<RCTUIView *> *)descendantViews
 {
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
   // On macOS when a large number of flex layouts are being performed, such
@@ -133,13 +133,13 @@
   _contentFrame = contentFrame;
 
   // FIXME: Optimize this.
-  for (UIView *view in _descendantViews) {
+  for (RCTUIView *view in _descendantViews) {
     [view removeFromSuperview];
   }
 
   _descendantViews = descendantViews;
 
-  for (UIView *view in descendantViews) {
+  for (RCTUIView *view in descendantViews) {
     [self addSubview:view];
   }
 

--- a/Libraries/Text/Text/RCTTextView.m
+++ b/Libraries/Text/Text/RCTTextView.m
@@ -41,7 +41,7 @@
     self.accessibilityRole = NSAccessibilityStaticTextRole;
 #endif // ]TODO(macOS ISS#2323203)
     self.opaque = NO;
-    UIViewSetContentModeRedraw(self); // TODO(macOS ISS#2323203)
+    RCTUIViewSetContentModeRedraw(self); // TODO(macOS ISS#2323203)
   }
   return self;
 }

--- a/Libraries/Text/Text/RCTTextViewManager.m
+++ b/Libraries/Text/Text/RCTTextViewManager.m
@@ -57,7 +57,7 @@ RCT_EXPORT_VIEW_PROPERTY(selectable, BOOL)
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (RCTUIView *)view
+- (RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   return [RCTTextView new];
 }

--- a/Libraries/Text/Text/RCTTextViewManager.m
+++ b/Libraries/Text/Text/RCTTextViewManager.m
@@ -57,7 +57,7 @@ RCT_EXPORT_VIEW_PROPERTY(selectable, BOOL)
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (UIView *)view
+- (RCTUIView *)view
 {
   return [RCTTextView new];
 }

--- a/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
@@ -14,7 +14,7 @@
 @implementation RCTMultilineTextInputView
 {
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
-  UIScrollView *_scrollView;
+  RCTUIScrollView *_scrollView;
 #endif // ]TODO(macOS ISS#2323203)
   RCTUITextView *_backedTextInputView;
 }
@@ -37,7 +37,7 @@
 #endif
     _backedTextInputView.scrollEnabled = YES;
 #else // [TODO(macOS ISS#2323203)
-    _scrollView = [[UIScrollView alloc] initWithFrame:self.bounds];
+    _scrollView = [[RCTUIScrollView alloc] initWithFrame:self.bounds];
     _scrollView.backgroundColor = [UIColor clearColor];
     _scrollView.drawsBackground = NO;
     _scrollView.borderType = NSNoBorder;
@@ -102,7 +102,7 @@
 
 #pragma mark - UIScrollViewDelegate
 
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+- (void)scrollViewDidScroll:(RCTUIScrollView *)scrollView
 {
   RCTDirectEventBlock onScroll = self.onScroll;
 

--- a/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m
@@ -14,7 +14,7 @@
 @implementation RCTMultilineTextInputView
 {
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
-  RCTUIScrollView *_scrollView;
+  RCTUIScrollView *_scrollView; // TODO(macOS ISS#3536887)
 #endif // ]TODO(macOS ISS#2323203)
   RCTUITextView *_backedTextInputView;
 }
@@ -37,7 +37,7 @@
 #endif
     _backedTextInputView.scrollEnabled = YES;
 #else // [TODO(macOS ISS#2323203)
-    _scrollView = [[RCTUIScrollView alloc] initWithFrame:self.bounds];
+    _scrollView = [[RCTUIScrollView alloc] initWithFrame:self.bounds]; // TODO(macOS ISS#3536887)
     _scrollView.backgroundColor = [UIColor clearColor];
     _scrollView.drawsBackground = NO;
     _scrollView.borderType = NSNoBorder;
@@ -102,7 +102,7 @@
 
 #pragma mark - UIScrollViewDelegate
 
-- (void)scrollViewDidScroll:(RCTUIScrollView *)scrollView
+- (void)scrollViewDidScroll:(RCTUIScrollView *)scrollView // TODO(macOS ISS#3536887)
 {
   RCTDirectEventBlock onScroll = self.onScroll;
 

--- a/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputViewManager.m
+++ b/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputViewManager.m
@@ -13,7 +13,7 @@
 
 RCT_EXPORT_MODULE()
 
-- (UIView *)view
+- (RCTUIView *)view
 {
   return [[RCTMultilineTextInputView alloc] initWithBridge:self.bridge];
 }

--- a/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputViewManager.m
+++ b/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputViewManager.m
@@ -13,7 +13,7 @@
 
 RCT_EXPORT_MODULE()
 
-- (RCTUIView *)view
+- (RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   return [[RCTMultilineTextInputView alloc] initWithBridge:self.bridge];
 }

--- a/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
@@ -163,7 +163,7 @@
 
   NSNumber *tag = self.reactTag;
 
-  [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+  [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
     RCTBaseTextInputView *baseTextInputView = (RCTBaseTextInputView *)viewRegistry[tag];
     if (!baseTextInputView) {
       return;

--- a/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputShadowView.m
@@ -163,7 +163,7 @@
 
   NSNumber *tag = self.reactTag;
 
-  [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+  [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
     RCTBaseTextInputView *baseTextInputView = (RCTBaseTextInputView *)viewRegistry[tag];
     if (!baseTextInputView) {
       return;

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.h
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCoder:(NSCoder *)decoder NS_UNAVAILABLE;
 - (instancetype)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
 
-@property (nonatomic, readonly) RCTUIView<RCTBackedTextInputViewProtocol> *backedTextInputView;
+@property (nonatomic, readonly) RCTUIView<RCTBackedTextInputViewProtocol> *backedTextInputView; // TODO(macOS ISS#3536887)
 
 /**
  Whether this text input ignores the `textAttributes` property. Defaults to `NO`. If set to `YES`, the value of `textAttributes` will be ignored in favor of standard text input behavior.

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.h
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCoder:(NSCoder *)decoder NS_UNAVAILABLE;
 - (instancetype)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
 
-@property (nonatomic, readonly) UIView<RCTBackedTextInputViewProtocol> *backedTextInputView;
+@property (nonatomic, readonly) RCTUIView<RCTBackedTextInputViewProtocol> *backedTextInputView;
 
 /**
  Whether this text input ignores the `textAttributes` property. Defaults to `NO`. If set to `YES`, the value of `textAttributes` will be ignored in favor of standard text input behavior.

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -44,7 +44,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)decoder)
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 
-- (UIView<RCTBackedTextInputViewProtocol> *)backedTextInputView
+- (RCTUIView<RCTBackedTextInputViewProtocol> *)backedTextInputView
 {
   RCTAssert(NO, @"-[RCTBaseTextInputView backedTextInputView] must be implemented in subclass.");
   return nil;
@@ -584,7 +584,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 
 #pragma mark - Accessibility
 
-- (UIView *)reactAccessibilityElement
+- (RCTUIView *)reactAccessibilityElement
 {
   return self.backedTextInputView;
 }

--- a/Libraries/Text/TextInput/RCTBaseTextInputView.m
+++ b/Libraries/Text/TextInput/RCTBaseTextInputView.m
@@ -44,7 +44,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)decoder)
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 
-- (RCTUIView<RCTBackedTextInputViewProtocol> *)backedTextInputView
+- (RCTUIView<RCTBackedTextInputViewProtocol> *)backedTextInputView // TODO(macOS ISS#3536887)
 {
   RCTAssert(NO, @"-[RCTBaseTextInputView backedTextInputView] must be implemented in subclass.");
   return nil;
@@ -584,7 +584,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
 
 #pragma mark - Accessibility
 
-- (RCTUIView *)reactAccessibilityElement
+- (RCTUIView *)reactAccessibilityElement // TODO(macOS ISS#3536887)
 {
   return self.backedTextInputView;
 }

--- a/Libraries/Text/TextInput/RCTInputAccessoryView.h
+++ b/Libraries/Text/TextInput/RCTInputAccessoryView.h
@@ -10,7 +10,7 @@
 @class RCTBridge;
 @class RCTInputAccessoryViewContent;
 
-@interface RCTInputAccessoryView : UIView
+@interface RCTInputAccessoryView : RCTUIView
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge;
 

--- a/Libraries/Text/TextInput/RCTInputAccessoryView.h
+++ b/Libraries/Text/TextInput/RCTInputAccessoryView.h
@@ -10,7 +10,7 @@
 @class RCTBridge;
 @class RCTInputAccessoryViewContent;
 
-@interface RCTInputAccessoryView : RCTUIView
+@interface RCTInputAccessoryView : RCTUIView // TODO(macOS ISS#3536887)
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge;
 

--- a/Libraries/Text/TextInput/RCTInputAccessoryViewContent.h
+++ b/Libraries/Text/TextInput/RCTInputAccessoryViewContent.h
@@ -7,6 +7,6 @@
 
 #import <React/RCTUIKit.h> // TODO(macOS ISS#2323203)
 
-@interface RCTInputAccessoryViewContent : UIView
+@interface RCTInputAccessoryViewContent : RCTUIView
 
 @end

--- a/Libraries/Text/TextInput/RCTInputAccessoryViewContent.h
+++ b/Libraries/Text/TextInput/RCTInputAccessoryViewContent.h
@@ -7,6 +7,6 @@
 
 #import <React/RCTUIKit.h> // TODO(macOS ISS#2323203)
 
-@interface RCTInputAccessoryViewContent : RCTUIView
+@interface RCTInputAccessoryViewContent : RCTUIView // TODO(macOS ISS#3536887)
 
 @end

--- a/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputViewManager.m
+++ b/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputViewManager.m
@@ -24,7 +24,7 @@ RCT_EXPORT_MODULE()
   return shadowView;
 }
 
-- (UIView *)view
+- (RCTUIView *)view
 {
   return [[RCTSinglelineTextInputView alloc] initWithBridge:self.bridge];
 }

--- a/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputViewManager.m
+++ b/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputViewManager.m
@@ -24,7 +24,7 @@ RCT_EXPORT_MODULE()
   return shadowView;
 }
 
-- (RCTUIView *)view
+- (RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   return [[RCTSinglelineTextInputView alloc] initWithBridge:self.bridge];
 }

--- a/Libraries/Text/VirtualText/RCTVirtualTextViewManager.m
+++ b/Libraries/Text/VirtualText/RCTVirtualTextViewManager.m
@@ -13,9 +13,9 @@
 
 RCT_EXPORT_MODULE(RCTVirtualText)
 
-- (UIView *)view
+- (RCTUIView *)view
 {
-  return [UIView new];
+  return [RCTUIView new];
 }
 
 - (RCTShadowView *)shadowView

--- a/Libraries/Text/VirtualText/RCTVirtualTextViewManager.m
+++ b/Libraries/Text/VirtualText/RCTVirtualTextViewManager.m
@@ -13,9 +13,9 @@
 
 RCT_EXPORT_MODULE(RCTVirtualText)
 
-- (RCTUIView *)view
+- (RCTUIView *)view // TODO(macOS ISS#3536887)
 {
-  return [RCTUIView new];
+  return [RCTUIView new]; // TODO(macOS ISS#3536887)
 }
 
 - (RCTShadowView *)shadowView

--- a/RNTester/RNTesterIntegrationTests/RCTUIManagerScenarioTests.m
+++ b/RNTester/RNTesterIntegrationTests/RCTUIManagerScenarioTests.m
@@ -22,7 +22,7 @@
         removeAtIndices:(NSArray *)removeAtIndices
                registry:(NSMutableDictionary<NSNumber *, id<RCTComponent>> *)registry;
 
-@property (nonatomic, readonly) NSMutableDictionary<NSNumber *, RCTUIView *> *viewRegistry;
+@property (nonatomic, readonly) NSMutableDictionary<NSNumber *, RCTUIView *> *viewRegistry; // TODO(macOS ISS#3536887)
 
 @end
 
@@ -42,7 +42,7 @@
 
   // Register 20 views to use in the tests
   for (NSInteger i = 1; i <= 20; i++) {
-    RCTUIView *registeredView = [RCTUIView new];
+    RCTUIView *registeredView = [RCTUIView new]; // TODO(macOS ISS#3536887)
     registeredView.reactTag = @(i);
     _uiManager.viewRegistry[@(i)] = registeredView;
   }
@@ -50,7 +50,7 @@
 
 - (void)testManagingChildrenToAddViews
 {
-  RCTUIView *containerView = _uiManager.viewRegistry[@20];
+  RCTUIView *containerView = _uiManager.viewRegistry[@20]; // TODO(macOS ISS#3536887)
   NSMutableArray *addedViews = [NSMutableArray array];
 
   NSArray *tagsToAdd = @[@1, @2, @3, @4, @5];
@@ -73,7 +73,7 @@
   XCTAssertTrue([[containerView reactSubviews] count] == 5,
                @"Expect to have 5 react subviews after calling manage children \
                with 5 tags to add, instead have %lu", (unsigned long)[[containerView reactSubviews] count]);
-  for (RCTUIView *view in addedViews) {
+  for (RCTUIView *view in addedViews) { // TODO(macOS ISS#3536887)
     XCTAssertTrue([view superview] == containerView,
                  @"Expected to have manage children successfully add children");
     [view removeFromSuperview];
@@ -82,7 +82,7 @@
 
 - (void)testManagingChildrenToRemoveViews
 {
-  RCTUIView *containerView = _uiManager.viewRegistry[@20];
+  RCTUIView *containerView = _uiManager.viewRegistry[@20]; // TODO(macOS ISS#3536887)
   NSMutableArray *removedViews = [NSMutableArray array];
 
   NSArray *removeAtIndices = @[@0, @4, @8, @12, @16];
@@ -91,7 +91,7 @@
     [removedViews addObject:_uiManager.viewRegistry[reactTag]];
   }
   for (NSInteger i = 2; i < 20; i++) {
-    RCTUIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)]; // TODO(macOS ISS#3536887)
     [containerView insertReactSubview:view atIndex:containerView.reactSubviews.count];
   }
 
@@ -110,14 +110,14 @@
                @"Expect to have 13 react subviews after calling manage children\
                with 5 tags to remove and 18 prior children, instead have %zd",
                containerView.reactSubviews.count);
-  for (RCTUIView *view in removedViews) {
+  for (RCTUIView *view in removedViews) { // TODO(macOS ISS#3536887)
     XCTAssertTrue([view superview] == nil,
                  @"Expected to have manage children successfully remove children");
     // After removing views are unregistered - we need to reregister
     _uiManager.viewRegistry[view.reactTag] = view;
   }
   for (NSInteger i = 2; i < 20; i++) {
-    RCTUIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)]; // TODO(macOS ISS#3536887)
     if (![removedViews containsObject:view]) {
       XCTAssertTrue([view superview] == containerView,
                    @"Should not have removed view with react tag %ld during delete but did", (long)i);
@@ -136,7 +136,7 @@
 // [11,5,1,2,7,8,12,10]
 - (void)testManagingChildrenToAddRemoveAndMove
 {
-  RCTUIView *containerView = _uiManager.viewRegistry[@20];
+  RCTUIView *containerView = _uiManager.viewRegistry[@20]; // TODO(macOS ISS#3536887)
 
   NSArray *removeAtIndices = @[@2, @3, @5, @8];
   NSArray *addAtIndices = @[@0, @6];
@@ -148,12 +148,12 @@
   NSMutableArray *viewsToRemove = [NSMutableArray array];
   for (NSUInteger i = 0; i < removeAtIndices.count; i++) {
     NSNumber *reactTagToRemove = @([removeAtIndices[i] integerValue] + 1);
-    RCTUIView *viewToRemove = _uiManager.viewRegistry[reactTagToRemove];
+    RCTUIView *viewToRemove = _uiManager.viewRegistry[reactTagToRemove]; // TODO(macOS ISS#3536887)
     [viewsToRemove addObject:viewToRemove];
   }
 
   for (NSInteger i = 1; i < 11; i++) {
-    RCTUIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)]; // TODO(macOS ISS#3536887)
     [containerView insertReactSubview:view atIndex:containerView.reactSubviews.count];
   }
 
@@ -178,10 +178,10 @@
 
   // Clean up after ourselves
   for (NSInteger i = 1; i < 13; i++) {
-    RCTUIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)]; // TODO(macOS ISS#3536887)
     [view removeFromSuperview];
   }
-  for (RCTUIView *view in viewsToRemove) {
+  for (RCTUIView *view in viewsToRemove) { // TODO(macOS ISS#3536887)
     _uiManager.viewRegistry[view.reactTag] = view;
   }
 }

--- a/RNTester/RNTesterIntegrationTests/RCTUIManagerScenarioTests.m
+++ b/RNTester/RNTesterIntegrationTests/RCTUIManagerScenarioTests.m
@@ -22,7 +22,7 @@
         removeAtIndices:(NSArray *)removeAtIndices
                registry:(NSMutableDictionary<NSNumber *, id<RCTComponent>> *)registry;
 
-@property (nonatomic, readonly) NSMutableDictionary<NSNumber *, UIView *> *viewRegistry;
+@property (nonatomic, readonly) NSMutableDictionary<NSNumber *, RCTUIView *> *viewRegistry;
 
 @end
 
@@ -42,7 +42,7 @@
 
   // Register 20 views to use in the tests
   for (NSInteger i = 1; i <= 20; i++) {
-    UIView *registeredView = [UIView new];
+    RCTUIView *registeredView = [RCTUIView new];
     registeredView.reactTag = @(i);
     _uiManager.viewRegistry[@(i)] = registeredView;
   }
@@ -50,7 +50,7 @@
 
 - (void)testManagingChildrenToAddViews
 {
-  UIView *containerView = _uiManager.viewRegistry[@20];
+  RCTUIView *containerView = _uiManager.viewRegistry[@20];
   NSMutableArray *addedViews = [NSMutableArray array];
 
   NSArray *tagsToAdd = @[@1, @2, @3, @4, @5];
@@ -73,7 +73,7 @@
   XCTAssertTrue([[containerView reactSubviews] count] == 5,
                @"Expect to have 5 react subviews after calling manage children \
                with 5 tags to add, instead have %lu", (unsigned long)[[containerView reactSubviews] count]);
-  for (UIView *view in addedViews) {
+  for (RCTUIView *view in addedViews) {
     XCTAssertTrue([view superview] == containerView,
                  @"Expected to have manage children successfully add children");
     [view removeFromSuperview];
@@ -82,7 +82,7 @@
 
 - (void)testManagingChildrenToRemoveViews
 {
-  UIView *containerView = _uiManager.viewRegistry[@20];
+  RCTUIView *containerView = _uiManager.viewRegistry[@20];
   NSMutableArray *removedViews = [NSMutableArray array];
 
   NSArray *removeAtIndices = @[@0, @4, @8, @12, @16];
@@ -91,7 +91,7 @@
     [removedViews addObject:_uiManager.viewRegistry[reactTag]];
   }
   for (NSInteger i = 2; i < 20; i++) {
-    UIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)];
     [containerView insertReactSubview:view atIndex:containerView.reactSubviews.count];
   }
 
@@ -110,14 +110,14 @@
                @"Expect to have 13 react subviews after calling manage children\
                with 5 tags to remove and 18 prior children, instead have %zd",
                containerView.reactSubviews.count);
-  for (UIView *view in removedViews) {
+  for (RCTUIView *view in removedViews) {
     XCTAssertTrue([view superview] == nil,
                  @"Expected to have manage children successfully remove children");
     // After removing views are unregistered - we need to reregister
     _uiManager.viewRegistry[view.reactTag] = view;
   }
   for (NSInteger i = 2; i < 20; i++) {
-    UIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)];
     if (![removedViews containsObject:view]) {
       XCTAssertTrue([view superview] == containerView,
                    @"Should not have removed view with react tag %ld during delete but did", (long)i);
@@ -136,7 +136,7 @@
 // [11,5,1,2,7,8,12,10]
 - (void)testManagingChildrenToAddRemoveAndMove
 {
-  UIView *containerView = _uiManager.viewRegistry[@20];
+  RCTUIView *containerView = _uiManager.viewRegistry[@20];
 
   NSArray *removeAtIndices = @[@2, @3, @5, @8];
   NSArray *addAtIndices = @[@0, @6];
@@ -148,12 +148,12 @@
   NSMutableArray *viewsToRemove = [NSMutableArray array];
   for (NSUInteger i = 0; i < removeAtIndices.count; i++) {
     NSNumber *reactTagToRemove = @([removeAtIndices[i] integerValue] + 1);
-    UIView *viewToRemove = _uiManager.viewRegistry[reactTagToRemove];
+    RCTUIView *viewToRemove = _uiManager.viewRegistry[reactTagToRemove];
     [viewsToRemove addObject:viewToRemove];
   }
 
   for (NSInteger i = 1; i < 11; i++) {
-    UIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)];
     [containerView insertReactSubview:view atIndex:containerView.reactSubviews.count];
   }
 
@@ -178,10 +178,10 @@
 
   // Clean up after ourselves
   for (NSInteger i = 1; i < 13; i++) {
-    UIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)];
     [view removeFromSuperview];
   }
-  for (UIView *view in viewsToRemove) {
+  for (RCTUIView *view in viewsToRemove) {
     _uiManager.viewRegistry[view.reactTag] = view;
   }
 }

--- a/RNTester/RNTesterUnitTests/RCTAllocationTests.m
+++ b/RNTester/RNTesterUnitTests/RCTAllocationTests.m
@@ -156,7 +156,7 @@ RCT_EXPORT_METHOD(test:(__unused NSString *)a
   RCTBridge *bridge = [[RCTBridge alloc] initWithBundleURL:_bundleURL
                                             moduleProvider:nil
                                              launchOptions:nil];
-  __weak RCTUIView *rootContentView;
+  __weak RCTUIView *rootContentView; // TODO(macOS ISS#3536887)
   @autoreleasepool {
     RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"" initialProperties:nil];
     RCT_RUN_RUNLOOP_WHILE(!(rootContentView = [rootView valueForKey:@"contentView"]))

--- a/RNTester/RNTesterUnitTests/RCTAllocationTests.m
+++ b/RNTester/RNTesterUnitTests/RCTAllocationTests.m
@@ -156,7 +156,7 @@ RCT_EXPORT_METHOD(test:(__unused NSString *)a
   RCTBridge *bridge = [[RCTBridge alloc] initWithBundleURL:_bundleURL
                                             moduleProvider:nil
                                              launchOptions:nil];
-  __weak UIView *rootContentView;
+  __weak RCTUIView *rootContentView;
   @autoreleasepool {
     RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"" initialProperties:nil];
     RCT_RUN_RUNLOOP_WHILE(!(rootContentView = [rootView valueForKey:@"contentView"]))

--- a/RNTester/RNTesterUnitTests/RCTComponentPropsTests.m
+++ b/RNTester/RNTesterUnitTests/RCTComponentPropsTests.m
@@ -30,7 +30,7 @@
 
 @end
 
-@interface RCTPropsTestView : UIView
+@interface RCTPropsTestView : RCTUIView
 
 @property (nonatomic, assign) NSInteger integerProp;
 @property (nonatomic, strong) id objectProp;
@@ -49,7 +49,7 @@
 
 RCT_EXPORT_MODULE()
 
-- (UIView *)view
+- (RCTUIView *)view
 {
   RCTPropsTestView *view = [RCTPropsTestView new];
   view.integerProp = 57;
@@ -111,7 +111,7 @@ RCT_CUSTOM_VIEW_PROPERTY(customProp, NSString, RCTPropsTestView)
 
   dispatch_async(uiManager.methodQueue, ^{
     [uiManager createView:@2 viewName:@"RCTPropsTestView" rootTag:self->_rootViewReactTag props:props];
-    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
       view = (RCTPropsTestView *)viewRegistry[@2];
       XCTAssertEqual(view.integerProp, 58);
       XCTAssertEqualObjects(view.objectProp, @10);
@@ -141,7 +141,7 @@ RCT_CUSTOM_VIEW_PROPERTY(customProp, NSString, RCTPropsTestView)
   dispatch_async(uiManager.methodQueue, ^{
     [uiManager createView:@2 viewName:@"RCTPropsTestView" rootTag:self->_rootViewReactTag props:props];
     [uiManager updateView:@2 viewName:@"RCTPropsTestView" props:resetProps];
-    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
       view = (RCTPropsTestView *)viewRegistry[@2];
       XCTAssertEqual(view.integerProp, 57);
       XCTAssertEqualObjects(view.objectProp, @9);
@@ -163,12 +163,12 @@ RCT_CUSTOM_VIEW_PROPERTY(customProp, NSString, RCTPropsTestView)
 
   dispatch_async(uiManager.methodQueue, ^{
     [uiManager createView:@2 viewName:@"RCTView" rootTag:self->_rootViewReactTag props:props];
-    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
       view = (RCTView *)viewRegistry[@2];
       XCTAssertEqualObjects(view.backgroundColor, [RCTConvert UIColor:@0xffffffff]);
     }];
     [uiManager updateView:@2 viewName:@"RCTView" props:resetProps];
-    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, __unused NSDictionary<NSNumber *,UIView *> *viewRegistry) {
+    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, __unused NSDictionary<NSNumber *,RCTUIView *> *viewRegistry) {
       view = (RCTView *)viewRegistry[@2];
       XCTAssertNil(view.backgroundColor);
     }];

--- a/RNTester/RNTesterUnitTests/RCTComponentPropsTests.m
+++ b/RNTester/RNTesterUnitTests/RCTComponentPropsTests.m
@@ -30,7 +30,7 @@
 
 @end
 
-@interface RCTPropsTestView : RCTUIView
+@interface RCTPropsTestView : RCTUIView // TODO(macOS ISS#3536887)
 
 @property (nonatomic, assign) NSInteger integerProp;
 @property (nonatomic, strong) id objectProp;
@@ -49,7 +49,7 @@
 
 RCT_EXPORT_MODULE()
 
-- (RCTUIView *)view
+- (RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   RCTPropsTestView *view = [RCTPropsTestView new];
   view.integerProp = 57;
@@ -111,7 +111,7 @@ RCT_CUSTOM_VIEW_PROPERTY(customProp, NSString, RCTPropsTestView)
 
   dispatch_async(uiManager.methodQueue, ^{
     [uiManager createView:@2 viewName:@"RCTPropsTestView" rootTag:self->_rootViewReactTag props:props];
-    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
       view = (RCTPropsTestView *)viewRegistry[@2];
       XCTAssertEqual(view.integerProp, 58);
       XCTAssertEqualObjects(view.objectProp, @10);
@@ -141,7 +141,7 @@ RCT_CUSTOM_VIEW_PROPERTY(customProp, NSString, RCTPropsTestView)
   dispatch_async(uiManager.methodQueue, ^{
     [uiManager createView:@2 viewName:@"RCTPropsTestView" rootTag:self->_rootViewReactTag props:props];
     [uiManager updateView:@2 viewName:@"RCTPropsTestView" props:resetProps];
-    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
       view = (RCTPropsTestView *)viewRegistry[@2];
       XCTAssertEqual(view.integerProp, 57);
       XCTAssertEqualObjects(view.objectProp, @9);
@@ -163,12 +163,12 @@ RCT_CUSTOM_VIEW_PROPERTY(customProp, NSString, RCTPropsTestView)
 
   dispatch_async(uiManager.methodQueue, ^{
     [uiManager createView:@2 viewName:@"RCTView" rootTag:self->_rootViewReactTag props:props];
-    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
       view = (RCTView *)viewRegistry[@2];
       XCTAssertEqualObjects(view.backgroundColor, [RCTConvert UIColor:@0xffffffff]);
     }];
     [uiManager updateView:@2 viewName:@"RCTView" props:resetProps];
-    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, __unused NSDictionary<NSNumber *,RCTUIView *> *viewRegistry) {
+    [uiManager addUIBlock:^(__unused RCTUIManager *_uiManager, __unused NSDictionary<NSNumber *,RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
       view = (RCTView *)viewRegistry[@2];
       XCTAssertNil(view.backgroundColor);
     }];

--- a/RNTester/RNTesterUnitTests/RCTUIManagerTests.m
+++ b/RNTester/RNTesterUnitTests/RCTUIManagerTests.m
@@ -21,7 +21,7 @@
         removeAtIndices:(NSArray *)removeAtIndices
                registry:(NSDictionary<NSNumber *, id<RCTComponent>> *)registry;
 
-@property (nonatomic, copy, readonly) NSMutableDictionary<NSNumber *, RCTUIView *> *viewRegistry;
+@property (nonatomic, copy, readonly) NSMutableDictionary<NSNumber *, RCTUIView *> *viewRegistry; // TODO(macOS ISS#3536887)
 
 @end
 
@@ -41,7 +41,7 @@
 
   // Register 20 views to use in the tests
   for (NSInteger i = 1; i <= 20; i++) {
-    RCTUIView *registeredView = [RCTUIView new];
+    RCTUIView *registeredView = [RCTUIView new]; // TODO(macOS ISS#3536887)
     registeredView.reactTag = @(i);
     _uiManager.viewRegistry[@(i)] = registeredView;
   }
@@ -49,7 +49,7 @@
 
 - (void)testManagingChildrenToAddViews
 {
-  RCTUIView *containerView = _uiManager.viewRegistry[@20];
+  RCTUIView *containerView = _uiManager.viewRegistry[@20]; // TODO(macOS ISS#3536887)
   NSMutableArray *addedViews = [NSMutableArray array];
 
   NSArray *tagsToAdd = @[@1, @2, @3, @4, @5];
@@ -72,7 +72,7 @@
   XCTAssertTrue([[containerView reactSubviews] count] == 5,
                @"Expect to have 5 react subviews after calling manage children \
                with 5 tags to add, instead have %lu", (unsigned long)[[containerView reactSubviews] count]);
-  for (RCTUIView *view in addedViews) {
+  for (RCTUIView *view in addedViews) { // TODO(macOS ISS#3536887)
     XCTAssertTrue([view reactSuperview] == containerView,
                   @"Expected to have manage children successfully add children");
     [view removeFromSuperview];
@@ -81,7 +81,7 @@
 
 - (void)testManagingChildrenToRemoveViews
 {
-  RCTUIView *containerView = _uiManager.viewRegistry[@20];
+  RCTUIView *containerView = _uiManager.viewRegistry[@20]; // TODO(macOS ISS#3536887)
   NSMutableArray *removedViews = [NSMutableArray array];
 
   NSArray *removeAtIndices = @[@0, @4, @8, @12, @16];
@@ -90,7 +90,7 @@
     [removedViews addObject:_uiManager.viewRegistry[reactTag]];
   }
   for (NSInteger i = 2; i < 20; i++) {
-    RCTUIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)]; // TODO(macOS ISS#3536887)
     [containerView insertReactSubview:view atIndex:containerView.reactSubviews.count];
   }
 
@@ -109,14 +109,14 @@
                @"Expect to have 13 react subviews after calling manage children\
                with 5 tags to remove and 18 prior children, instead have %zd",
                containerView.reactSubviews.count);
-  for (RCTUIView *view in removedViews) {
+  for (RCTUIView *view in removedViews) { // TODO(macOS ISS#3536887)
     XCTAssertTrue([view reactSuperview] == nil,
                  @"Expected to have manage children successfully remove children");
     // After removing views are unregistered - we need to reregister
     _uiManager.viewRegistry[view.reactTag] = view;
   }
   for (NSInteger i = 2; i < 20; i++) {
-    RCTUIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)]; // TODO(macOS ISS#3536887)
     if (![removedViews containsObject:view]) {
       XCTAssertTrue([view superview] == containerView,
                    @"Should not have removed view with react tag %ld during delete but did", (long)i);
@@ -135,7 +135,7 @@
 // [11,5,1,2,7,8,12,10]
 - (void)testManagingChildrenToAddRemoveAndMove
 {
-  RCTUIView *containerView = _uiManager.viewRegistry[@20];
+  RCTUIView *containerView = _uiManager.viewRegistry[@20]; // TODO(macOS ISS#3536887)
 
   NSArray *removeAtIndices = @[@2, @3, @5, @8];
   NSArray *addAtIndices = @[@0, @6];
@@ -147,12 +147,12 @@
   NSMutableArray *viewsToRemove = [NSMutableArray array];
   for (NSUInteger i = 0; i < removeAtIndices.count; i++) {
     NSNumber *reactTagToRemove = @([removeAtIndices[i] integerValue] + 1);
-    RCTUIView *viewToRemove = _uiManager.viewRegistry[reactTagToRemove];
+    RCTUIView *viewToRemove = _uiManager.viewRegistry[reactTagToRemove]; // TODO(macOS ISS#3536887)
     [viewsToRemove addObject:viewToRemove];
   }
 
   for (NSInteger i = 1; i < 11; i++) {
-    RCTUIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)]; // TODO(macOS ISS#3536887)
     [containerView insertReactSubview:view atIndex:containerView.reactSubviews.count];
   }
 
@@ -179,10 +179,10 @@
 
   // Clean up after ourselves
   for (NSInteger i = 1; i < 13; i++) {
-    RCTUIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)]; // TODO(macOS ISS#3536887)
     [view removeFromSuperview];
   }
-  for (RCTUIView *view in viewsToRemove) {
+  for (RCTUIView *view in viewsToRemove) { // TODO(macOS ISS#3536887)
     _uiManager.viewRegistry[view.reactTag] = view;
   }
 }

--- a/RNTester/RNTesterUnitTests/RCTUIManagerTests.m
+++ b/RNTester/RNTesterUnitTests/RCTUIManagerTests.m
@@ -21,7 +21,7 @@
         removeAtIndices:(NSArray *)removeAtIndices
                registry:(NSDictionary<NSNumber *, id<RCTComponent>> *)registry;
 
-@property (nonatomic, copy, readonly) NSMutableDictionary<NSNumber *, UIView *> *viewRegistry;
+@property (nonatomic, copy, readonly) NSMutableDictionary<NSNumber *, RCTUIView *> *viewRegistry;
 
 @end
 
@@ -41,7 +41,7 @@
 
   // Register 20 views to use in the tests
   for (NSInteger i = 1; i <= 20; i++) {
-    UIView *registeredView = [UIView new];
+    RCTUIView *registeredView = [RCTUIView new];
     registeredView.reactTag = @(i);
     _uiManager.viewRegistry[@(i)] = registeredView;
   }
@@ -49,7 +49,7 @@
 
 - (void)testManagingChildrenToAddViews
 {
-  UIView *containerView = _uiManager.viewRegistry[@20];
+  RCTUIView *containerView = _uiManager.viewRegistry[@20];
   NSMutableArray *addedViews = [NSMutableArray array];
 
   NSArray *tagsToAdd = @[@1, @2, @3, @4, @5];
@@ -72,7 +72,7 @@
   XCTAssertTrue([[containerView reactSubviews] count] == 5,
                @"Expect to have 5 react subviews after calling manage children \
                with 5 tags to add, instead have %lu", (unsigned long)[[containerView reactSubviews] count]);
-  for (UIView *view in addedViews) {
+  for (RCTUIView *view in addedViews) {
     XCTAssertTrue([view reactSuperview] == containerView,
                   @"Expected to have manage children successfully add children");
     [view removeFromSuperview];
@@ -81,7 +81,7 @@
 
 - (void)testManagingChildrenToRemoveViews
 {
-  UIView *containerView = _uiManager.viewRegistry[@20];
+  RCTUIView *containerView = _uiManager.viewRegistry[@20];
   NSMutableArray *removedViews = [NSMutableArray array];
 
   NSArray *removeAtIndices = @[@0, @4, @8, @12, @16];
@@ -90,7 +90,7 @@
     [removedViews addObject:_uiManager.viewRegistry[reactTag]];
   }
   for (NSInteger i = 2; i < 20; i++) {
-    UIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)];
     [containerView insertReactSubview:view atIndex:containerView.reactSubviews.count];
   }
 
@@ -109,14 +109,14 @@
                @"Expect to have 13 react subviews after calling manage children\
                with 5 tags to remove and 18 prior children, instead have %zd",
                containerView.reactSubviews.count);
-  for (UIView *view in removedViews) {
+  for (RCTUIView *view in removedViews) {
     XCTAssertTrue([view reactSuperview] == nil,
                  @"Expected to have manage children successfully remove children");
     // After removing views are unregistered - we need to reregister
     _uiManager.viewRegistry[view.reactTag] = view;
   }
   for (NSInteger i = 2; i < 20; i++) {
-    UIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)];
     if (![removedViews containsObject:view]) {
       XCTAssertTrue([view superview] == containerView,
                    @"Should not have removed view with react tag %ld during delete but did", (long)i);
@@ -135,7 +135,7 @@
 // [11,5,1,2,7,8,12,10]
 - (void)testManagingChildrenToAddRemoveAndMove
 {
-  UIView *containerView = _uiManager.viewRegistry[@20];
+  RCTUIView *containerView = _uiManager.viewRegistry[@20];
 
   NSArray *removeAtIndices = @[@2, @3, @5, @8];
   NSArray *addAtIndices = @[@0, @6];
@@ -147,12 +147,12 @@
   NSMutableArray *viewsToRemove = [NSMutableArray array];
   for (NSUInteger i = 0; i < removeAtIndices.count; i++) {
     NSNumber *reactTagToRemove = @([removeAtIndices[i] integerValue] + 1);
-    UIView *viewToRemove = _uiManager.viewRegistry[reactTagToRemove];
+    RCTUIView *viewToRemove = _uiManager.viewRegistry[reactTagToRemove];
     [viewsToRemove addObject:viewToRemove];
   }
 
   for (NSInteger i = 1; i < 11; i++) {
-    UIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)];
     [containerView insertReactSubview:view atIndex:containerView.reactSubviews.count];
   }
 
@@ -179,10 +179,10 @@
 
   // Clean up after ourselves
   for (NSInteger i = 1; i < 13; i++) {
-    UIView *view = _uiManager.viewRegistry[@(i)];
+    RCTUIView *view = _uiManager.viewRegistry[@(i)];
     [view removeFromSuperview];
   }
-  for (UIView *view in viewsToRemove) {
+  for (RCTUIView *view in viewsToRemove) {
     _uiManager.viewRegistry[view.reactTag] = view;
   }
 }

--- a/React/Base/RCTRootContentView.m
+++ b/React/Base/RCTRootContentView.m
@@ -93,7 +93,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder:(nonnull NSCoder *)aDecoder)
   [self updateAvailableSize];
 }
 
-- (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
+- (void)insertReactSubview:(RCTUIView *)subview atIndex:(NSInteger)atIndex
 {
   [super insertReactSubview:subview atIndex:atIndex];
   [_bridge.performanceLogger markStopForTag:RCTPLTTI];
@@ -134,10 +134,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder:(nonnull NSCoder *)aDecoder)
   [_bridge.uiManager setAvailableSize:self.availableSize forRootView:self];
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RCTUIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
   // The root content view itself should never receive touches
-  UIView *hitView = [super hitTest:point withEvent:event];
+  RCTUIView *hitView = [super hitTest:point withEvent:event];
   if (_passThroughTouches && hitView == self) {
     return nil;
   }

--- a/React/Base/RCTRootContentView.m
+++ b/React/Base/RCTRootContentView.m
@@ -93,7 +93,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder:(nonnull NSCoder *)aDecoder)
   [self updateAvailableSize];
 }
 
-- (void)insertReactSubview:(RCTUIView *)subview atIndex:(NSInteger)atIndex
+- (void)insertReactSubview:(RCTUIView *)subview atIndex:(NSInteger)atIndex // TODO(macOS ISS#3536887)
 {
   [super insertReactSubview:subview atIndex:atIndex];
   [_bridge.performanceLogger markStopForTag:RCTPLTTI];
@@ -134,10 +134,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder:(nonnull NSCoder *)aDecoder)
   [_bridge.uiManager setAvailableSize:self.availableSize forRootView:self];
 }
 
-- (RCTUIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (RCTUIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event // TODO(macOS ISS#3536887)
 {
   // The root content view itself should never receive touches
-  RCTUIView *hitView = [super hitTest:point withEvent:event];
+  RCTUIView *hitView = [super hitTest:point withEvent:event]; // TODO(macOS ISS#3536887)
   if (_passThroughTouches && hitView == self) {
     return nil;
   }

--- a/React/Base/RCTRootView.h
+++ b/React/Base/RCTRootView.h
@@ -42,7 +42,7 @@ NSString *const RCTContentDidAppearNotification;
  * like any ordinary UIView. You can have multiple RCTRootViews on screen at
  * once, all controlled by the same JavaScript application.
  */
-@interface RCTRootView : RCTUIView
+@interface RCTRootView : RCTUIView // TODO(macOS ISS#3536887)
 
 /**
  * - Designated initializer -
@@ -105,14 +105,14 @@ NSString *const RCTContentDidAppearNotification;
 /**
  * The React-managed contents view of the root view.
  */
-@property (nonatomic, strong, readonly) RCTUIView *contentView;
+@property (nonatomic, strong, readonly) RCTUIView *contentView; // TODO(macOS ISS#3536887)
 
 /**
  * A view to display while the JavaScript is loading, so users aren't presented
  * with a blank screen. By default this is nil, but you can override it with
  * (for example) a UIActivityIndicatorView or a placeholder image.
  */
-@property (nonatomic, strong) RCTUIView *loadingView;
+@property (nonatomic, strong) RCTUIView *loadingView; // TODO(macOS ISS#3536887)
 
 /**
  * Calling this will result in emitting a "touches cancelled" event to js,

--- a/React/Base/RCTRootView.h
+++ b/React/Base/RCTRootView.h
@@ -42,7 +42,7 @@ NSString *const RCTContentDidAppearNotification;
  * like any ordinary UIView. You can have multiple RCTRootViews on screen at
  * once, all controlled by the same JavaScript application.
  */
-@interface RCTRootView : UIView
+@interface RCTRootView : RCTUIView
 
 /**
  * - Designated initializer -
@@ -105,14 +105,14 @@ NSString *const RCTContentDidAppearNotification;
 /**
  * The React-managed contents view of the root view.
  */
-@property (nonatomic, strong, readonly) UIView *contentView;
+@property (nonatomic, strong, readonly) RCTUIView *contentView;
 
 /**
  * A view to display while the JavaScript is loading, so users aren't presented
  * with a blank screen. By default this is nil, but you can override it with
  * (for example) a UIActivityIndicatorView or a placeholder image.
  */
-@property (nonatomic, strong) UIView *loadingView;
+@property (nonatomic, strong) RCTUIView *loadingView;
 
 /**
  * Calling this will result in emitting a "touches cancelled" event to js,

--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -209,7 +209,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 #endif // ]TODO(macOS ISS#2323203)
 }
 
-- (void)setLoadingView:(UIView *)loadingView
+- (void)setLoadingView:(RCTUIView *)loadingView
 {
   _loadingView = loadingView;
   if (!_contentView.contentHasAppeared) {

--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -209,7 +209,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 #endif // ]TODO(macOS ISS#2323203)
 }
 
-- (void)setLoadingView:(RCTUIView *)loadingView
+- (void)setLoadingView:(RCTUIView *)loadingView // TODO(macOS ISS#3536887)
 {
   _loadingView = loadingView;
   if (!_contentView.contentHasAppeared) {

--- a/React/Base/RCTTouchHandler.h
+++ b/React/Base/RCTTouchHandler.h
@@ -15,8 +15,8 @@
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;
 
-- (void)attachToView:(UIView *)view;
-- (void)detachFromView:(UIView *)view;
+- (void)attachToView:(RCTUIView *)view;
+- (void)detachFromView:(RCTUIView *)view;
 
 - (void)cancel;
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)

--- a/React/Base/RCTTouchHandler.h
+++ b/React/Base/RCTTouchHandler.h
@@ -15,8 +15,8 @@
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;
 
-- (void)attachToView:(RCTUIView *)view;
-- (void)detachFromView:(RCTUIView *)view;
+- (void)attachToView:(RCTUIView *)view; // TODO(macOS ISS#3536887)
+- (void)detachFromView:(RCTUIView *)view; // TODO(macOS ISS#3536887)
 
 - (void)cancel;
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)

--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -40,7 +40,7 @@
   NSMutableArray<NSMutableDictionary *> *_reactTouches;
   NSMutableArray<RCTPlatformView *> *_touchViews; // TODO(macOS ISS#2323203)
 
-  __weak UIView *_cachedRootView;
+  __weak RCTUIView *_cachedRootView;
 
   uint16_t _coalescingKey;
 #if TARGET_OS_OSX// [TODO(macOS ISS#2323203)
@@ -82,14 +82,14 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithTarget:(id)target action:(SEL)action
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
 #endif // ]TODO(macOS ISS#2323203)
 
-- (void)attachToView:(UIView *)view
+- (void)attachToView:(RCTUIView *)view
 {
   RCTAssert(self.view == nil, @"RCTTouchHandler already has attached view.");
 
   [view addGestureRecognizer:self];
 }
 
-- (void)detachFromView:(UIView *)view
+- (void)detachFromView:(RCTUIView *)view
 {
   RCTAssertParam(view);
   RCTAssert(self.view == view, @"RCTTouchHandler attached to another view.");
@@ -137,8 +137,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
     
     while (targetView) {
       BOOL isUserInteractionEnabled = NO;
-      if ([((UIView*)targetView) respondsToSelector:@selector(isUserInteractionEnabled)]) {
-        isUserInteractionEnabled = ((UIView*)targetView).isUserInteractionEnabled;
+      if ([((RCTUIView*)targetView) respondsToSelector:@selector(isUserInteractionEnabled)]) {
+        isUserInteractionEnabled = ((RCTUIView*)targetView).isUserInteractionEnabled;
       }
       if (targetView.reactTag && isUserInteractionEnabled) {
         break;
@@ -148,8 +148,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
 
     NSNumber *reactTag = [targetView reactTagAtPoint:touchLocation];
     BOOL isUserInteractionEnabled = NO;
-    if ([((UIView*)targetView) respondsToSelector:@selector(isUserInteractionEnabled)]) {
-      isUserInteractionEnabled = ((UIView*)targetView).isUserInteractionEnabled;
+    if ([((RCTUIView*)targetView) respondsToSelector:@selector(isUserInteractionEnabled)]) {
+      isUserInteractionEnabled = ((RCTUIView*)targetView).isUserInteractionEnabled;
     }
     if (!reactTag || !isUserInteractionEnabled) {
       continue;
@@ -355,7 +355,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
  */
 - (void)_cacheRootView
 {
-  UIView *rootView = self.view;
+  RCTUIView *rootView = self.view;
   while (rootView.superview && ![rootView isReactRootView] && ![rootView isKindOfClass:[RCTSurfaceView class]]) {
     rootView = rootView.superview;
   }

--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -535,7 +535,7 @@ static BOOL RCTAnyTouchesChanged(NSSet *touches) // [TODO(macOS ISS#2323203)
 {
   // We fail in favour of other external gesture recognizers.
   // iOS will ask `delegate`'s opinion about this gesture recognizer little bit later.
-  return !UIViewIsDescendantOfView(preventingGestureRecognizer.view, self.view); // TODO(macOS ISS#2323203)
+  return !RCTUIViewIsDescendantOfView(preventingGestureRecognizer.view, self.view); // TODO(macOS ISS#2323203)
 }
 
 - (void)reset

--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -82,14 +82,14 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithTarget:(id)target action:(SEL)action
 RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
 #endif // ]TODO(macOS ISS#2323203)
 
-- (void)attachToView:(RCTUIView *)view
+- (void)attachToView:(RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   RCTAssert(self.view == nil, @"RCTTouchHandler already has attached view.");
 
   [view addGestureRecognizer:self];
 }
 
-- (void)detachFromView:(RCTUIView *)view
+- (void)detachFromView:(RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   RCTAssertParam(view);
   RCTAssert(self.view == view, @"RCTTouchHandler attached to another view.");
@@ -137,8 +137,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
     
     while (targetView) {
       BOOL isUserInteractionEnabled = NO;
-      if ([((RCTUIView*)targetView) respondsToSelector:@selector(isUserInteractionEnabled)]) {
-        isUserInteractionEnabled = ((RCTUIView*)targetView).isUserInteractionEnabled;
+      if ([((RCTUIView*)targetView) respondsToSelector:@selector(isUserInteractionEnabled)]) { // TODO(macOS ISS#3536887)
+        isUserInteractionEnabled = ((RCTUIView*)targetView).isUserInteractionEnabled; // TODO(macOS ISS#3536887)
       }
       if (targetView.reactTag && isUserInteractionEnabled) {
         break;
@@ -148,8 +148,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
 
     NSNumber *reactTag = [targetView reactTagAtPoint:touchLocation];
     BOOL isUserInteractionEnabled = NO;
-    if ([((RCTUIView*)targetView) respondsToSelector:@selector(isUserInteractionEnabled)]) {
-      isUserInteractionEnabled = ((RCTUIView*)targetView).isUserInteractionEnabled;
+    if ([((RCTUIView*)targetView) respondsToSelector:@selector(isUserInteractionEnabled)]) { // TODO(macOS ISS#3536887)
+      isUserInteractionEnabled = ((RCTUIView*)targetView).isUserInteractionEnabled; // TODO(macOS ISS#3536887)
     }
     if (!reactTag || !isUserInteractionEnabled) {
       continue;
@@ -355,7 +355,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
  */
 - (void)_cacheRootView
 {
-  RCTUIView *rootView = self.view;
+  RCTUIView *rootView = self.view; // TODO(macOS ISS#3536887)
   while (rootView.superview && ![rootView isReactRootView] && ![rootView isKindOfClass:[RCTSurfaceView class]]) {
     rootView = rootView.superview;
   }
@@ -535,7 +535,7 @@ static BOOL RCTAnyTouchesChanged(NSSet *touches) // [TODO(macOS ISS#2323203)
 {
   // We fail in favour of other external gesture recognizers.
   // iOS will ask `delegate`'s opinion about this gesture recognizer little bit later.
-  return !RCTUIViewIsDescendantOfView(preventingGestureRecognizer.view, self.view); // TODO(macOS ISS#2323203)
+  return !RCTUIViewIsDescendantOfView(preventingGestureRecognizer.view, self.view); // TODO(macOS ISS#2323203) and TODO(macOS ISS#3536887)
 }
 
 - (void)reset

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -60,8 +60,8 @@ UIKIT_STATIC_INLINE CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path)
 
 // UIView
 #define RCTPlatformView         UIView
-#define RCTUIView UIView
-#define RCTUIScrollView UIScrollView
+#define RCTUIView UIView // TODO(macOS ISS#3536887)
+#define RCTUIScrollView UIScrollView // TODO(macOS ISS#3536887)
 
 UIKIT_STATIC_INLINE RCTPlatformView *RCTUIViewHitTestWithEvent(RCTPlatformView *view, CGPoint point, UIEvent *event)
 {
@@ -355,7 +355,7 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 // UIView
 #define RCTPlatformView NSView
 
-@interface RCTUIView : NSView
+@interface RCTUIView : NSView // TODO(macOS ISS#3536887)
 
 @property (nonatomic, readonly) BOOL canBecomeFirstResponder;
 - (BOOL)becomeFirstResponder;
@@ -396,7 +396,7 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 
 // UIScrollView
 
-@interface RCTUIScrollView : NSScrollView
+@interface RCTUIScrollView : NSScrollView // TODO(macOS ISS#3536887)
 
 // UIScrollView properties missing in NSScrollView
 @property (nonatomic, assign) CGPoint contentOffset;

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -61,6 +61,7 @@ UIKIT_STATIC_INLINE CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path)
 // UIView
 #define RCTPlatformView         UIView
 #define RCTUIView UIView
+#define RCTUIScrollView UIScrollView
 
 UIKIT_STATIC_INLINE RCTPlatformView *UIViewHitTestWithEvent(RCTPlatformView *view, CGPoint point, UIEvent *event)
 {
@@ -395,7 +396,7 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 
 // UIScrollView
 
-@interface UIScrollView : NSScrollView
+@interface RCTUIScrollView : NSScrollView
 
 // UIScrollView properties missing in NSScrollView
 @property (nonatomic, assign) CGPoint contentOffset;

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -63,27 +63,27 @@ UIKIT_STATIC_INLINE CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path)
 #define RCTUIView UIView
 #define RCTUIScrollView UIScrollView
 
-UIKIT_STATIC_INLINE RCTPlatformView *UIViewHitTestWithEvent(RCTPlatformView *view, CGPoint point, UIEvent *event)
+UIKIT_STATIC_INLINE RCTPlatformView *RCTUIViewHitTestWithEvent(RCTPlatformView *view, CGPoint point, UIEvent *event)
 {
   return [view hitTest:point withEvent:event];
 }
 
-UIKIT_STATIC_INLINE BOOL UIViewSetClipsToBounds(RCTPlatformView *view)
+UIKIT_STATIC_INLINE BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 {
   return view.clipsToBounds;
 }
 
-UIKIT_STATIC_INLINE void UIViewSetContentModeRedraw(UIView *view)
+UIKIT_STATIC_INLINE void RCTUIViewSetContentModeRedraw(UIView *view)
 {
   view.contentMode = UIViewContentModeRedraw;
 }
 
-UIKIT_STATIC_INLINE BOOL UIViewDrawViewHierarchyInRectAfterScreenUpdates(RCTPlatformView *view, CGRect rect, BOOL afterUpdates)
+UIKIT_STATIC_INLINE BOOL RCTUIViewDrawViewHierarchyInRectAfterScreenUpdates(RCTPlatformView *view, CGRect rect, BOOL afterUpdates)
 {
   return [view drawViewHierarchyInRect:rect afterScreenUpdates:afterUpdates];
 }
 
-UIKIT_STATIC_INLINE BOOL UIViewIsDescendantOfView(RCTPlatformView *view, RCTPlatformView *parent)
+UIKIT_STATIC_INLINE BOOL RCTUIViewIsDescendantOfView(RCTPlatformView *view, RCTPlatformView *parent)
 {
   return [view isDescendantOfView:parent];
 }
@@ -411,19 +411,19 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 
 @end
 
-NS_INLINE RCTPlatformView *UIViewHitTestWithEvent(RCTPlatformView *view, CGPoint point, __unused UIEvent *event)
+NS_INLINE RCTPlatformView *RCTUIViewHitTestWithEvent(RCTPlatformView *view, CGPoint point, __unused UIEvent *event)
 {
   return [view hitTest:point];
 }
 
-BOOL UIViewSetClipsToBounds(RCTPlatformView *view);
+BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view);
 
-NS_INLINE void UIViewSetContentModeRedraw(RCTPlatformView *view)
+NS_INLINE void RCTUIViewSetContentModeRedraw(RCTPlatformView *view)
 {
   view.layerContentsRedrawPolicy = NSViewLayerContentsRedrawDuringViewResize;
 }
 
-NS_INLINE BOOL UIViewDrawViewHierarchyInRectAfterScreenUpdates(RCTPlatformView *view, CGRect rect, __unused BOOL afterUpdates)
+NS_INLINE BOOL RCTUIViewDrawViewHierarchyInRectAfterScreenUpdates(RCTPlatformView *view, CGRect rect, __unused BOOL afterUpdates)
 {
   RCTAssert(afterUpdates, @"We're redrawing the view so it will necessarily include the latest changes.");
   (void) afterUpdates;
@@ -431,14 +431,14 @@ NS_INLINE BOOL UIViewDrawViewHierarchyInRectAfterScreenUpdates(RCTPlatformView *
   return YES;
 }
 
-NS_INLINE BOOL UIViewIsDescendantOfView(RCTPlatformView *view, RCTPlatformView *parent)
+NS_INLINE BOOL RCTUIViewIsDescendantOfView(RCTPlatformView *view, RCTPlatformView *parent)
 {
   return [view isDescendantOf:parent];
 }
 
-NSArray *UIViewCalculateKeyViewLoop(RCTPlatformView *root);
+NSArray *RCTUIViewCalculateKeyViewLoop(RCTPlatformView *root);
 
-BOOL UIViewHasDescendantPassingPredicate(RCTPlatformView *root, BOOL (^predicate)(RCTPlatformView *view));
+BOOL RCTUIViewHasDescendantPassingPredicate(RCTPlatformView *root, BOOL (^predicate)(RCTPlatformView *view));
 
 NS_INLINE NSValue *NSValueWithCGRect(CGRect rect)
 {

--- a/React/Base/RCTUIKit.h
+++ b/React/Base/RCTUIKit.h
@@ -60,6 +60,7 @@ UIKIT_STATIC_INLINE CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path)
 
 // UIView
 #define RCTPlatformView         UIView
+#define RCTUIView UIView
 
 UIKIT_STATIC_INLINE RCTPlatformView *UIViewHitTestWithEvent(RCTPlatformView *view, CGPoint point, UIEvent *event)
 {
@@ -353,7 +354,7 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *path);
 // UIView
 #define RCTPlatformView NSView
 
-@interface UIView : NSView
+@interface RCTUIView : NSView
 
 @property (nonatomic, readonly) BOOL canBecomeFirstResponder;
 - (BOOL)becomeFirstResponder;
@@ -416,7 +417,7 @@ NS_INLINE RCTPlatformView *UIViewHitTestWithEvent(RCTPlatformView *view, CGPoint
 
 BOOL UIViewSetClipsToBounds(RCTPlatformView *view);
 
-NS_INLINE void UIViewSetContentModeRedraw(UIView *view)
+NS_INLINE void UIViewSetContentModeRedraw(RCTPlatformView *view)
 {
   view.layerContentsRedrawPolicy = NSViewLayerContentsRedrawDuringViewResize;
 }

--- a/React/Base/Surface/RCTSurfaceView.h
+++ b/React/Base/Surface/RCTSurfaceView.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * UIView instance which represents the Surface
  */
-@interface RCTSurfaceView : RCTUIView
+@interface RCTSurfaceView : RCTUIView // TODO(macOS ISS#3536887)
 
 - (instancetype)initWithSurface:(RCTSurface *)surface NS_DESIGNATED_INITIALIZER;
 

--- a/React/Base/Surface/RCTSurfaceView.h
+++ b/React/Base/Surface/RCTSurfaceView.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * UIView instance which represents the Surface
  */
-@interface RCTSurfaceView : UIView
+@interface RCTSurfaceView : RCTUIView
 
 - (instancetype)initWithSurface:(RCTSurface *)surface NS_DESIGNATED_INITIALIZER;
 

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -234,7 +234,7 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *bezierPath)
   return keyPaths;
 }
 
-static RCTUIView *UIViewCommonInit(RCTUIView *self)
+static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
 {
   if (self != nil) {
     self.wantsLayer = YES;
@@ -246,12 +246,12 @@ static RCTUIView *UIViewCommonInit(RCTUIView *self)
 
 - (instancetype)initWithFrame:(NSRect)frameRect
 {
-  return UIViewCommonInit([super initWithFrame:frameRect]);
+  return RCTUIViewCommonInit([super initWithFrame:frameRect]);
 }
 
 - (instancetype)initWithCoder:(NSCoder *)coder
 {
-  return UIViewCommonInit([super initWithCoder:coder]);
+  return RCTUIViewCommonInit([super initWithCoder:coder]);
 }
 
 - (BOOL)acceptsFirstResponder
@@ -499,7 +499,7 @@ static RCTUIView *UIViewCommonInit(RCTUIView *self)
 
 @end
 
-BOOL UIViewSetClipsToBounds(RCTPlatformView *view)
+BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
 {
   // NSViews are always clipped to bounds
   BOOL clipsToBounds = YES;
@@ -513,7 +513,7 @@ BOOL UIViewSetClipsToBounds(RCTPlatformView *view)
   return clipsToBounds;
 }
 
-static BOOL UIViewIsFieldEditor(RCTPlatformView *view)
+static BOOL RCTUIViewIsFieldEditor(RCTPlatformView *view)
 {
   if ([view isKindOfClass:[NSText class]]) {
     NSText *textObj = (NSText *) view;
@@ -522,14 +522,14 @@ static BOOL UIViewIsFieldEditor(RCTPlatformView *view)
   return NO;
 }
 
-static BOOL UIViewDescendantIsFieldEditor(RCTPlatformView *root)
+static BOOL RCTUIViewDescendantIsFieldEditor(RCTPlatformView *root)
 {
-  return UIViewHasDescendantPassingPredicate(root, ^BOOL(RCTPlatformView *view) {
-    return UIViewIsFieldEditor(view);
+  return RCTUIViewHasDescendantPassingPredicate(root, ^BOOL(RCTPlatformView *view) {
+    return RCTUIViewIsFieldEditor(view);
   });
 }
 
-static RCTPlatformView *UIViewDescendantPassingPredicate_DFS(RCTPlatformView *root, BOOL (^predicate)(RCTPlatformView *view))
+static RCTPlatformView *RCTUIViewDescendantPassingPredicate_DFS(RCTPlatformView *root, BOOL (^predicate)(RCTPlatformView *view))
 {
   if (!root || !predicate) {
     return nil;
@@ -540,7 +540,7 @@ static RCTPlatformView *UIViewDescendantPassingPredicate_DFS(RCTPlatformView *ro
   }
 
   for (RCTPlatformView *subview in [root subviews]) {
-    RCTPlatformView *passingView = UIViewDescendantPassingPredicate_DFS(subview, predicate);
+    RCTPlatformView *passingView = RCTUIViewDescendantPassingPredicate_DFS(subview, predicate);
 
     if (passingView) {
       return passingView;
@@ -550,15 +550,15 @@ static RCTPlatformView *UIViewDescendantPassingPredicate_DFS(RCTPlatformView *ro
   return nil;
 }
 
-BOOL UIViewHasDescendantPassingPredicate(RCTPlatformView *root, BOOL (^predicate)(RCTPlatformView *view))
+BOOL RCTUIViewHasDescendantPassingPredicate(RCTPlatformView *root, BOOL (^predicate)(RCTPlatformView *view))
 {
-  return UIViewDescendantPassingPredicate_DFS(root, predicate) != nil;
+  return RCTUIViewDescendantPassingPredicate_DFS(root, predicate) != nil;
 }
 
-static void UIViewCalculateKeyViewLoopInternal(RCTPlatformView *root, NSMutableArray *keyViewLoop)
+static void RCTUIViewCalculateKeyViewLoopInternal(RCTPlatformView *root, NSMutableArray *keyViewLoop)
 {
   for (RCTPlatformView *view in root.subviews) {
-    UIViewCalculateKeyViewLoopInternal(view, keyViewLoop);
+    RCTUIViewCalculateKeyViewLoopInternal(view, keyViewLoop);
   }
   if ([root canBecomeKeyView]) {
     BOOL include = YES;
@@ -579,7 +579,7 @@ static void UIViewCalculateKeyViewLoopInternal(RCTPlatformView *root, NSMutableA
          NSTextView <-- The field editor. We do not want this in the key view loop.
      
      */
-    if (UIViewDescendantIsFieldEditor(root)) {
+    if (RCTUIViewDescendantIsFieldEditor(root)) {
       BOOL isEditedControl = [root isKindOfClass:[NSControl class]] ? ([(NSControl *) root currentEditor] != nil) : NO;
       
       if (!isEditedControl) {
@@ -592,10 +592,10 @@ static void UIViewCalculateKeyViewLoopInternal(RCTPlatformView *root, NSMutableA
   }
 }
 
-NSArray *UIViewCalculateKeyViewLoop(RCTPlatformView *root)
+NSArray *RCTUIViewCalculateKeyViewLoop(RCTPlatformView *root)
 {
   NSMutableArray *keyViewLoop = [NSMutableArray array];
-  UIViewCalculateKeyViewLoopInternal(root, keyViewLoop);
+  RCTUIViewCalculateKeyViewLoopInternal(root, keyViewLoop);
   // Avoid returning self-referential single-link loops
   if ([keyViewLoop count] == 1 && [keyViewLoop firstObject] == root) {
     return nil;

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -201,11 +201,8 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *bezierPath)
 
 // UIView
 
-@interface RCTUIView ()
 
-@end
-
-@implementation RCTUIView
+@implementation RCTUIView // TODO(macOS ISS#3536887)
 {
 @private
   NSColor *_backgroundColor;
@@ -402,7 +399,7 @@ static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
 
 // RCTUIScrollView
 
-@implementation RCTUIScrollView
+@implementation RCTUIScrollView // TODO(macOS ISS#3536887)
 
 // UIScrollView properties missing from NSScrollView
 - (CGPoint)contentOffset

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -201,11 +201,11 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *bezierPath)
 
 // UIView
 
-@interface UIView ()
+@interface RCTUIView ()
 
 @end
 
-@implementation UIView
+@implementation RCTUIView
 {
 @private
   NSColor *_backgroundColor;
@@ -234,7 +234,7 @@ CGPathRef UIBezierPathCreateCGPathRef(UIBezierPath *bezierPath)
   return keyPaths;
 }
 
-static UIView *UIViewCommonInit(UIView *self)
+static RCTUIView *UIViewCommonInit(RCTUIView *self)
 {
   if (self != nil) {
     self.wantsLayer = YES;

--- a/React/Base/macOS/RCTUIKit.m
+++ b/React/Base/macOS/RCTUIKit.m
@@ -400,9 +400,9 @@ static RCTUIView *UIViewCommonInit(RCTUIView *self)
 
 @end
 
-// UIScrollView
+// RCTUIScrollView
 
-@implementation UIScrollView
+@implementation RCTUIScrollView
 
 // UIScrollView properties missing from NSScrollView
 - (CGPoint)contentOffset

--- a/React/Modules/RCTUIManager.h
+++ b/React/Modules/RCTUIManager.h
@@ -37,7 +37,7 @@ void RCTTraverseViewNodes(id<RCTComponent> view, void (^block)(id<RCTComponent>)
 /**
  * Register a root view with the RCTUIManager.
  */
-- (void)registerRootView:(UIView *)rootView;
+- (void)registerRootView:(RCTUIView *)rootView;
 
 /**
  * Gets the view name associated with a reactTag.
@@ -61,7 +61,7 @@ void RCTTraverseViewNodes(id<RCTComponent> view, void (^block)(id<RCTComponent>)
  * this value does not affect root node size style properties.
  * Can be considered as something similar to `setSize:forView:` but applicable only for root view.
  */
-- (void)setAvailableSize:(CGSize)availableSize forRootView:(UIView *)rootView;
+- (void)setAvailableSize:(CGSize)availableSize forRootView:(RCTUIView *)rootView;
 
 /**
  * Sets local data for a shadow view corresponded with given view.
@@ -72,7 +72,7 @@ void RCTTraverseViewNodes(id<RCTComponent> view, void (^block)(id<RCTComponent>)
  * the shadow view.
  * Please respect one-directional data flow of React.
  */
-- (void)setLocalData:(NSObject *)localData forView:(UIView *)view;
+- (void)setLocalData:(NSObject *)localData forView:(RCTUIView *)view;
 
 /**
  * Set the size of a view. This might be in response to a screen rotation
@@ -134,7 +134,7 @@ void RCTTraverseViewNodes(id<RCTComponent> view, void (^block)(id<RCTComponent>)
  * @param nativeID the id reference to native component relative to root view.
  * @param rootTag the react tag of root view hierarchy from which to find the view.
  */
-- (UIView *)viewForNativeID:(NSString *)nativeID withRootTag:(NSNumber *)rootTag;
+- (RCTUIView *)viewForNativeID:(NSString *)nativeID withRootTag:(NSNumber *)rootTag;
 
 /**
  * The view that is currently first responder, according to the JS context.

--- a/React/Modules/RCTUIManager.h
+++ b/React/Modules/RCTUIManager.h
@@ -37,7 +37,7 @@ void RCTTraverseViewNodes(id<RCTComponent> view, void (^block)(id<RCTComponent>)
 /**
  * Register a root view with the RCTUIManager.
  */
-- (void)registerRootView:(RCTUIView *)rootView;
+- (void)registerRootView:(RCTUIView *)rootView; // TODO(macOS ISS#3536887)
 
 /**
  * Gets the view name associated with a reactTag.
@@ -61,7 +61,7 @@ void RCTTraverseViewNodes(id<RCTComponent> view, void (^block)(id<RCTComponent>)
  * this value does not affect root node size style properties.
  * Can be considered as something similar to `setSize:forView:` but applicable only for root view.
  */
-- (void)setAvailableSize:(CGSize)availableSize forRootView:(RCTUIView *)rootView;
+- (void)setAvailableSize:(CGSize)availableSize forRootView:(RCTUIView *)rootView; // TODO(macOS ISS#3536887)
 
 /**
  * Sets local data for a shadow view corresponded with given view.
@@ -72,7 +72,7 @@ void RCTTraverseViewNodes(id<RCTComponent> view, void (^block)(id<RCTComponent>)
  * the shadow view.
  * Please respect one-directional data flow of React.
  */
-- (void)setLocalData:(NSObject *)localData forView:(RCTUIView *)view;
+- (void)setLocalData:(NSObject *)localData forView:(RCTUIView *)view; // TODO(macOS ISS#3536887)
 
 /**
  * Set the size of a view. This might be in response to a screen rotation
@@ -134,7 +134,7 @@ void RCTTraverseViewNodes(id<RCTComponent> view, void (^block)(id<RCTComponent>)
  * @param nativeID the id reference to native component relative to root view.
  * @param rootTag the react tag of root view hierarchy from which to find the view.
  */
-- (RCTUIView *)viewForNativeID:(NSString *)nativeID withRootTag:(NSNumber *)rootTag;
+- (RCTUIView *)viewForNativeID:(NSString *)nativeID withRootTag:(NSNumber *)rootTag; // TODO(macOS ISS#3536887)
 
 /**
  * The view that is currently first responder, according to the JS context.

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -1056,7 +1056,7 @@ RCT_EXPORT_METHOD(findSubviewIn:(nonnull NSNumber *)reactTag atPoint:(CGPoint)po
 {
   [self addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPlatformView *> *viewRegistry) { // TODO(macOS ISS#2323203)
     RCTPlatformView *view = viewRegistry[reactTag]; // TODO(macOS ISS#2323203)
-    RCTPlatformView *target = UIViewHitTestWithEvent(view, point, nil); // TODO(macOS ISS#2323203)
+    RCTPlatformView *target = RCTUIViewHitTestWithEvent(view, point, nil); // TODO(macOS ISS#2323203)
     CGRect frame = [target convertRect:target.bounds toView:view];
 
     while (target.reactTag == nil && target.superview != nil) {
@@ -1420,7 +1420,7 @@ RCT_EXPORT_METHOD(takeSnapshot:(id /* NSString or NSNumber */)target
       size = view.bounds.size;
     }
     UIGraphicsBeginImageContextWithOptions(size, NO, 0);
-    BOOL success = UIViewDrawViewHierarchyInRectAfterScreenUpdates(view, (CGRect){CGPointZero, size}, YES); // TODO(macOS ISS#2323203)
+    BOOL success = RCTUIViewDrawViewHierarchyInRectAfterScreenUpdates(view, (CGRect){CGPointZero, size}, YES); // TODO(macOS ISS#2323203)
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
 

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -107,7 +107,7 @@ RCT_EXPORT_MODULE()
   RCTExecuteOnMainQueue(^{
     RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"UIManager invalidate", nil);
     for (NSNumber *rootViewTag in self->_rootViewTags) {
-      RCTUIView *rootView = self->_viewRegistry[rootViewTag];
+      RCTUIView *rootView = self->_viewRegistry[rootViewTag]; // TODO(macOS ISS#3536887)
       if ([rootView conformsToProtocol:@protocol(RCTInvalidating)]) {
         [(id<RCTInvalidating>)rootView invalidate];
       }
@@ -360,7 +360,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
   });
 }
 
-- (void)setAvailableSize:(CGSize)availableSize forRootView:(RCTUIView *)rootView
+- (void)setAvailableSize:(CGSize)availableSize forRootView:(RCTUIView *)rootView // TODO(macOS ISS#3536887)
 {
   RCTAssertMainQueue();
   [self _executeBlockWithShadowView:^(RCTShadowView *shadowView) {
@@ -377,7 +377,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
   } forTag:rootView.reactTag];
 }
 
-- (void)setLocalData:(NSObject *)localData forView:(RCTUIView *)view
+- (void)setLocalData:(NSObject *)localData forView:(RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   RCTAssertMainQueue();
   [self _executeBlockWithShadowView:^(RCTShadowView *shadowView) {
@@ -390,22 +390,22 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
  * TODO(yuwang): implement the nativeID functionality in a more efficient way
  *               instead of searching the whole view tree
  */
-- (RCTUIView *)viewForNativeID:(NSString *)nativeID withRootTag:(NSNumber *)rootTag
+- (RCTUIView *)viewForNativeID:(NSString *)nativeID withRootTag:(NSNumber *)rootTag // TODO(macOS ISS#3536887)
 {
   RCTAssertMainQueue();
-  RCTUIView *view = [self viewForReactTag:rootTag];
+  RCTUIView *view = [self viewForReactTag:rootTag]; // TODO(macOS ISS#3536887)
   return [self _lookupViewForNativeID:nativeID inView:view];
 }
 
-- (RCTUIView *)_lookupViewForNativeID:(NSString *)nativeID inView:(RCTUIView *)view
+- (RCTUIView *)_lookupViewForNativeID:(NSString *)nativeID inView:(RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   RCTAssertMainQueue();
   if (view != nil && [nativeID isEqualToString:view.nativeID]) {
     return view;
   }
 
-  for (RCTUIView *subview in view.subviews) {
-    RCTUIView *targetView = [self _lookupViewForNativeID:nativeID inView:subview];
+  for (RCTUIView *subview in view.subviews) { // TODO(macOS ISS#3536887)
+    RCTUIView *targetView = [self _lookupViewForNativeID:nativeID inView:subview]; // TODO(macOS ISS#3536887)
     if (targetView != nil) {
       return targetView;
     }
@@ -413,7 +413,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
   return nil;
 }
 
-- (void)setSize:(CGSize)size forView:(RCTUIView *)view
+- (void)setSize:(CGSize)size forView:(RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   RCTAssertMainQueue();
   [self _executeBlockWithShadowView:^(RCTShadowView *shadowView) {
@@ -426,7 +426,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
   } forTag:view.reactTag];
 }
 
-- (void)setIntrinsicContentSize:(CGSize)intrinsicContentSize forView:(RCTUIView *)view
+- (void)setIntrinsicContentSize:(CGSize)intrinsicContentSize forView:(RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   RCTAssertMainQueue();
   [self _executeBlockWithShadowView:^(RCTShadowView *shadowView) {
@@ -771,7 +771,7 @@ RCT_EXPORT_METHOD(removeSubviewsFromContainerWithID:(nonnull NSNumber *)containe
     // Disable user interaction while the view is animating
     // since the view is (conceptually) deleted and not supposed to be interactive.
     if ([removedChild respondsToSelector:@selector(setUserInteractionEnabled:)]) { // [TODO(macOS ISS#2323203)
-      ((RCTUIView *)removedChild).userInteractionEnabled = NO;
+      ((RCTUIView *)removedChild).userInteractionEnabled = NO; // TODO(macOS ISS#3536887)
     }
 #if !TARGET_OS_OSX // ]TODO(macOS ISS#2323203)
     [originalSuperview insertSubview:removedChild atIndex:originalIndex];
@@ -1032,22 +1032,22 @@ RCT_EXPORT_METHOD(updateView:(nonnull NSNumber *)reactTag
 {
   RCTAssertMainQueue();
   RCTComponentData *componentData = _componentDataByName[viewName];
-  RCTUIView *view = _viewRegistry[reactTag];
+  RCTUIView *view = _viewRegistry[reactTag]; // TODO(macOS ISS#3536887)
   [componentData setProps:props forView:view];
 }
 
 RCT_EXPORT_METHOD(focus:(nonnull NSNumber *)reactTag)
 {
-  [self addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
-    RCTUIView *newResponder = viewRegistry[reactTag];
+  [self addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
+    RCTUIView *newResponder = viewRegistry[reactTag]; // TODO(macOS ISS#3536887)
     [newResponder reactFocus];
   }];
 }
 
 RCT_EXPORT_METHOD(blur:(nonnull NSNumber *)reactTag)
 {
-  [self addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry){
-    RCTUIView *currentResponder = viewRegistry[reactTag];
+  [self addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry){ // TODO(macOS ISS#3536887)
+    RCTUIView *currentResponder = viewRegistry[reactTag]; // TODO(macOS ISS#3536887)
     [currentResponder reactBlur];
   }];
 }
@@ -1056,7 +1056,7 @@ RCT_EXPORT_METHOD(findSubviewIn:(nonnull NSNumber *)reactTag atPoint:(CGPoint)po
 {
   [self addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTPlatformView *> *viewRegistry) { // TODO(macOS ISS#2323203)
     RCTPlatformView *view = viewRegistry[reactTag]; // TODO(macOS ISS#2323203)
-    RCTPlatformView *target = RCTUIViewHitTestWithEvent(view, point, nil); // TODO(macOS ISS#2323203)
+    RCTPlatformView *target = RCTUIViewHitTestWithEvent(view, point, nil); // TODO(macOS ISS#2323203) and TODO(macOS ISS#3536887)
     CGRect frame = [target convertRect:target.bounds toView:view];
 
     while (target.reactTag == nil && target.superview != nil) {
@@ -1214,9 +1214,9 @@ RCT_EXPORT_METHOD(dispatchViewManagerCommand:(nonnull NSNumber *)reactTag
     [tags addObject:shadowView.reactTag];
   }
 
-  [self addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+  [self addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
     for (NSNumber *tag in tags) {
-      RCTUIView<RCTComponent> *view = viewRegistry[tag];
+      RCTUIView<RCTComponent> *view = viewRegistry[tag]; // TODO(macOS ISS#3536887)
       [view didUpdateReactSubviews];
     }
   }];
@@ -1239,9 +1239,9 @@ RCT_EXPORT_METHOD(dispatchViewManagerCommand:(nonnull NSNumber *)reactTag
     [tags setObject:props forKey:shadowView.reactTag];
   }
 
-  [self addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+  [self addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
     for (NSNumber *tag in tags) {
-      RCTUIView<RCTComponent> *view = viewRegistry[tag];
+      RCTUIView<RCTComponent> *view = viewRegistry[tag]; // TODO(macOS ISS#3536887)
       [view didSetProps:[tags objectForKey:tag]];
     }
   }];
@@ -1420,7 +1420,7 @@ RCT_EXPORT_METHOD(takeSnapshot:(id /* NSString or NSNumber */)target
       size = view.bounds.size;
     }
     UIGraphicsBeginImageContextWithOptions(size, NO, 0);
-    BOOL success = RCTUIViewDrawViewHierarchyInRectAfterScreenUpdates(view, (CGRect){CGPointZero, size}, YES); // TODO(macOS ISS#2323203)
+    BOOL success = RCTUIViewDrawViewHierarchyInRectAfterScreenUpdates(view, (CGRect){CGPointZero, size}, YES); // TODO(macOS ISS#2323203) and TODO(macOS ISS#3536887)
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
 

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -43,7 +43,7 @@
 @property (nonatomic, assign) RCTPointerEvents pointerEvents;
 
 + (void)autoAdjustInsetsForView:(RCTUIView<RCTAutoInsetsProtocol> *)parentView
-                 withScrollView:(UIScrollView *)scrollView
+                 withScrollView:(RCTUIScrollView *)scrollView
                    updateOffset:(BOOL)updateOffset;
 
 #if !TARGET_OS_OSX // TODO(macOS ISS#2323203)

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -15,7 +15,7 @@
 
 @class RCTView;
 
-@interface RCTView : RCTUIView
+@interface RCTView : RCTUIView // TODO(macOS ISS#3536887)
 
 // [TODO(OSS Candidate ISS#2710739)
 - (BOOL)becomeFirstResponder;
@@ -42,8 +42,8 @@
  */
 @property (nonatomic, assign) RCTPointerEvents pointerEvents;
 
-+ (void)autoAdjustInsetsForView:(RCTUIView<RCTAutoInsetsProtocol> *)parentView
-                 withScrollView:(RCTUIScrollView *)scrollView
++ (void)autoAdjustInsetsForView:(RCTUIView<RCTAutoInsetsProtocol> *)parentView // TODO(macOS ISS#3536887)
+                 withScrollView:(RCTUIScrollView *)scrollView // TODO(macOS ISS#3536887) and TODO(macOS ISS#3536887)
                    updateOffset:(BOOL)updateOffset;
 
 #if !TARGET_OS_OSX // TODO(macOS ISS#2323203)

--- a/React/Views/RCTView.h
+++ b/React/Views/RCTView.h
@@ -15,7 +15,7 @@
 
 @class RCTView;
 
-@interface RCTView : UIView
+@interface RCTView : RCTUIView
 
 // [TODO(OSS Candidate ISS#2710739)
 - (BOOL)becomeFirstResponder;
@@ -42,7 +42,7 @@
  */
 @property (nonatomic, assign) RCTPointerEvents pointerEvents;
 
-+ (void)autoAdjustInsetsForView:(UIView<RCTAutoInsetsProtocol> *)parentView
++ (void)autoAdjustInsetsForView:(RCTUIView<RCTAutoInsetsProtocol> *)parentView
                  withScrollView:(UIScrollView *)scrollView
                    updateOffset:(BOOL)updateOffset;
 

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -24,7 +24,7 @@
   // this does is forward message to our subviews,
   // in case any of those do support it
 
-  for (RCTUIView *subview in self.subviews) {
+  for (RCTUIView *subview in self.subviews) { // TODO(macOS ISS#3536887)
     [subview react_remountAllSubviews];
   }
 }
@@ -35,7 +35,7 @@
   // we do support clipsToBounds, so if that's enabled
   // we'll update the clipping
 
-  if (RCTUIViewSetClipsToBounds(self) && self.subviews.count > 0) { // TODO(macOS ISS#2323203)
+  if (RCTUIViewSetClipsToBounds(self) && self.subviews.count > 0) { // TODO(macOS ISS#2323203) and TODO(macOS ISS#3536887)
     clipRect = [clipView convertRect:clipRect toView:self];
     clipRect = CGRectIntersection(clipRect, self.bounds);
     clipView = self;
@@ -45,7 +45,7 @@
   // this does is forward message to our subviews,
   // in case any of those do support it
 
-  for (RCTUIView *subview in self.subviews) {
+  for (RCTUIView *subview in self.subviews) { // TODO(macOS ISS#3536887)
     [subview react_updateClippedSubviewsWithClipRect:clipRect relativeToView:clipView];
   }
 }
@@ -57,7 +57,7 @@
   CGRect clipRect = self.bounds;
   // We will only look for a clipping view up the view hierarchy until we hit the root view.
   while (testView) {
-    if (RCTUIViewSetClipsToBounds(testView)) { // TODO(macOS ISS#2323203)
+    if (RCTUIViewSetClipsToBounds(testView)) { // TODO(macOS ISS#2323203) and TODO(macOS ISS#3536887)
       if (clipView) {
         CGRect testRect = [clipView convertRect:clipRect toView:testView];
         if (!CGRectContainsRect(testView.bounds, testRect)) {
@@ -83,10 +83,10 @@
 
 @end
 
-static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view)
+static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // TODO(macOS ISS#3536887)
 {
   NSMutableString *str = [NSMutableString stringWithString:@""];
-  for (RCTUIView *subview in view.subviews) {
+  for (RCTUIView *subview in view.subviews) { // TODO(macOS ISS#3536887)
     NSString *label = subview.accessibilityLabel;
     if (!label) {
       label = RCTRecursiveAccessibilityLabel(subview);
@@ -230,7 +230,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   BOOL needsHitSubview = !(_pointerEvents == RCTPointerEventsNone || _pointerEvents == RCTPointerEventsBoxOnly);
   if (needsHitSubview && (![self clipsToBounds] || isPointInside)) {
     // Take z-index into account when calculating the touch target.
-    NSArray<RCTUIView *> *sortedSubviews = [self reactZIndexSortedSubviews];
+    NSArray<RCTUIView *> *sortedSubviews = [self reactZIndexSortedSubviews]; // TODO(macOS ISS#3536887)
 
     // The default behaviour of UIKit is that if a view does not contain a point,
     // then no subviews will be returned from hit testing, even if they contain
@@ -238,7 +238,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
     // the strict containment policy (i.e., UIKit guarantees that every ancestor
     // of the hit view will return YES from -pointInside:withEvent:). See:
     //  - https://developer.apple.com/library/ios/qa/qa2013/qa1812.html
-    for (RCTUIView *subview in [sortedSubviews reverseObjectEnumerator]) {
+    for (RCTUIView *subview in [sortedSubviews reverseObjectEnumerator]) { // TODO(macOS ISS#3536887)
       CGPoint pointForHitTest = CGPointZero; // [TODO(macOS ISS#2323203)
 #if TARGET_OS_OSX
       if ([subview isKindOfClass:[RCTView class]]) {
@@ -249,7 +249,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 #else
       pointForHitTest = [subview convertPoint:point fromView:self];
 #endif
-      hitSubview = RCTUIViewHitTestWithEvent(subview, pointForHitTest, event); // ]TODO(macOS ISS#2323203)
+      hitSubview = RCTUIViewHitTestWithEvent(subview, pointForHitTest, event); // ]TODO(macOS ISS#2323203) and TODO(macOS ISS#3536887)
       if (hitSubview != nil) {
         break;
       }
@@ -417,8 +417,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 
 #pragma mark - Statics for dealing with layoutGuides
 
-+ (void)autoAdjustInsetsForView:(RCTUIView<RCTAutoInsetsProtocol> *)parentView
-                 withScrollView:(RCTUIScrollView *)scrollView
++ (void)autoAdjustInsetsForView:(RCTUIView<RCTAutoInsetsProtocol> *)parentView // TODO(macOS ISS#3536887)
+                 withScrollView:(RCTUIScrollView *)scrollView // TODO(macOS ISS#3536887)
                    updateOffset:(BOOL)updateOffset
 {
   UIEdgeInsets baseInset = parentView.contentInset;
@@ -472,7 +472,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 - (void)react_remountAllSubviews
 {
   if (_removeClippedSubviews) {
-    for (RCTUIView *view in self.reactSubviews) {
+    for (RCTUIView *view in self.reactSubviews) { // TODO(macOS ISS#3536887)
       if (view.superview != self) {
         [self addSubview:view];
         [view react_remountAllSubviews];
@@ -511,7 +511,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   clipView = self;
 
   // Mount / unmount views
-  for (RCTUIView *view in self.reactSubviews) {
+  for (RCTUIView *view in self.reactSubviews) { // TODO(macOS ISS#3536887)
     if (!CGSizeEqualToSize(CGRectIntersection(clipRect, view.frame).size, CGSizeZero)) {
       // View is at least partially visible, so remount it if unmounted
       [self addSubview:view];

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -35,7 +35,7 @@
   // we do support clipsToBounds, so if that's enabled
   // we'll update the clipping
 
-  if (UIViewSetClipsToBounds(self) && self.subviews.count > 0) { // TODO(macOS ISS#2323203)
+  if (RCTUIViewSetClipsToBounds(self) && self.subviews.count > 0) { // TODO(macOS ISS#2323203)
     clipRect = [clipView convertRect:clipRect toView:self];
     clipRect = CGRectIntersection(clipRect, self.bounds);
     clipView = self;
@@ -57,7 +57,7 @@
   CGRect clipRect = self.bounds;
   // We will only look for a clipping view up the view hierarchy until we hit the root view.
   while (testView) {
-    if (UIViewSetClipsToBounds(testView)) { // TODO(macOS ISS#2323203)
+    if (RCTUIViewSetClipsToBounds(testView)) { // TODO(macOS ISS#2323203)
       if (clipView) {
         CGRect testRect = [clipView convertRect:clipRect toView:testView];
         if (!CGRectContainsRect(testView.bounds, testRect)) {
@@ -249,7 +249,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 #else
       pointForHitTest = [subview convertPoint:point fromView:self];
 #endif
-      hitSubview = UIViewHitTestWithEvent(subview, pointForHitTest, event); // ]TODO(macOS ISS#2323203)
+      hitSubview = RCTUIViewHitTestWithEvent(subview, pointForHitTest, event); // ]TODO(macOS ISS#2323203)
       if (hitSubview != nil) {
         break;
       }

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -24,7 +24,7 @@
   // this does is forward message to our subviews,
   // in case any of those do support it
 
-  for (UIView *subview in self.subviews) {
+  for (RCTUIView *subview in self.subviews) {
     [subview react_remountAllSubviews];
   }
 }
@@ -45,7 +45,7 @@
   // this does is forward message to our subviews,
   // in case any of those do support it
 
-  for (UIView *subview in self.subviews) {
+  for (RCTUIView *subview in self.subviews) {
     [subview react_updateClippedSubviewsWithClipRect:clipRect relativeToView:clipView];
   }
 }
@@ -83,10 +83,10 @@
 
 @end
 
-static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
+static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view)
 {
   NSMutableString *str = [NSMutableString stringWithString:@""];
-  for (UIView *subview in view.subviews) {
+  for (RCTUIView *subview in view.subviews) {
     NSString *label = subview.accessibilityLabel;
     if (!label) {
       label = RCTRecursiveAccessibilityLabel(subview);
@@ -230,7 +230,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   BOOL needsHitSubview = !(_pointerEvents == RCTPointerEventsNone || _pointerEvents == RCTPointerEventsBoxOnly);
   if (needsHitSubview && (![self clipsToBounds] || isPointInside)) {
     // Take z-index into account when calculating the touch target.
-    NSArray<UIView *> *sortedSubviews = [self reactZIndexSortedSubviews];
+    NSArray<RCTUIView *> *sortedSubviews = [self reactZIndexSortedSubviews];
 
     // The default behaviour of UIKit is that if a view does not contain a point,
     // then no subviews will be returned from hit testing, even if they contain
@@ -238,7 +238,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
     // the strict containment policy (i.e., UIKit guarantees that every ancestor
     // of the hit view will return YES from -pointInside:withEvent:). See:
     //  - https://developer.apple.com/library/ios/qa/qa2013/qa1812.html
-    for (UIView *subview in [sortedSubviews reverseObjectEnumerator]) {
+    for (RCTUIView *subview in [sortedSubviews reverseObjectEnumerator]) {
       CGPoint pointForHitTest = CGPointZero; // [TODO(macOS ISS#2323203)
 #if TARGET_OS_OSX
       if ([subview isKindOfClass:[RCTView class]]) {
@@ -417,7 +417,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 
 #pragma mark - Statics for dealing with layoutGuides
 
-+ (void)autoAdjustInsetsForView:(UIView<RCTAutoInsetsProtocol> *)parentView
++ (void)autoAdjustInsetsForView:(RCTUIView<RCTAutoInsetsProtocol> *)parentView
                  withScrollView:(UIScrollView *)scrollView
                    updateOffset:(BOOL)updateOffset
 {
@@ -472,7 +472,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 - (void)react_remountAllSubviews
 {
   if (_removeClippedSubviews) {
-    for (UIView *view in self.reactSubviews) {
+    for (RCTUIView *view in self.reactSubviews) {
       if (view.superview != self) {
         [self addSubview:view];
         [view react_remountAllSubviews];
@@ -511,7 +511,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
   clipView = self;
 
   // Mount / unmount views
-  for (UIView *view in self.reactSubviews) {
+  for (RCTUIView *view in self.reactSubviews) {
     if (!CGSizeEqualToSize(CGRectIntersection(clipRect, view.frame).size, CGSizeZero)) {
       // View is at least partially visible, so remount it if unmounted
       [self addSubview:view];

--- a/React/Views/RCTView.m
+++ b/React/Views/RCTView.m
@@ -418,7 +418,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:unused)
 #pragma mark - Statics for dealing with layoutGuides
 
 + (void)autoAdjustInsetsForView:(RCTUIView<RCTAutoInsetsProtocol> *)parentView
-                 withScrollView:(UIScrollView *)scrollView
+                 withScrollView:(RCTUIScrollView *)scrollView
                    updateOffset:(BOOL)updateOffset
 {
   UIEdgeInsets baseInset = parentView.contentInset;

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -24,7 +24,7 @@
 
 RCT_EXPORT_MODULE()
 
-- (UIView *)view
+- (RCTUIView *)view
 {
   RCTWebView *webView = [RCTWebView new];
   webView.delegate = self;

--- a/React/Views/RCTWebViewManager.m
+++ b/React/Views/RCTWebViewManager.m
@@ -24,7 +24,7 @@
 
 RCT_EXPORT_MODULE()
 
-- (RCTUIView *)view
+- (RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   RCTWebView *webView = [RCTWebView new];
   webView.delegate = self;

--- a/React/Views/ScrollView/RCTScrollView.h
+++ b/React/Views/ScrollView/RCTScrollView.h
@@ -30,7 +30,7 @@
  * efficiently since it will have already been computed by the off-main-thread
  * layout system.
  */
-@property (nonatomic, readonly) RCTUIView *contentView;
+@property (nonatomic, readonly) RCTUIView *contentView; // TODO(macOS ISS#3536887)
 
 /**
  * If the `contentSize` is not specified (or is specified as {0, 0}, then the
@@ -41,7 +41,7 @@
 /**
  * The underlying scrollView (TODO: can we remove this?)
  */
-@property (nonatomic, readonly) RCTUIScrollView *scrollView;
+@property (nonatomic, readonly) RCTUIScrollView *scrollView; // TODO(macOS ISS#3536887)
 
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 @property (nonatomic, assign) BOOL automaticallyAdjustContentInsets;

--- a/React/Views/ScrollView/RCTScrollView.h
+++ b/React/Views/ScrollView/RCTScrollView.h
@@ -30,7 +30,7 @@
  * efficiently since it will have already been computed by the off-main-thread
  * layout system.
  */
-@property (nonatomic, readonly) UIView *contentView;
+@property (nonatomic, readonly) RCTUIView *contentView;
 
 /**
  * If the `contentSize` is not specified (or is specified as {0, 0}, then the

--- a/React/Views/ScrollView/RCTScrollView.h
+++ b/React/Views/ScrollView/RCTScrollView.h
@@ -41,7 +41,7 @@
 /**
  * The underlying scrollView (TODO: can we remove this?)
  */
-@property (nonatomic, readonly) UIScrollView *scrollView;
+@property (nonatomic, readonly) RCTUIScrollView *scrollView;
 
 @property (nonatomic, assign) UIEdgeInsets contentInset;
 @property (nonatomic, assign) BOOL automaticallyAdjustContentInsets;

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -160,7 +160,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
  */
 @interface RCTCustomScrollView :
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
-  UIScrollView
+  RCTUIScrollView
 #else
   UIScrollView<UIGestureRecognizerDelegate>
 #endif // ]TODO(macOS ISS#2323203)

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -324,7 +324,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
  * In order to have this called, you must have delaysContentTouches set to NO
  * (which is the not the `UIKit` default).
  */
-- (BOOL)touchesShouldCancelInContentView:(__unused UIView *)view
+- (BOOL)touchesShouldCancelInContentView:(__unused RCTUIView *)view
 {
   //TODO: shouldn't this call super if _shouldDisableScrollInteraction returns NO?
   return ![self _shouldDisableScrollInteraction];
@@ -338,9 +338,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
  */
 - (void)setContentOffset:(CGPoint)contentOffset
 {
-  UIView *contentView = nil;
+  RCTUIView *contentView = nil;
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
-  contentView = (UIView *) self.documentView;	// NSScrollView's documentView must be of type UIView/RCTView
+  contentView = (RCTUIView *) self.documentView;	// NSScrollView's documentView must be of type UIView/RCTView
 #else
   contentView = [self contentView];
 #endif // ]TODO(macOS ISS#2323203)
@@ -455,7 +455,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 {
   RCTEventDispatcher *_eventDispatcher;
   CGRect _prevFirstVisibleFrame;
-  __weak UIView *_firstVisibleView;
+  __weak RCTUIView *_firstVisibleView;
   RCTCustomScrollView *_scrollView;
 #if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
   UIView *_contentView;
@@ -540,7 +540,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   }
 }
 
-- (UIView *)contentView
+- (RCTUIView *)contentView
 {
   return _scrollView.documentView;
 }
@@ -591,7 +591,7 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(RCTPlatformVie
   // Does nothing
 }
 
-- (void)insertReactSubview:(UIView *)view atIndex:(NSInteger)atIndex
+- (void)insertReactSubview:(RCTUIView *)view atIndex:(NSInteger)atIndex
 {
   [super insertReactSubview:view atIndex:atIndex];
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
@@ -617,7 +617,7 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(RCTPlatformVie
 #endif // TODO(macOS ISS#2323203)
 }
 
-- (void)removeReactSubview:(UIView *)subview
+- (void)removeReactSubview:(RCTUIView *)subview
 {
   [super removeReactSubview:subview];
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
@@ -1272,13 +1272,13 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
 - (void)uiManagerWillPerformMounting:(RCTUIManager *)manager
 {
   RCTAssertUIManagerQueue();
-  [manager prependUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+  [manager prependUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
     BOOL horz = [self isHorizontal:self->_scrollView];
     NSUInteger minIdx = [self->_maintainVisibleContentPosition[@"minIndexForVisible"] integerValue];
     for (NSUInteger ii = minIdx; ii < self.contentView.subviews.count; ++ii) { // TODO(OSS Candidate ISS#2710739) use property instead of ivar for mac
       // Find the first entirely visible view. This must be done after we update the content offset
       // or it will tend to grab rows that were made visible by the shift in position
-      UIView *subview = self.contentView.subviews[ii]; // TODO(OSS Candidate ISS#2710739) use property instead of ivar for mac
+      RCTUIView *subview = self.contentView.subviews[ii]; // TODO(OSS Candidate ISS#2710739) use property instead of ivar for mac
       if ((horz
            ? subview.frame.origin.x >= self->_scrollView.contentOffset.x
            : subview.frame.origin.y >= self->_scrollView.contentOffset.y) ||
@@ -1289,7 +1289,7 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
       }
     }
   }];
-  [manager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+  [manager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
     if (self->_maintainVisibleContentPosition == nil) {
       return; // The prop might have changed in the previous UIBlocks, so need to abort here.
     }

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -225,7 +225,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   // the hierarchy on rare occasions.
   RCTPlatformView *JSResponder = [RCTUIManager JSResponder]; // TODO(macOS ISS#2323203)
   if (JSResponder && JSResponder != self.superview) {
-    BOOL superviewHasResponder = UIViewIsDescendantOfView(self, JSResponder); // TODO(macOS ISS#2323203)
+    BOOL superviewHasResponder = RCTUIViewIsDescendantOfView(self, JSResponder); // TODO(macOS ISS#2323203)
     return superviewHasResponder;
   }
   return NO;

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -160,7 +160,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
  */
 @interface RCTCustomScrollView :
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
-  RCTUIScrollView
+  RCTUIScrollView // TODO(macOS ISS#3536887)
 #else
   UIScrollView<UIGestureRecognizerDelegate>
 #endif // ]TODO(macOS ISS#2323203)
@@ -225,7 +225,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   // the hierarchy on rare occasions.
   RCTPlatformView *JSResponder = [RCTUIManager JSResponder]; // TODO(macOS ISS#2323203)
   if (JSResponder && JSResponder != self.superview) {
-    BOOL superviewHasResponder = RCTUIViewIsDescendantOfView(self, JSResponder); // TODO(macOS ISS#2323203)
+    BOOL superviewHasResponder = RCTUIViewIsDescendantOfView(self, JSResponder); // TODO(macOS ISS#2323203) and TODO(macOS ISS#3536887)
     return superviewHasResponder;
   }
   return NO;
@@ -324,7 +324,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
  * In order to have this called, you must have delaysContentTouches set to NO
  * (which is the not the `UIKit` default).
  */
-- (BOOL)touchesShouldCancelInContentView:(__unused RCTUIView *)view
+- (BOOL)touchesShouldCancelInContentView:(__unused RCTUIView *)view // TODO(macOS ISS#3536887)
 {
   //TODO: shouldn't this call super if _shouldDisableScrollInteraction returns NO?
   return ![self _shouldDisableScrollInteraction];
@@ -338,9 +338,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
  */
 - (void)setContentOffset:(CGPoint)contentOffset
 {
-  RCTUIView *contentView = nil;
+  RCTUIView *contentView = nil; // TODO(macOS ISS#3536887)
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
-  contentView = (RCTUIView *) self.documentView;	// NSScrollView's documentView must be of type UIView/RCTView
+  contentView = (RCTUIView *) self.documentView;	// NSScrollView's documentView must be of type UIView/RCTView and TODO(macOS ISS#3536887)
 #else
   contentView = [self contentView];
 #endif // ]TODO(macOS ISS#2323203)
@@ -455,7 +455,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 {
   RCTEventDispatcher *_eventDispatcher;
   CGRect _prevFirstVisibleFrame;
-  __weak RCTUIView *_firstVisibleView;
+  __weak RCTUIView *_firstVisibleView; // TODO(macOS ISS#3536887)
   RCTCustomScrollView *_scrollView;
 #if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
   UIView *_contentView;
@@ -540,7 +540,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
   }
 }
 
-- (RCTUIView *)contentView
+- (RCTUIView *)contentView // TODO(macOS ISS#3536887)
 {
   return _scrollView.documentView;
 }
@@ -591,7 +591,7 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(RCTPlatformVie
   // Does nothing
 }
 
-- (void)insertReactSubview:(RCTUIView *)view atIndex:(NSInteger)atIndex
+- (void)insertReactSubview:(RCTUIView *)view atIndex:(NSInteger)atIndex // TODO(macOS ISS#3536887)
 {
   [super insertReactSubview:view atIndex:atIndex];
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
@@ -617,7 +617,7 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(RCTPlatformVie
 #endif // TODO(macOS ISS#2323203)
 }
 
-- (void)removeReactSubview:(RCTUIView *)subview
+- (void)removeReactSubview:(RCTUIView *)subview // TODO(macOS ISS#3536887)
 {
   [super removeReactSubview:subview];
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)
@@ -1272,13 +1272,13 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
 - (void)uiManagerWillPerformMounting:(RCTUIManager *)manager
 {
   RCTAssertUIManagerQueue();
-  [manager prependUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+  [manager prependUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
     BOOL horz = [self isHorizontal:self->_scrollView];
     NSUInteger minIdx = [self->_maintainVisibleContentPosition[@"minIndexForVisible"] integerValue];
     for (NSUInteger ii = minIdx; ii < self.contentView.subviews.count; ++ii) { // TODO(OSS Candidate ISS#2710739) use property instead of ivar for mac
       // Find the first entirely visible view. This must be done after we update the content offset
       // or it will tend to grab rows that were made visible by the shift in position
-      RCTUIView *subview = self.contentView.subviews[ii]; // TODO(OSS Candidate ISS#2710739) use property instead of ivar for mac
+      RCTUIView *subview = self.contentView.subviews[ii]; // TODO(OSS Candidate ISS#2710739) use property instead of ivar for mac and TODO(macOS ISS#3536887)
       if ((horz
            ? subview.frame.origin.x >= self->_scrollView.contentOffset.x
            : subview.frame.origin.y >= self->_scrollView.contentOffset.y) ||
@@ -1289,7 +1289,7 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
       }
     }
   }];
-  [manager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) {
+  [manager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry) { // TODO(macOS ISS#3536887)
     if (self->_maintainVisibleContentPosition == nil) {
       return; // The prop might have changed in the previous UIBlocks, so need to abort here.
     }

--- a/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/React/Views/ScrollView/RCTScrollViewManager.m
@@ -158,8 +158,8 @@ RCT_EXPORT_METHOD(scrollTo:(nonnull NSNumber *)reactTag
                   animated:(BOOL)animated)
 {
   [self.bridge.uiManager addUIBlock:
-   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry){
-    UIView *view = viewRegistry[reactTag];
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry){
+    RCTUIView *view = viewRegistry[reactTag];
     if ([view conformsToProtocol:@protocol(RCTScrollableProtocol)]) {
       [(id<RCTScrollableProtocol>)view scrollToOffset:(CGPoint){x, y} animated:animated];
     } else {
@@ -173,8 +173,8 @@ RCT_EXPORT_METHOD(scrollToEnd:(nonnull NSNumber *)reactTag
                   animated:(BOOL)animated)
 {
   [self.bridge.uiManager addUIBlock:
-   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry){
-     UIView *view = viewRegistry[reactTag];
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry){
+     RCTUIView *view = viewRegistry[reactTag];
      if ([view conformsToProtocol:@protocol(RCTScrollableProtocol)]) {
        [(id<RCTScrollableProtocol>)view scrollToEnd:animated];
      } else {
@@ -189,8 +189,8 @@ RCT_EXPORT_METHOD(zoomToRect:(nonnull NSNumber *)reactTag
                   animated:(BOOL)animated)
 {
   [self.bridge.uiManager addUIBlock:
-   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry){
-    UIView *view = viewRegistry[reactTag];
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry){
+    RCTUIView *view = viewRegistry[reactTag];
     if ([view conformsToProtocol:@protocol(RCTScrollableProtocol)]) {
       [(id<RCTScrollableProtocol>)view zoomToRect:rect animated:animated];
     } else {

--- a/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/React/Views/ScrollView/RCTScrollViewManager.m
@@ -158,8 +158,8 @@ RCT_EXPORT_METHOD(scrollTo:(nonnull NSNumber *)reactTag
                   animated:(BOOL)animated)
 {
   [self.bridge.uiManager addUIBlock:
-   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry){
-    RCTUIView *view = viewRegistry[reactTag];
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry){ // TODO(macOS ISS#3536887)
+    RCTUIView *view = viewRegistry[reactTag]; // TODO(macOS ISS#3536887)
     if ([view conformsToProtocol:@protocol(RCTScrollableProtocol)]) {
       [(id<RCTScrollableProtocol>)view scrollToOffset:(CGPoint){x, y} animated:animated];
     } else {
@@ -173,8 +173,8 @@ RCT_EXPORT_METHOD(scrollToEnd:(nonnull NSNumber *)reactTag
                   animated:(BOOL)animated)
 {
   [self.bridge.uiManager addUIBlock:
-   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry){
-     RCTUIView *view = viewRegistry[reactTag];
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry){ // TODO(macOS ISS#3536887)
+     RCTUIView *view = viewRegistry[reactTag]; // TODO(macOS ISS#3536887)
      if ([view conformsToProtocol:@protocol(RCTScrollableProtocol)]) {
        [(id<RCTScrollableProtocol>)view scrollToEnd:animated];
      } else {
@@ -189,8 +189,8 @@ RCT_EXPORT_METHOD(zoomToRect:(nonnull NSNumber *)reactTag
                   animated:(BOOL)animated)
 {
   [self.bridge.uiManager addUIBlock:
-   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry){
-    RCTUIView *view = viewRegistry[reactTag];
+   ^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RCTUIView *> *viewRegistry){ // TODO(macOS ISS#3536887)
+    RCTUIView *view = viewRegistry[reactTag]; // TODO(macOS ISS#3536887)
     if ([view conformsToProtocol:@protocol(RCTScrollableProtocol)]) {
       [(id<RCTScrollableProtocol>)view zoomToRect:rect animated:animated];
     } else {

--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -61,7 +61,7 @@
 
 - (NSNumber *)reactTagAtPoint:(CGPoint)point
 {
-  RCTPlatformView *view = UIViewHitTestWithEvent(self, point, nil); // TODO(macOS ISS#2323203)
+  RCTPlatformView *view = RCTUIViewHitTestWithEvent(self, point, nil); // TODO(macOS ISS#2323203)
   while (view && !view.reactTag) {
     view = view.superview;
   }

--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -164,13 +164,13 @@
 {
   // Check if sorting is required - in most cases it won't be.
   BOOL sortingRequired = NO;
-  for (UIView *subview in self.subviews) {
+  for (RCTUIView *subview in self.subviews) {
     if (subview.reactZIndex != 0) {
       sortingRequired = YES;
       break;
     }
   }
-  return sortingRequired ? [self.reactSubviews sortedArrayUsingComparator:^NSComparisonResult(UIView *a, UIView *b) {
+  return sortingRequired ? [self.reactSubviews sortedArrayUsingComparator:^NSComparisonResult(RCTUIView *a, RCTUIView *b) {
     if (a.reactZIndex > b.reactZIndex) {
       return NSOrderedDescending;
     } else {

--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -61,7 +61,7 @@
 
 - (NSNumber *)reactTagAtPoint:(CGPoint)point
 {
-  RCTPlatformView *view = RCTUIViewHitTestWithEvent(self, point, nil); // TODO(macOS ISS#2323203)
+  RCTPlatformView *view = RCTUIViewHitTestWithEvent(self, point, nil); // TODO(macOS ISS#2323203) and TODO(macOS ISS#3536887)
   while (view && !view.reactTag) {
     view = view.superview;
   }
@@ -164,13 +164,13 @@
 {
   // Check if sorting is required - in most cases it won't be.
   BOOL sortingRequired = NO;
-  for (RCTUIView *subview in self.subviews) {
+  for (RCTUIView *subview in self.subviews) { // TODO(macOS ISS#3536887)
     if (subview.reactZIndex != 0) {
       sortingRequired = YES;
       break;
     }
   }
-  return sortingRequired ? [self.reactSubviews sortedArrayUsingComparator:^NSComparisonResult(RCTUIView *a, RCTUIView *b) {
+  return sortingRequired ? [self.reactSubviews sortedArrayUsingComparator:^NSComparisonResult(RCTUIView *a, RCTUIView *b) { // TODO(macOS ISS#3536887)
     if (a.reactZIndex > b.reactZIndex) {
       return NSOrderedDescending;
     } else {


### PR DESCRIPTION

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

In Xcode 11 Apple introduced the new Catalyst feature allowing iPadOS (and UIKit) apps to run on macOS. The main thread checker relies on the presence of a class named `UIView` to determine whether a macOS app is running in standard AppKit mode or in Catalyst/UIKit mode. Our macOS port of React Native defines a class named UIView as a subclass of NSView which confuses the main thread checker and causes all apps that link in React Native with Xcode 11 to crash on boot.

Let's switch from using `UIView` as our "cross-platform" view and rename it to `RCTUIView` so as to avoid conflicts with Apple's naming. On iOS we can use a simple #define and on macOS we'll repurpose our existing NSView subclass.

Do the same for our NSScrollView subclass named `UIScrollView`.

Fix up the fallout by switching "cross-platform" usages of UIView and UIScrollView to RCTUIView and RCTUIScrollView.

#### Focus areas to test

Sanity pass through various controls touched in RNTester. This is more of a mechanical change so successful compilation should imply that our rename was successful.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/127)