### PR TITLE
Fix warning (treated as compilation error) in inc\folly\conv.h

### DIFF
--- a/Folly/folly/Conv.h
+++ b/Folly/folly/Conv.h
@@ -699,10 +699,11 @@ toAppend(
     case DoubleToStringConverter::FIXED:
       conv.ToFixed(value, int(numDigits), &builder);
       break;
-    default:
-      CHECK(mode == DoubleToStringConverter::PRECISION);
+    case DoubleToStringConverter::PRECISION:
       conv.ToPrecision(value, int(numDigits), &builder);
       break;
+    default:
+      std::abort();
   }
   const size_t length = size_t(builder.position());
   builder.Finalize();


### PR DESCRIPTION
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

While working in this space, I noticed that the compiler flags line 703 in conv.h as a warning (and so as an error):
officereact.uwp.0.59.0-vnext.87\inc\folly\conv.h(703) : error C2220: warning treated as error - no 'object' file generated
officereact.uwp.0.59.0-vnext.87\inc\folly\conv.h(703) : warning C4702: unreachable code

while trying to unpack an int using jsArgAsInt(args, 0), likely because the CHECK macro uses an inverse condition on its boolean, and that block of code isn't hittable, since the other 3 enum values already have switch..cases for them? I was able to fix it locally by changing the default to a "case DoubleToStringConverter::PRECISION:" and getting rid of the CHECK call there entirely. 

This change is just to make the fix more formal at the source of the warning/error, so that we don't get an error flagged when compiling whenever we sync ahead to this change.

#### Focus areas to test

Verified that build succeeded


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/139)