### PR TITLE
Fix regression caused by PR 146: 'add normalize/processColorObject.js for ios and macos'

### DIFF
--- a/Libraries/Color/normalizeColor.js
+++ b/Libraries/Color/normalizeColor.js
@@ -11,7 +11,6 @@
 /* eslint no-bitwise: 0 */
 'use strict';
 
-const normalizeColorObject = require('normalizeColorObject'); // TODO(macOS ISS#2323203)
 import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
 
 function normalizeColor(
@@ -33,6 +32,8 @@ function normalizeColor(
 
   // [TODO(macOS ISS#2323203)
   if (typeof color === 'object' && color !== null) {
+    const normalizeColorObject = require('normalizeColorObject'); // TODO(macOS ISS#2323203)
+
     const normalizedColorObj = normalizeColorObject(color);
 
     if (normalizedColorObj !== null) {

--- a/Libraries/Color/normalizeColorObject.macos.js
+++ b/Libraries/Color/normalizeColorObject.macos.js
@@ -10,8 +10,6 @@
 // [TODO(macOS ISS#2323203)
 'use strict';
 
-const normalizeColor = require('normalizeColor');
-
 export type NativeOrDynamicColorType = {
   semantic?: string,
   dynamic?: {
@@ -27,6 +25,8 @@ function normalizeColorObject(
     // a macos semantic color
     return color;
   } else if ('dynamic' in color && color.dynamic !== undefined) {
+    const normalizeColor = require('normalizeColor');
+
     // a dynamic, appearance aware color
     const dynamic = color.dynamic;
     const dynamicColor: NativeOrDynamicColorType = {

--- a/Libraries/StyleSheet/processColor.js
+++ b/Libraries/StyleSheet/processColor.js
@@ -11,7 +11,6 @@
 'use strict';
 
 const Platform = require('Platform');
-const processColorObject = require('processColorObject'); // TODO(macOS ISS#2323203)
 const normalizeColor = require('normalizeColor');
 import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
 
@@ -29,6 +28,8 @@ function processColor(
   }
 
   if (typeof int32Color === 'object') {
+    const processColorObject = require('processColorObject'); // TODO(macOS ISS#2323203)
+
     const processedColorObj = processColorObject(int32Color);
 
     if (processedColorObj !== null) {


### PR DESCRIPTION
## Summary

The recent PR https://github.com/microsoft/react-native/pull/146 ("add normalize/processColorObject.js for ios and macos") caused a regression.   At runtime in ios and macOS a RedBox error saying that processColor is undefined.  The reason was because require('processColor') was returning an empty object due to circular dependencies between the new modules normalizeColor, normalizeColorObject, processColor and processColorObject.  The fix is to move the require()'s within the functions that need them so that they are executed after the module.exports.

It unclear how PR 146 passed validation.  I'm guessing one of the npm dependencies used for packaging changed since the PR impacting the module order.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/152)