### PR TITLE
Reverting the changes in this method to the original version.

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -427,11 +427,7 @@ public class ReactEditText extends EditText {
   }
 
   protected boolean showSoftKeyboard() {
-    // Don't show soft keyboard when a hardware keyboard is attached
-    if (!isHardwareKeyboardAvailable()) {
       return mInputMethodManager.showSoftInput(this, 0);
-    }
-    return false;
   }
 
   protected void hideSoftKeyboard() {


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

This change is part of the effort of reducing the delta between FB/rn and MS/rn, the removed code is something we added few years back.

Base on my testing using the TextInput page in the RNTester, the removed code in this file is not bringing any improvements to the behavior of the TextInput, when a hard keyboard is attached. The platform seems to be handling it just fine. The soft keyboard might show up when the focus is in the TextInput, but once the physical keyboard is used, the page is refreshed and the softkeyboard goes away, letting the physical keyboard take control. 

#### Focus areas to test

My testing was in RNTester based on the Facebook master, with and without this change.
