### PR TITLE
fix yellow box style in win32

### DIFF
--- a/Libraries/YellowBox/UI/YellowBoxList.js
+++ b/Libraries/YellowBox/UI/YellowBoxList.js
@@ -73,6 +73,7 @@ class YellowBoxList extends React.Component<Props, State> {
     }
 
     const listStyle = {
+      width: Platform.OS === 'win32' ? '85%' : undefined,
       height:
         // Additional `0.5` so the (N + 1)th row can peek into view.
         Math.min(items.length, MAX_ITEMS + 0.5) *
@@ -126,16 +127,16 @@ const styles = StyleSheet.create({
   list: {
     bottom: 0,
     position: 'absolute',
-    width: Platform.OS === 'win32' ? 270 : '100%',
+    width: '100%',
   },
   dismissAll: {
-    bottom: Platform.OS === 'win32' ? undefined : '100%',
+    bottom: Platform.OS === 'win32' ? 0 : '100%',
     flexDirection: 'row',
     justifyContent: 'flex-end',
     paddingBottom: 4,
     paddingEnd: 4,
     position: 'absolute',
-    width: Platform.OS === 'win32' ? 350 : '100%',
+    width: '100%',
   },
   safeArea: {
     backgroundColor: YellowBoxStyle.getBackgroundColor(0.95),


### PR DESCRIPTION
## Summary

Fix the Yellow Box style on win32.

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

Fix the styling of YellowBox on win32. We have supported the % values for 'width' and 'height' properties, so I'm removing the forked code where we are hard coding the width of the yellow box.

However, the 'bottom' property still hasn't supported % value. Therefore, we still need to fork the code for that.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/150)