### PR TITLE
Include RCTBackedTextInputViewProtocol and RCTBackedTextInputDelegate in RCTText

### DIFF
--- a/Libraries/Text/RCTText.xcodeproj/project.pbxproj
+++ b/Libraries/Text/RCTText.xcodeproj/project.pbxproj
@@ -107,6 +107,10 @@
 		8F2807C7202D2B6B005D65E6 /* RCTInputAccessoryViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F2807C1202D2B6A005D65E6 /* RCTInputAccessoryViewManager.m */; };
 		8F2807C8202D2B6B005D65E6 /* RCTInputAccessoryView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F2807C3202D2B6A005D65E6 /* RCTInputAccessoryView.m */; };
 		8F2807C9202D2B6B005D65E6 /* RCTInputAccessoryViewContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F2807C5202D2B6B005D65E6 /* RCTInputAccessoryViewContent.m */; };
+		9F4658BD23563A92000929DF /* RCTBackedTextInputViewProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 5956B112200FEBA9008D9D16 /* RCTBackedTextInputViewProtocol.h */; };
+		9F4658BE23563A92000929DF /* RCTBackedTextInputViewProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 5956B112200FEBA9008D9D16 /* RCTBackedTextInputViewProtocol.h */; };
+		9F4658BF23563AB8000929DF /* RCTBackedTextInputDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5956B10C200FEBA9008D9D16 /* RCTBackedTextInputDelegate.h */; };
+		9F4658C023563AB8000929DF /* RCTBackedTextInputDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5956B10C200FEBA9008D9D16 /* RCTBackedTextInputDelegate.h */; };
 		9F5C189A230DD5E600E3E5A7 /* RCTVirtualTextViewManager.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B12D200FEBAA008D9D16 /* RCTVirtualTextViewManager.h */; };
 		9F5C189C230DD67C00E3E5A7 /* RCTVirtualTextShadowView.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B12C200FEBAA008D9D16 /* RCTVirtualTextShadowView.h */; };
 		9F5C189D230DD68B00E3E5A7 /* RCTUITextField.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B105200FEBA9008D9D16 /* RCTUITextField.h */; };
@@ -493,6 +497,8 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9F4658BD23563A92000929DF /* RCTBackedTextInputViewProtocol.h in Headers */,
+				9F4658BF23563AB8000929DF /* RCTBackedTextInputDelegate.h in Headers */,
 				9F5C1912230DF3E700E3E5A7 /* RCTTextUIKit.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -501,6 +507,8 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9F4658BE23563A92000929DF /* RCTBackedTextInputViewProtocol.h in Headers */,
+				9F4658C023563AB8000929DF /* RCTBackedTextInputDelegate.h in Headers */,
 				9F5C1913230DF3E700E3E5A7 /* RCTTextUIKit.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Include RCTBackedTextInputViewProtocol and RCTBackedTextInputDelegate in RCTText as they weren't getting built into the RCTTextLibrary, which is necessary for Polyester's consumption.

#### Please select one of the following
- [X] I am making a fix / change for the macOS implementation of react-native

These headers must be included in the RCTText library so Polyester classes can import them.

#### Focus areas to test

It must get pushed into github, get pushed to SDX-Platform, and then we can see if there are any other issues hiding behind this header issue.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/174)