### PR TITLE
Add dependency required when using pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "fbjs-scripts": "^1.1.0",
     "invariant": "^2.2.4",
     "jsc-android": "245459.0.0",
+    "metro": "0.54.1",
     "metro-babel-register": "0.54.1",
     "metro-react-native-babel-transformer": "0.54.1",
     "nullthrows": "^1.1.0",


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

This just adds metro as a declare dependency.  Most package managers already allow access to metro from react-native through the metro-babel-register dependency, but pnpm is more picky about actually declaring everything you use.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/169)