### PR TITLE
[DO NOT CHECK IN] Test enabling the address sanitizer for our cloud builds

### DIFF
--- a/.ado/templates/apple-xcode-build.yml
+++ b/.ado/templates/apple-xcode-build.yml
@@ -21,7 +21,7 @@ steps:
       signingOption: auto
       packageApp: false
       teamId: '$(XCodeSigningMicrosoftTeamID)'
-      args: '-destination "${{ parameters.xcode_destination }}" ONLY_ACTIVE_ARCH=NO -verbose -UseModernBuildSystem=NO -derivedDataPath DerivedData ${{ parameters.xcode_extraArgs }}'
+      args: '-destination "${{ parameters.xcode_destination }}" ONLY_ACTIVE_ARCH=NO -verbose -UseModernBuildSystem=NO -derivedDataPath DerivedData ${{ parameters.xcode_extraArgs }} -enableAddressSanitizer YES'
       exportPath: '$(agent.builddirectory)/output/${{ parameters.xcode_sdk }}/${{ parameters.xcode_configuration }}'
       useXcpretty: ${{ parameters.xcode_useXcpretty }}
       publishJUnitResults: ${{ parameters.xcode_useXcpretty }}


### PR DESCRIPTION
- [X] I am making a fix / change for the macOS implementation of react-native
- [X] I am making a change required for Microsoft usage of react-native

Test passing the address sanitizer enabled through to our builds and verify builds run as expected. Don't check this in as we'll want to run this continuously in a separate pipeline, but this can be a prototype that we can stand up the test.

#### Focus areas to test

Only impacts build machines