### PR TITLE
Remove accessibility props that are no longer valid.

### DIFF
--- a/RNTester/js/RNTesterExampleList.js
+++ b/RNTester/js/RNTesterExampleList.js
@@ -54,8 +54,6 @@ class RowComponent extends React.PureComponent<{
       <TouchableHighlight
         onShowUnderlay={this.props.onShowUnderlay}
         onHideUnderlay={this.props.onHideUnderlay}
-        accessibilityTraits={['group']}
-        accessibilityLabel={item.module.title}
         onAccessibilityTap={this._onPress}
         acceptsKeyboardFocus={false}
         onPress={this._onPress}>


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

The `accessibilityTraits` and `accessibilityLabel` props no longer exist in the official react-native code. I'm removing it to get rid of the errors during debugging of RNTester app.

#### Focus areas to test

(optional)

## Summary
Remove obsolete accessibility props in RNTesterExampleList.js


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/136)