### PR TITLE
A couple of minor fixes in NativeToJsBridge

### DIFF
--- a/ReactCommon/cxxreact/NativeToJsBridge.cpp
+++ b/ReactCommon/cxxreact/NativeToJsBridge.cpp
@@ -181,7 +181,6 @@ void NativeToJsBridge::callFunction(
       #else
       (void)(systraceCookie);
       #endif
-      SystraceSection s("NativeToJsBridge::callFunction", "module", module, "method", method);
       // This is safe because we are running on the executor's thread: it won't
       // destruct until after it's been unregistered (which we check above) and
       // that will happen on this thread

--- a/ReactCommon/cxxreact/NativeToJsBridge.h
+++ b/ReactCommon/cxxreact/NativeToJsBridge.h
@@ -114,7 +114,7 @@ private:
   bool m_applicationScriptHasFailure = false;
 
   #ifdef WITH_FBSYSTRACE
-  std::atomic_uint_least32_t m_systraceCookie = ATOMIC_VAR_INIT();
+  std::atomic_uint_least32_t m_systraceCookie{};
   #endif
 };
 


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes

These changes will windows builds with systrace turned on. It contains two changes,
1. The change in NativeToJsBridge.cpp removes a statement that we added over the FB's change last year. In other words, it is removing an existing difference.
2. The change in NativeToJsBridge.h fixes a non-standard c++ statement. I've raised a PR in FB repo too : https://github.com/facebook/react-native/pull/26238

#### Focus areas to test

Build validation should suffice.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/151)