### PR TITLE
Ontiv/fb60 revert bucks

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/bridge/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/bridge/BUCK
@@ -28,6 +28,7 @@ rn_android_library(
         react_native_dep("third-party/android/androidx:legacy-support-core-ui"),
         react_native_dep("third-party/android/androidx:legacy-support-core-utils"),
     ],
+    required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/common/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/common/BUCK
@@ -18,6 +18,7 @@ rn_android_library(
         react_native_dep("third-party/android/androidx:legacy-support-core-ui"),
         react_native_dep("third-party/android/androidx:legacy-support-core-utils"),
     ],
+    required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",
     ],

--- a/ReactAndroid/src/main/java/com/facebook/react/processing/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/processing/BUCK
@@ -2,6 +2,7 @@ load("//tools/build_defs/oss:rn_defs.bzl", "react_native_dep", "react_native_tar
 
 rn_java_annotation_processor(
     name = "processing",
+    does_not_affect_abi = True,
     processor_class = "com.facebook.react.processing.ReactPropertyProcessor",
     visibility = [
         "PUBLIC",
@@ -13,7 +14,7 @@ rn_java_annotation_processor(
 
 rn_java_library(
     name = "processing-lib",
-    srcs = glob(["ReactPropertyProcessor.java"]),
+    srcs = glob(["*.java"]),
     source = "7",
     target = "7",
     deps = [

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/BUCK
@@ -21,6 +21,7 @@ rn_android_library(
         react_native_dep("third-party/android/androidx:legacy-support-core-ui"),
         react_native_dep("third-party/android/androidx:legacy-support-core-utils"),
     ],
+    required_for_source_only_abi = True,
     visibility = [
         "PUBLIC",
     ],


### PR DESCRIPTION
We are working on reducing the diff between Facebook's public version of react-native, and our microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [x ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

Reverting BUCK files.

#### Focus areas to test

N/A


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/164)