### PR TITLE
Add support for registering custom fonts by family+weight

### DIFF
--- a/.ado/publish.js
+++ b/.ado/publish.js
@@ -128,8 +128,12 @@ function doPublish() {
       }
 
       console.log("Created GitHub Release: " + JSON.stringify(body, null, 2));
+      if (body.id) {
       uploadReleaseAssetUrl = assetUpdateUrl.replace(/{id}/, body.id);
       uploadTarBallToRelease();
+      } else {
+        console.warn('Unable to find release to upload tar...skipping custom tar for release.')
+      }
     }
   );
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
@@ -69,11 +69,11 @@ public class ReactFontManager {
       int weight,
       AssetManager assetManager) {
     Pair key = Pair.create(fontFamilyName, weight);
-    if(mCustomTypefaceCache.containsKey(key) {
+    if(mCustomTypefaceCache.containsKey(key)) {
       return Typeface.create(mCustomTypefaceCache.get(key), style);
     } else {
       key = Pair.create(fontFamilyName, -1);
-      if(mCustomTypefaceCache.containsKey(key) {
+      if(mCustomTypefaceCache.containsKey(key)) {
         Typeface typeface = mCustomTypefaceCache.get(key);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && weight >= 100 && weight <= 1000) {
           return Typeface.create(typeface, weight, (style & Typeface.ITALIC) != 0);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
@@ -15,6 +15,7 @@ import android.content.Context;
 import android.content.res.AssetManager;
 import android.graphics.Typeface;
 import android.os.Build;
+import android.util.Pair;
 import android.util.SparseArray;
 
 import androidx.annotation.NonNull;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
@@ -42,7 +42,7 @@ public class ReactFontManager {
   private static ReactFontManager sReactFontManagerInstance;
 
   final private Map<String, FontFamily> mFontCache;
-  final private Map<Pair<String, int>, Typeface> mCustomTypefaceCache;
+  final private Map<Pair<String, Integer>, Typeface> mCustomTypefaceCache;
 
   private ReactFontManager() {
     mFontCache = new HashMap<>();

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
@@ -8,7 +8,6 @@
 package com.facebook.react.views.text;
 
 import java.util.HashMap;
-import java.util.Pair;
 import java.util.Map;
 
 import android.content.Context;

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
@@ -72,7 +72,7 @@ public class ReactFontManager {
     if(mCustomTypefaceCache.containsKey(key)) {
       return Typeface.create(mCustomTypefaceCache.get(key), style);
     } else {
-      key = Pair.create(fontFamilyName, -1);
+      key = Pair.create(fontFamilyName, null);
       if(mCustomTypefaceCache.containsKey(key)) {
         Typeface typeface = mCustomTypefaceCache.get(key);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && weight >= 100 && weight <= 1000) {
@@ -134,7 +134,7 @@ public class ReactFontManager {
    * ReactFontManager.getInstance().addCustomFont("Srisakdi", typeface);
    */
   public void addCustomFont(@NonNull String fontFamily, @NonNull Typeface typeface) {
-    mCustomTypefaceCache.put(Pair.create(fontFamily, -1), typeface);
+    mCustomTypefaceCache.put(Pair.create(fontFamily, null), typeface);
   }
 
   /**

--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.java
@@ -8,6 +8,7 @@
 package com.facebook.react.views.text;
 
 import java.util.HashMap;
+import java.util.Pair;
 import java.util.Map;
 
 import android.content.Context;
@@ -41,7 +42,7 @@ public class ReactFontManager {
   private static ReactFontManager sReactFontManagerInstance;
 
   final private Map<String, FontFamily> mFontCache;
-  final private Map<String, Typeface> mCustomTypefaceCache;
+  final private Map<Pair<String, int>, Typeface> mCustomTypefaceCache;
 
   private ReactFontManager() {
     mFontCache = new HashMap<>();
@@ -67,12 +68,18 @@ public class ReactFontManager {
       int style,
       int weight,
       AssetManager assetManager) {
-    if(mCustomTypefaceCache.containsKey(fontFamilyName)) {
-      Typeface typeface = mCustomTypefaceCache.get(fontFamilyName);
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && weight >= 100 && weight <= 1000) {
-        return Typeface.create(typeface, weight, (style & Typeface.ITALIC) != 0);
+    Pair key = Pair.create(fontFamilyName, weight);
+    if(mCustomTypefaceCache.containsKey(key) {
+      return Typeface.create(mCustomTypefaceCache.get(key), style);
+    } else {
+      key = Pair.create(fontFamilyName, -1);
+      if(mCustomTypefaceCache.containsKey(key) {
+        Typeface typeface = mCustomTypefaceCache.get(key);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && weight >= 100 && weight <= 1000) {
+          return Typeface.create(typeface, weight, (style & Typeface.ITALIC) != 0);
+        }
+        return Typeface.create(typeface, style);
       }
-      return Typeface.create(typeface, style);
     }
 
     FontFamily fontFamily = mFontCache.get(fontFamilyName);
@@ -106,8 +113,28 @@ public class ReactFontManager {
     }
   }
 
-  public void addCustomFont(@NonNull String fontFamily, @NonNull Typeface font) {
-    mCustomTypefaceCache.put(fontFamily, font);
+/*
+   * This method allows you to load custom fonts from a custom Typeface object and register it as a specific 
+   * fontFamily and weight.  This can be used when fonts are delivered during runtime and cannot be included in
+   * the standard app resources.  Typeface's registered using a specific weight will take priority over ones
+   * registered without a specific weight.
+   *
+   * ReactFontManager.getInstance().addCustomFont("Srisakdi", 600, typeface);
+   */
+  public void addCustomFont(@NonNull String fontFamily, int weight, @NonNull Typeface typeface) {
+    mCustomTypefaceCache.put(Pair.create(fontFamily, weight), typeface);
+  }
+
+  /*
+   * This method allows you to load custom fonts from a custom Typeface object and register it as a specific 
+   * fontFamily.  This can be used when fonts are delivered during runtime and cannot be included in
+   * the standard app resources. Typeface's registered using a specific weight will take priority over ones
+   * registered without a specific weight.
+   *
+   * ReactFontManager.getInstance().addCustomFont("Srisakdi", typeface);
+   */
+  public void addCustomFont(@NonNull String fontFamily, @NonNull Typeface typeface) {
+    mCustomTypefaceCache.put(Pair.create(fontFamily, -1), typeface);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.60.0-microsoft.8",
+  "version": "0.60.0-microsoft.9",
   "description": "[Microsoft Fork] A framework for building native apps using React",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/179)