### PR TITLE
Start transitioning CI to use github actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+
+  AndroidRNPR:
+    name: Android React Native PR
+
+    runs-on: windows-2016
+    
+    steps:
+    - uses: actions/checkout@v1
+      submodules: true
+
+    - run: npm install
+
+    - name: Setup Nuget.exe
+      uses: warrenbuckley/Setup-Nuget@v1
+
+    - name: NuGet restore
+      run: nuget.exe restore ReactAndroid/packages.config -PackagesDirectory packages/ -Verbosity Detailed -NonInteractive
+
+    - name: Create RNTester bundle
+      run: node cli.js bundle --entry-file .\RNTester\js\RNTesterApp.android.js --bundle-output RNTesterApp.android.bundle --platform android --reactNativePath .
+      
+    - run: gradlew.bat "-Pparam=excludeLibs" installArchives
+
+    - name: Extract version from package.json, and put it in nuspec
+      run: |
+        $lines = Get-Content package.json | Where {$_ -match '^\s*"version":.*'} 
+        $npmVersion = $lines.Trim().Split()[1].Trim('",');
+        (Get-Content ReactAndroid/ReactAndroid.nuspec).replace('__BuildBuildNumber__', $npmVersion) | Set-Content ReactAndroid/ReactAndroid.nuspec
+      shell: powershell
+
+    - name: Change pom file to always use version 1000
+      run: |
+        (Get-Content android\com\facebook\react\react-native\0.59.0\react-native-0.59.0.pom).replace('<version>0.59.0</version>', '<version>1000.0.0-master</version>') | Set-Content android\com\facebook\react\react-native\0.59.0\react-native-0.59.0.pom
+      shell: powershell
+
+    - run: nuget pack ReactAndroid/ReactAndroid.nuspec
+
+    - run: gradlew.bat "clean"


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/141)