### PR TITLE
Adding metro-config dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "jsc-android": "245459.0.0",
     "metro": "0.54.1",
     "metro-babel-register": "0.54.1",
-    "metro-config": "0.51.0",
+    "metro-config": "0.54.1",
     "metro-react-native-babel-transformer": "0.54.1",
     "nullthrows": "^1.1.0",
     "pretty-format": "^24.7.0",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "jsc-android": "245459.0.0",
     "metro": "0.54.1",
     "metro-babel-register": "0.54.1",
+    "metro-config": "0.51.0",
     "metro-react-native-babel-transformer": "0.54.1",
     "nullthrows": "^1.1.0",
     "pretty-format": "^24.7.0",


### PR DESCRIPTION
<!--
We are working on reducing the diff between Facebook's public version of react-native, and our microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

**Issue**
Creation of RNTester app bundle is failing in sdx-platform even though it is getting created in MS React-Native GitHub repo.

**Fix**
Added dependency of metro-config in react-native package.json to resolve this issue.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/176)