### PR TITLE
Added AlertWindows 

### DIFF
--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -183,24 +183,24 @@ class AlertAndroid {
     };
 
     if (options) {
-      config = { ...config, cancelable: options.cancelable };
+      config = {...config, cancelable: options.cancelable};
     }
     // At most three buttons (neutral, negative, positive). Ignore rest.
     // The text 'OK' should be probably localized. iOS Alert does that in native.
     const validButtons: Buttons = buttons
       ? buttons.slice(0, 3)
-      : [{ text: 'OK' }];
+      : [{text: 'OK'}];
     const buttonPositive = validButtons.pop();
     const buttonNegative = validButtons.pop();
     const buttonNeutral = validButtons.pop();
     if (buttonNeutral) {
-      config = { ...config, buttonNeutral: buttonNeutral.text || '' };
+      config = {...config, buttonNeutral: buttonNeutral.text || ''};
     }
     if (buttonNegative) {
-      config = { ...config, buttonNegative: buttonNegative.text || '' };
+      config = {...config, buttonNegative: buttonNegative.text || ''};
     }
     if (buttonPositive) {
-      config = { ...config, buttonPositive: buttonPositive.text || '' };
+      config = {...config, buttonPositive: buttonPositive.text || ''};
     }
     NativeModules.DialogManagerAndroid.showAlert(
       config,

--- a/Libraries/Alert/Alert.js
+++ b/Libraries/Alert/Alert.js
@@ -12,7 +12,7 @@
 
 const AlertMacOS = require('AlertMacOS'); // TODO(macOS ISS#2323203)
 const NativeModules = require('NativeModules');
-const AlertWindowsOS = NativeModules.Alert;
+const AlertWindows = NativeModules.AlertWindows;
 const RCTAlertManager = NativeModules.AlertManager;
 const Platform = require('Platform');
 
@@ -59,7 +59,7 @@ class Alert {
     } else if (Platform.OS === 'android') {
       AlertAndroid.alert(title, message, buttons, options);
     } else if (Platform.OS === 'windows') {
-      AlertWindows.alert(title, message, buttons);
+      AlertWindowsOS.alert(title, message, buttons);
     }
   }
 
@@ -107,9 +107,9 @@ class AlertIOS {
     if (typeof type === 'function') {
       console.warn(
         'You passed a callback function as the "type" argument to Alert.prompt(). React Native is ' +
-        'assuming  you want to use the deprecated Alert.prompt(title, defaultValue, buttons, callback) ' +
-        'signature. The current signature is Alert.prompt(title, message, callbackOrButtons, type, defaultValue, ' +
-        'keyboardType) and the old syntax will be removed in a future version.',
+         'assuming  you want to use the deprecated Alert.prompt(title, defaultValue, buttons, callback) ' +
+         'signature. The current signature is Alert.prompt(title, message, callbackOrButtons, type, defaultValue, ' +
+         'keyboardType) and the old syntax will be removed in a future version.',
       );
 
       const callback = type;
@@ -226,7 +226,10 @@ class AlertAndroid {
   }
 }
 
-export class AlertWindows {
+/**
+ * Wrapper around the Windows native module.
+ */
+export class AlertWindowsOS {
   static alert(
     title: ?string,
     message?: ?string,
@@ -248,7 +251,7 @@ export class AlertWindows {
     buttonPositive: buttonPositive ? buttonPositive.text : '',
   };
 
-  AlertWindowsOS.showAlert(args, (actionResult) => {
+  AlertWindows.showAlert(args, (actionResult) => {
     if (actionResult === 'neutral') {
       buttonNeutral && buttonNeutral.onPress && buttonNeutral.onPress();
     } else if (actionResult === 'negative') {


### PR DESCRIPTION

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

I had previously added implementation to use alert on windows, on the react-native-windows fork. However, when I added the JS wrapper around the alertwindows native module I had to do so in a seperate TS file. Because of this, alert for windows had to be imported from a different place. This change adds the windows alert wrapper to Alert.js, so it can be imported from the same place. 
