### PR TITLE
Switch AzureDevops to use vmImage macOS-10.14

### DIFF
--- a/.ado/apple-pr.yml
+++ b/.ado/apple-pr.yml
@@ -27,7 +27,7 @@ jobs:
           xcode_scheme: 'RNTester-macOS'
           xcode_destination: 'platform=macOS,arch=x86_64'
     pool:
-      name: Hosted Mac Internal Mojave
+      vmImage: macOS-10.14
       demands: ['xcode', 'sh', 'npm']
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -16,6 +16,8 @@ steps:
   - script: 'brew bundle'
     displayName: 'brew bundle'
 
+  - script: brew link node@10 --overwrite --force
+
   # Task Group: XCode select proper version
   - template: apple-xcode-select.yml
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

#### Description of changes

Switch the Azure Devops yaml script to use vmImage macOS-10.14

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/165)