### PR TITLE
Replace unique_ptrs in ScriptStore.h with shared_ptrs.

### DIFF
--- a/ReactCommon/jsi/jsi/ScriptStore.h
+++ b/ReactCommon/jsi/jsi/ScriptStore.h
@@ -11,7 +11,7 @@ using ScriptVersion_t = uint64_t;  // It shouldbe std::optional<uint64_t> once w
 using JSRuntimeVersion_t = uint64_t; // 0 implies version can't be computed. We assert whenever that happens.
 
 struct VersionedBuffer {
-  std::unique_ptr<const facebook::jsi::Buffer> buffer;
+  std::shared_ptr<const facebook::jsi::Buffer> buffer;
   ScriptVersion_t version;
 };
 
@@ -34,7 +34,7 @@ struct PreparedScriptStore {
   // RuntimeSignature : Javascript engine type and version
   // prepareTag : Custom tag to uniquely identify JS engine specific preparation schemes. It is usually useful while experimentation and can be null.
   // It is possible that no prepared script is available for a given script & runtime signature. This method should null if so
-  virtual std::unique_ptr<const facebook::jsi::Buffer> tryGetPreparedScript(
+  virtual std::shared_ptr<const facebook::jsi::Buffer> tryGetPreparedScript(
     const ScriptSignature& scriptSignature,
     const JSRuntimeSignature& runtimeSignature,
     const char* prepareTag // Optional tag. For e.g. eagerly evaluated vs lazy cache.


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

Recently, we brought in an updated version of JSI through commit db6d02f4fda111c926390b0f1afad1765abb87a9. In the new version of JSI, jsi::Runtime::evaluateJavaScript takes in a shared_ptr instead of a unique_ptr. As a result, we need to refresh our ScriptStore interfaces accordingly.

#### Focus areas to test

N/A


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/132)