### PR TITLE
Update cmake build for jsi file moves

### DIFF
--- a/ReactCommon/CMakeLists.txt
+++ b/ReactCommon/CMakeLists.txt
@@ -12,8 +12,8 @@ set(SOURCES
 	cxxreact/Platform.cpp
 	cxxreact/RAMBundleRegistry.cpp
 	cxxreact/ReactMarker.cpp
-	jsi/jsi.cpp
-	jsi/JSIDynamic.cpp
+	jsi/jsi/jsi.cpp
+	jsi/jsi/JSIDynamic.cpp
 	jsiexecutor/jsireact/JSIExecutor.cpp
 	jsiexecutor/jsireact/JSINativeModules.cpp
 	yoga/yoga/Utils.cpp
@@ -64,6 +64,8 @@ endif(ANDROID)
 target_include_directories(reactcommon PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/yoga")
 
 target_include_directories(reactcommon PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/jsiexecutor")
+
+target_include_directories(reactcommon PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/jsi")
 
 target_link_libraries(reactcommon PUBLIC folly)
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

Update CMake build logic for new jsi file location


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/130)