### PR TITLE
Fixed `import type` circular references of NativeOrDynamicColorType

### DIFF
--- a/Libraries/Color/NativeOrDynamicColorType.js
+++ b/Libraries/Color/NativeOrDynamicColorType.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+'use strict';
+
+export type NativeOrDynamicColorType = {
+  semantic?: string,
+  dynamic?: {
+    light: ?(string | number | NativeOrDynamicColorType),
+    dark: ?(string | number | NativeOrDynamicColorType),
+  },
+};

--- a/Libraries/Color/normalizeColor.js
+++ b/Libraries/Color/normalizeColor.js
@@ -11,7 +11,7 @@
 /* eslint no-bitwise: 0 */
 'use strict';
 
-import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType'; // TODO(macOS ISS#2323203)
 
 function normalizeColor(
   color: ?(

--- a/Libraries/Color/normalizeColorObject.android.js
+++ b/Libraries/Color/normalizeColorObject.android.js
@@ -10,7 +10,7 @@
 // [TODO(macOS ISS#2323203)
 'use strict';
 
-export type NativeOrDynamicColorType = {};
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType';
 
 function normalizeColorObject(
   color: NativeOrDynamicColorType,

--- a/Libraries/Color/normalizeColorObject.ios.js
+++ b/Libraries/Color/normalizeColorObject.ios.js
@@ -10,13 +10,7 @@
 // [TODO(macOS ISS#2323203)
 'use strict';
 
-export type NativeOrDynamicColorType = {
-  semantic?: string,
-  dynamic?: {
-    light: ?(string | number | NativeOrDynamicColorType),
-    dark: ?(string | number | NativeOrDynamicColorType),
-  },
-};
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType';
 
 function normalizeColorObject(
   color: NativeOrDynamicColorType,

--- a/Libraries/Color/normalizeColorObject.macos.js
+++ b/Libraries/Color/normalizeColorObject.macos.js
@@ -10,13 +10,7 @@
 // [TODO(macOS ISS#2323203)
 'use strict';
 
-export type NativeOrDynamicColorType = {
-  semantic?: string,
-  dynamic?: {
-    light: ?(string | number | NativeOrDynamicColorType),
-    dark: ?(string | number | NativeOrDynamicColorType),
-  },
-};
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType';
 
 function normalizeColorObject(
   color: NativeOrDynamicColorType,

--- a/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -19,7 +19,7 @@ const RCTActivityIndicatorViewNativeComponent = require('RCTActivityIndicatorVie
 
 import type {NativeComponent} from 'ReactNative';
 import type {ViewProps} from 'ViewPropTypes';
-import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType'; // TODO(macOS ISS#2323203)
 
 const RCTActivityIndicator =
   Platform.OS === 'android'

--- a/Libraries/Components/ActivityIndicator/RCTActivityIndicatorViewNativeComponent.js
+++ b/Libraries/Components/ActivityIndicator/RCTActivityIndicatorViewNativeComponent.js
@@ -15,7 +15,7 @@ const requireNativeComponent = require('requireNativeComponent');
 import type {ViewProps} from 'ViewPropTypes';
 import type {ViewStyleProp} from 'StyleSheet';
 import type {NativeComponent} from 'ReactNative';
-import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType'; // TODO(macOS ISS#2323203)
 
 type NativeProps = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/DrawerAndroid/AndroidDrawerLayoutNativeComponent.js
+++ b/Libraries/Components/DrawerAndroid/AndroidDrawerLayoutNativeComponent.js
@@ -16,7 +16,7 @@ import type {NativeComponent} from 'ReactNative';
 import type {SyntheticEvent} from 'CoreEventTypes';
 import type {ViewStyleProp} from 'StyleSheet';
 import type React from 'React';
-import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType'; // TODO(macOS ISS#2323203)
 
 type ColorValue = null | string | NativeOrDynamicColorType; // TODO(macOS ISS#2323203)
 

--- a/Libraries/Components/Picker/PickerIOS.ios.js
+++ b/Libraries/Components/Picker/PickerIOS.ios.js
@@ -24,7 +24,7 @@ import type {SyntheticEvent} from 'CoreEventTypes';
 import type {ColorValue} from 'StyleSheetTypes';
 import type {ViewProps} from 'ViewPropTypes';
 import type {TextStyleProp} from 'StyleSheet';
-import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType'; // TODO(macOS ISS#2323203)
 
 type PickerIOSChangeEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/Picker/RCTPickerNativeComponent.js
+++ b/Libraries/Components/Picker/RCTPickerNativeComponent.js
@@ -14,7 +14,7 @@ const requireNativeComponent = require('requireNativeComponent');
 import type {SyntheticEvent} from 'CoreEventTypes';
 import type {TextStyleProp} from 'StyleSheet';
 import type {NativeComponent} from 'ReactNative';
-import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType'; // TODO(macOS ISS#2323203)
 
 type PickerIOSChangeEvent = SyntheticEvent<
   $ReadOnly<{|

--- a/Libraries/Components/Switch/SwitchNativeComponent.js
+++ b/Libraries/Components/Switch/SwitchNativeComponent.js
@@ -17,7 +17,7 @@ const requireNativeComponent = require('requireNativeComponent');
 
 import type {SwitchChangeEvent} from 'CoreEventTypes';
 import type {ViewProps} from 'ViewPropTypes';
-import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType'; // TODO(macOS ISS#2323203)
 
 type SwitchProps = $ReadOnly<{|
   ...ViewProps,

--- a/Libraries/Components/ToolbarAndroid/ToolbarAndroidNativeComponent.js
+++ b/Libraries/Components/ToolbarAndroid/ToolbarAndroidNativeComponent.js
@@ -16,7 +16,7 @@ import type {SyntheticEvent} from 'CoreEventTypes';
 import type {ImageSource} from 'ImageSource';
 import type {ViewProps} from 'ViewPropTypes';
 import type {NativeComponent} from 'ReactNative';
-import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType'; // TODO(macOS ISS#2323203)
 
 type Action = $ReadOnly<{|
   title: string,

--- a/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.android.js
@@ -24,7 +24,7 @@ const ensurePositiveDelayProps = require('ensurePositiveDelayProps');
 const processColor = require('processColor');
 
 import type {PressEvent} from 'CoreEventTypes';
-import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType'; // TODO(macOS ISS#2323203)
 
 const rippleBackgroundPropType = PropTypes.shape({
   type: PropTypes.oneOf(['RippleAndroid']),

--- a/Libraries/ReactNative/getNativeComponentAttributes.js
+++ b/Libraries/ReactNative/getNativeComponentAttributes.js
@@ -21,7 +21,7 @@ const resolveAssetSource = require('resolveAssetSource');
 const sizesDiffer = require('sizesDiffer');
 const invariant = require('invariant');
 const warning = require('fbjs/lib/warning');
-import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType'; // TODO(macOS ISS#2323203)
 
 function getNativeComponentAttributes(uiViewClassName: string) {
   const viewConfig = UIManager.getViewManagerConfig(uiViewClassName);

--- a/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/Libraries/StyleSheet/StyleSheetTypes.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const AnimatedNode = require('AnimatedNode');
-import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType'; // TODO(macOS ISS#2323203)
 
 export type ColorValue = null | string | NativeOrDynamicColorType; // TODO(macOS ISS#2323203)
 export type DimensionValue = null | number | string | AnimatedNode;

--- a/Libraries/StyleSheet/processColor.js
+++ b/Libraries/StyleSheet/processColor.js
@@ -12,7 +12,7 @@
 
 const Platform = require('Platform');
 const normalizeColor = require('normalizeColor');
-import type {NativeOrDynamicColorType} from 'normalizeColorObject'; // TODO(macOS ISS#2323203)
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType'; // TODO(macOS ISS#2323203)
 
 /* eslint no-bitwise: 0 */
 function processColor(

--- a/Libraries/StyleSheet/processColorObject.android.js
+++ b/Libraries/StyleSheet/processColorObject.android.js
@@ -10,7 +10,7 @@
 // [TODO(macOS ISS#2323203)
 'use strict';
 
-import type {NativeOrDynamicColorType} from 'normalizeColorObject';
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType';
 
 function processColorObject(
   color: NativeOrDynamicColorType,

--- a/Libraries/StyleSheet/processColorObject.ios.js
+++ b/Libraries/StyleSheet/processColorObject.ios.js
@@ -10,13 +10,13 @@
 // [TODO(macOS ISS#2323203)
 'use strict';
 
-import type {NativeOrDynamicColorType} from 'normalizeColorObject';
-const processColor = require('processColor');
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType';
 
 function processColorObject(
   color: NativeOrDynamicColorType,
 ): ?NativeOrDynamicColorType {
   if ('dynamic' in color && color.dynamic !== undefined) {
+    const processColor = require('processColor');
     const dynamic = color.dynamic;
     const dynamicColor: NativeOrDynamicColorType = {
       dynamic: {

--- a/Libraries/StyleSheet/processColorObject.macos.js
+++ b/Libraries/StyleSheet/processColorObject.macos.js
@@ -10,13 +10,13 @@
 // [TODO(macOS ISS#2323203)
 'use strict';
 
-import type {NativeOrDynamicColorType} from 'normalizeColorObject';
-const processColor = require('processColor');
+import type {NativeOrDynamicColorType} from 'NativeOrDynamicColorType';
 
 function processColorObject(
   color: NativeOrDynamicColorType,
 ): ?NativeOrDynamicColorType {
   if ('dynamic' in color && color.dynamic !== undefined) {
+    const processColor = require('processColor');
     const dynamic = color.dynamic;
     const dynamicColor: NativeOrDynamicColorType = {
       dynamic: {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

#### Description of changes
The previous Pull Request https://github.com/microsoft/react-native/pull/146 renamed and moved the Flow type NativeOrDynamicColorType.   It also created some circular references via the `import type` imports of this type.   Flow itself seems to be able to handle these circular references, but an internal tool in Microsoft cannot.   And these circular references are a bad practice.

Created a new file, Libraries/Color/NativeOrDynamicColorType.js, that contains the `export type NativeOrDynamicColorType = ...` definition.  Changed all the `import type {NativeOrDynamicColorType} from` instances to reference the new file.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/154)