### PR TITLE
Fork the InspectorOverlay.js to avoid using Dimensions type.

### DIFF
--- a/Libraries/Inspector/InspectorOverlay.win32.js
+++ b/Libraries/Inspector/InspectorOverlay.win32.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const ElementBox = require('ElementBox');
+const React = require('React');
+const StyleSheet = require('StyleSheet');
+const UIManager = require('UIManager');
+const View = require('View');
+
+import type {PressEvent} from 'CoreEventTypes';
+import type {ViewStyleProp} from 'StyleSheet';
+
+type Inspected = $ReadOnly<{|
+  frame?: Object,
+  style?: ViewStyleProp,
+|}>;
+
+type Props = $ReadOnly<{|
+  inspected?: Inspected,
+  inspectedViewTag?: ?number,
+  onTouchViewTag: (tag: number, frame: Object, pointerY: number) => mixed,
+|}>;
+
+class InspectorOverlay extends React.Component<Props> {
+  findViewForTouchEvent = (e: PressEvent) => {
+    const {locationX, locationY} = e.nativeEvent.touches[0];
+    UIManager.findSubviewIn(
+      this.props.inspectedViewTag,
+      [locationX, locationY],
+      (nativeViewTag, left, top, width, height) => {
+        this.props.onTouchViewTag(
+          nativeViewTag,
+          {left, top, width, height},
+          locationY,
+        );
+      },
+    );
+  };
+
+  shouldSetResponser = (e: PressEvent): boolean => {
+    this.findViewForTouchEvent(e);
+    return true;
+  };
+
+  render() {
+    let content = null;
+    if (this.props.inspected) {
+      content = (
+        <ElementBox
+          frame={this.props.inspected.frame}
+          style={this.props.inspected.style}
+        />
+      );
+    }
+
+    return (
+      <View
+        onStartShouldSetResponder={this.shouldSetResponser}
+        onResponderMove={this.findViewForTouchEvent}
+        style={[styles.inspector, {height: "100%"}]}>
+        {content}
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  inspector: {
+    backgroundColor: 'transparent',
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    right: 0,
+  },
+});
+
+module.exports = InspectorOverlay;


### PR DESCRIPTION
## Summary

Add `InspectorOverlay.win32.js` to fork the `InspectorOverlay.js` file for win32 platform.

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

The current `InspectorOverlay.js` uses the `Dimensions` type, which is not supported on win32. I'm forking it and replace the usage of `Dimensions`. Instead of 

```{height: Dimensions.get('window').height}```

I do: 

```{height: '100%'}```

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/140)