### PR TITLE
Added 'list' and 'listitem' accessibilityRoles

### DIFF
--- a/Libraries/Components/View/ViewAccessibility.js
+++ b/Libraries/Components/View/ViewAccessibility.js
@@ -74,7 +74,9 @@ export type AccessibilityRole =
   | 'tab'
   | 'tablist'
   | 'timer'
-  | 'toolbar';
+  | 'toolbar'
+  | 'list' // RNW-only
+  | 'listitem'; // RNW-only
 
 export type AccessibilityState =
   | 'selected'
@@ -145,6 +147,8 @@ module.exports = {
     'tablist',
     'timer',
     'toolbar',
+    'list', // RNW-only
+    'listitem', // RNW-only
   ],
   AccessibilityStates: [
     'selected',

--- a/Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js
+++ b/Libraries/DeprecatedPropTypes/DeprecatedViewAccessibility.js
@@ -65,6 +65,8 @@ module.exports = {
     'tablist',
     'timer',
     'toolbar',
+    'list', // RNW-only
+    'listitem', // RNW-only
   ],
   // This must be kept in sync with the AccessibilityStatesMask in RCTViewManager.m
   DeprecatedAccessibilityStates: [


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

Adding RNW accessibility extensions for lists, as per https://github.com/ReactWindows/discussions-and-proposals/blob/master/proposals/0000-accessibilityapis-lists.md

* Adding the `list` and `listitem` accessibilityRoles values

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/129)