### PR TITLE
apple: fix timing issue crash in executeApplicationScript

### DIFF
--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -1302,19 +1302,21 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithBundleURL:(__unused NSURL *)bundleUR
     [[NSNotificationCenter defaultCenter]
       postNotificationName:RCTJavaScriptWillStartExecutingNotification
       object:self->_parentBridge userInfo:@{@"bridge": self}];
+    auto reactInstance = self->_reactInstance;
     if (isRAMBundle(script)) {
       [self->_performanceLogger markStartForTag:RCTPLRAMBundleLoad];
       auto ramBundle = std::make_unique<JSIndexedRAMBundle>(sourceUrlStr.UTF8String);
       std::unique_ptr<const JSBigString> scriptStr = ramBundle->getStartupCode();
       [self->_performanceLogger markStopForTag:RCTPLRAMBundleLoad];
       [self->_performanceLogger setValue:scriptStr->size() forTag:RCTPLRAMStartupCodeSize];
-      if (self->_reactInstance) {
+      if (reactInstance) {
         auto registry = RAMBundleRegistry::multipleBundlesRegistry(std::move(ramBundle), JSIndexedRAMBundle::buildFactory());
-        self->_reactInstance->loadRAMBundle(std::move(registry), std::move(scriptStr),
+        reactInstance->loadRAMBundle(std::move(registry), std::move(scriptStr),
                                             sourceUrlStr.UTF8String, !async);
       }
-    } else if (self->_reactInstance) {
-      self->_reactInstance->loadScriptFromString(std::make_unique<NSDataBigString>(script), 0,
+    } else if (reactInstance) {
+      // TODO(OSS Candidate ISS#2710739) - use local reactInstance, instance can be null'd while constructing NSDataBigString
+      reactInstance->loadScriptFromString(std::make_unique<NSDataBigString>(script), 0,
                                                  sourceUrlStr.UTF8String, !async, ""); // TODO(OSS Candidate ISS#2710739)
     } else {
       std::string methodName = async ? "loadApplicationScript" : "loadApplicationScriptSync";

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -1302,6 +1302,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithBundleURL:(__unused NSURL *)bundleUR
     [[NSNotificationCenter defaultCenter]
       postNotificationName:RCTJavaScriptWillStartExecutingNotification
       object:self->_parentBridge userInfo:@{@"bridge": self}];
+    // TODO(OSS Candidate ISS#2710739) - use local reactInstance, instance can be null'd while constructing NSDataBigString
     auto reactInstance = self->_reactInstance;
     if (isRAMBundle(script)) {
       [self->_performanceLogger markStartForTag:RCTPLRAMBundleLoad];
@@ -1315,7 +1316,6 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithBundleURL:(__unused NSURL *)bundleUR
                                             sourceUrlStr.UTF8String, !async);
       }
     } else if (reactInstance) {
-      // TODO(OSS Candidate ISS#2710739) - use local reactInstance, instance can be null'd while constructing NSDataBigString
       reactInstance->loadScriptFromString(std::make_unique<NSDataBigString>(script), 0,
                                                  sourceUrlStr.UTF8String, !async, ""); // TODO(OSS Candidate ISS#2710739)
     } else {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

#### Description of changes

We've for a long time been running into a crash on startup in dev/debugging scenarios on mac with executeApplicationScript.  The problem is that a null check is done on self->_reactInstance, then a large object is created, then self->_reactInstance is used.  A parallel thread reset's _reactInstance if when bridge settings are reset (which happens when the remote js debugger is auto-enabled).  It may be that the debug build and/or the large size of our debug bundles (20mb in one case, 34 in another) make it more likely.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/134)