### PR TITLE
Copy over ios/mac header files that polyester references to fix the 0.60 merg…

### DIFF
--- a/.ado/apple-pr.yml
+++ b/.ado/apple-pr.yml
@@ -16,6 +16,8 @@ jobs:
           xcode_sdk: iphonesimulator
           xcode_scheme: 'RNTester'
           xcode_destination: 'platform=iOS Simulator,OS=latest,name=iPhone 8'
+          xcode_actions_debug: 'build test'
+          xcode_actions_release: 'build'
         # Microsoft- We don't use tvOS, so don't bother maintaining the infra
         # tvos:
         #   packager_platform: 'ios'
@@ -27,6 +29,11 @@ jobs:
           xcode_sdk: macosx
           xcode_scheme: 'RNTester-macOS'
           xcode_destination: 'platform=macOS,arch=x86_64'
+#           TODO: There's a build failure on ADO Mac VMs where XCodeHelper lost Accessibility permission to control the computer. The issue is tracked here
+# https://developercommunity.visualstudio.com/content/problem/788271/xcode-helper-not-configured-for-accessibility-on-m.html
+#   To unblock Mac loop builds, we need to temporarily disable integration tests since they consistently fail without proper access. Once the ticket is resolved, we can uncomment the tests below.
+          xcode_actions_debug: 'build'
+          xcode_actions_release: 'build'
     pool:
       vmImage: macOS-10.14
       demands: ['xcode', 'sh', 'npm']
@@ -39,5 +46,6 @@ jobs:
           xcode_sdk: $(xcode_sdk)
           xcode_configuration: $(xcode_configuration)
           xcode_scheme: $(xcode_scheme)
-          xcode_actions: $(xcode_actions)
+          xcode_actions_debug: $(xcode_actions_debug)
+          xcode_actions_release: $(xcode_actions_release)
           xcode_destination: $(xcode_destination)

--- a/.ado/templates/apple-job-react-native.yml
+++ b/.ado/templates/apple-job-react-native.yml
@@ -3,7 +3,8 @@ parameters:
   xcode_sdk: ''
   xcode_configuration: ''
   xcode_scheme: ''
-  xcode_actions: ''
+  xcode_actions_debug: ''
+  xcode_actions_release: ''
   xcode_destination: ''
 
 steps:
@@ -46,7 +47,7 @@ steps:
       xcode_configuration: Debug
       xcode_workspacePath: RNTester/RNTester.xcodeproj
       xcode_scheme: ${{ parameters.xcode_scheme }}
-      xcode_actions: 'build test'
+      xcode_actions: ${{ parameters.xcode_actions_debug }}
       xcode_useXcpretty: true
       xcode_destination: ${{ parameters.xcode_destination }}
 
@@ -56,7 +57,7 @@ steps:
       xcode_configuration: Release
       xcode_workspacePath: RNTester/RNTester.xcodeproj
       xcode_scheme: ${{ parameters.xcode_scheme }}
-      xcode_actions: 'build'
+      xcode_actions: ${{ parameters.xcode_actions_release }}
       xcode_useXcpretty: false
       xcode_destination: ${{ parameters.xcode_destination }}
 

--- a/Libraries/Text/RCTText.xcodeproj/project.pbxproj
+++ b/Libraries/Text/RCTText.xcodeproj/project.pbxproj
@@ -107,10 +107,6 @@
 		8F2807C7202D2B6B005D65E6 /* RCTInputAccessoryViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F2807C1202D2B6A005D65E6 /* RCTInputAccessoryViewManager.m */; };
 		8F2807C8202D2B6B005D65E6 /* RCTInputAccessoryView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F2807C3202D2B6A005D65E6 /* RCTInputAccessoryView.m */; };
 		8F2807C9202D2B6B005D65E6 /* RCTInputAccessoryViewContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F2807C5202D2B6B005D65E6 /* RCTInputAccessoryViewContent.m */; };
-		9F4658BD23563A92000929DF /* RCTBackedTextInputViewProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 5956B112200FEBA9008D9D16 /* RCTBackedTextInputViewProtocol.h */; };
-		9F4658BE23563A92000929DF /* RCTBackedTextInputViewProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 5956B112200FEBA9008D9D16 /* RCTBackedTextInputViewProtocol.h */; };
-		9F4658BF23563AB8000929DF /* RCTBackedTextInputDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5956B10C200FEBA9008D9D16 /* RCTBackedTextInputDelegate.h */; };
-		9F4658C023563AB8000929DF /* RCTBackedTextInputDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5956B10C200FEBA9008D9D16 /* RCTBackedTextInputDelegate.h */; };
 		9F46597C23623E14000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B10C200FEBA9008D9D16 /* RCTBackedTextInputDelegate.h */; };
 		9F46597D23623E2D000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B112200FEBA9008D9D16 /* RCTBackedTextInputViewProtocol.h */; };
 		9F4659A623624EBF000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B112200FEBA9008D9D16 /* RCTBackedTextInputViewProtocol.h */; };
@@ -505,8 +501,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F4658BD23563A92000929DF /* RCTBackedTextInputViewProtocol.h in Headers */,
-				9F4658BF23563AB8000929DF /* RCTBackedTextInputDelegate.h in Headers */,
 				9F5C1912230DF3E700E3E5A7 /* RCTTextUIKit.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -515,8 +509,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F4658BE23563A92000929DF /* RCTBackedTextInputViewProtocol.h in Headers */,
-				9F4658C023563AB8000929DF /* RCTBackedTextInputDelegate.h in Headers */,
 				9F5C1913230DF3E700E3E5A7 /* RCTTextUIKit.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Libraries/Text/RCTText.xcodeproj/project.pbxproj
+++ b/Libraries/Text/RCTText.xcodeproj/project.pbxproj
@@ -107,10 +107,10 @@
 		8F2807C7202D2B6B005D65E6 /* RCTInputAccessoryViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F2807C1202D2B6A005D65E6 /* RCTInputAccessoryViewManager.m */; };
 		8F2807C8202D2B6B005D65E6 /* RCTInputAccessoryView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F2807C3202D2B6A005D65E6 /* RCTInputAccessoryView.m */; };
 		8F2807C9202D2B6B005D65E6 /* RCTInputAccessoryViewContent.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F2807C5202D2B6B005D65E6 /* RCTInputAccessoryViewContent.m */; };
-		9F46597C23623E14000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B10C200FEBA9008D9D16 /* RCTBackedTextInputDelegate.h */; };
-		9F46597D23623E2D000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B112200FEBA9008D9D16 /* RCTBackedTextInputViewProtocol.h */; };
-		9F4659A623624EBF000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B112200FEBA9008D9D16 /* RCTBackedTextInputViewProtocol.h */; };
-		9F4659A723624ECA000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B10C200FEBA9008D9D16 /* RCTBackedTextInputDelegate.h */; };
+		9F4659E2236262E9000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B10C200FEBA9008D9D16 /* RCTBackedTextInputDelegate.h */; };
+		9F4659E3236262E9000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B112200FEBA9008D9D16 /* RCTBackedTextInputViewProtocol.h */; };
+		9F4659E42362634A000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B10C200FEBA9008D9D16 /* RCTBackedTextInputDelegate.h */; };
+		9F4659E52362634A000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B112200FEBA9008D9D16 /* RCTBackedTextInputViewProtocol.h */; };
 		9F5C189A230DD5E600E3E5A7 /* RCTVirtualTextViewManager.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B12D200FEBAA008D9D16 /* RCTVirtualTextViewManager.h */; };
 		9F5C189C230DD67C00E3E5A7 /* RCTVirtualTextShadowView.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B12C200FEBAA008D9D16 /* RCTVirtualTextShadowView.h */; };
 		9F5C189D230DD68B00E3E5A7 /* RCTUITextField.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B105200FEBA9008D9D16 /* RCTUITextField.h */; };
@@ -165,9 +165,11 @@
 		183496EA1F5DF07600C0A1B4 /* Copy Headers */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = include/React;
+			dstPath = include/RCTText;
 			dstSubfolderSpec = 16;
 			files = (
+				9F4659E2236262E9000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */,
+				9F4659E3236262E9000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */,
 			);
 			name = "Copy Headers";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -178,8 +180,6 @@
 			dstPath = include/RCTText;
 			dstSubfolderSpec = 16;
 			files = (
-				9F4659A723624ECA000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */,
-				9F4659A623624EBF000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */,
 				9F5C18B4230DDBEE00E3E5A7 /* RCTBaseTextShadowView.h in Copy Headers */,
 				9F5C18B5230DDBEE00E3E5A7 /* RCTBaseTextViewManager.h in Copy Headers */,
 				9F5C18B2230DDBDE00E3E5A7 /* RCTRawTextShadowView.h in Copy Headers */,
@@ -213,8 +213,6 @@
 			dstPath = include/RCTText;
 			dstSubfolderSpec = 16;
 			files = (
-				9F46597D23623E2D000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */,
-				9F46597C23623E14000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */,
 				5970936920845EFC00D163A7 /* RCTTextTransform.h in Copy Headers */,
 				5956B160200FF324008D9D16 /* RCTBaseTextShadowView.h in Copy Headers */,
 				5956B161200FF324008D9D16 /* RCTBaseTextViewManager.h in Copy Headers */,
@@ -285,6 +283,8 @@
 			dstPath = include/React;
 			dstSubfolderSpec = 16;
 			files = (
+				9F4659E42362634A000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */,
+				9F4659E52362634A000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */,
 			);
 			name = "Copy Headers";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Libraries/Text/RCTText.xcodeproj/project.pbxproj
+++ b/Libraries/Text/RCTText.xcodeproj/project.pbxproj
@@ -111,6 +111,10 @@
 		9F4658BE23563A92000929DF /* RCTBackedTextInputViewProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 5956B112200FEBA9008D9D16 /* RCTBackedTextInputViewProtocol.h */; };
 		9F4658BF23563AB8000929DF /* RCTBackedTextInputDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5956B10C200FEBA9008D9D16 /* RCTBackedTextInputDelegate.h */; };
 		9F4658C023563AB8000929DF /* RCTBackedTextInputDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5956B10C200FEBA9008D9D16 /* RCTBackedTextInputDelegate.h */; };
+		9F46597C23623E14000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B10C200FEBA9008D9D16 /* RCTBackedTextInputDelegate.h */; };
+		9F46597D23623E2D000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B112200FEBA9008D9D16 /* RCTBackedTextInputViewProtocol.h */; };
+		9F4659A623624EBF000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B112200FEBA9008D9D16 /* RCTBackedTextInputViewProtocol.h */; };
+		9F4659A723624ECA000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B10C200FEBA9008D9D16 /* RCTBackedTextInputDelegate.h */; };
 		9F5C189A230DD5E600E3E5A7 /* RCTVirtualTextViewManager.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B12D200FEBAA008D9D16 /* RCTVirtualTextViewManager.h */; };
 		9F5C189C230DD67C00E3E5A7 /* RCTVirtualTextShadowView.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B12C200FEBAA008D9D16 /* RCTVirtualTextShadowView.h */; };
 		9F5C189D230DD68B00E3E5A7 /* RCTUITextField.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 5956B105200FEBA9008D9D16 /* RCTUITextField.h */; };
@@ -178,6 +182,8 @@
 			dstPath = include/RCTText;
 			dstSubfolderSpec = 16;
 			files = (
+				9F4659A723624ECA000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */,
+				9F4659A623624EBF000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */,
 				9F5C18B4230DDBEE00E3E5A7 /* RCTBaseTextShadowView.h in Copy Headers */,
 				9F5C18B5230DDBEE00E3E5A7 /* RCTBaseTextViewManager.h in Copy Headers */,
 				9F5C18B2230DDBDE00E3E5A7 /* RCTRawTextShadowView.h in Copy Headers */,
@@ -211,6 +217,8 @@
 			dstPath = include/RCTText;
 			dstSubfolderSpec = 16;
 			files = (
+				9F46597D23623E2D000929DF /* RCTBackedTextInputViewProtocol.h in Copy Headers */,
+				9F46597C23623E14000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */,
 				5970936920845EFC00D163A7 /* RCTTextTransform.h in Copy Headers */,
 				5956B160200FF324008D9D16 /* RCTBaseTextShadowView.h in Copy Headers */,
 				5956B161200FF324008D9D16 /* RCTBaseTextViewManager.h in Copy Headers */,

--- a/RNTester/RNTesterIntegrationTests/RCTLoggingTests.m
+++ b/RNTester/RNTesterIntegrationTests/RCTLoggingTests.m
@@ -17,12 +17,6 @@
 
 @end
 
-/*
-TODO: There's a build failure on ADO Mac VMs where XCodeHelper lost Accessibility permission to control the computer. The issue is tracked here
-https://developercommunity.visualstudio.com/content/problem/788271/xcode-helper-not-configured-for-accessibility-on-m.html
-  To unblock Mac loop builds, we need to temporarily disable integration tests since they consistently fail without proper access. Once the ticket is resolved, we can uncomment the tests below.
- */
-/*
 @implementation RCTLoggingTests
 {
   RCTBridge *_bridge;
@@ -132,4 +126,3 @@ https://developercommunity.visualstudio.com/content/problem/788271/xcode-helper-
 }
 
 @end
-*/

--- a/RNTester/RNTesterIntegrationTests/RCTLoggingTests.m
+++ b/RNTester/RNTesterIntegrationTests/RCTLoggingTests.m
@@ -17,6 +17,12 @@
 
 @end
 
+/*
+TODO: There's a build failure on ADO Mac VMs where XCodeHelper lost Accessibility permission to control the computer. The issue is tracked here
+https://developercommunity.visualstudio.com/content/problem/788271/xcode-helper-not-configured-for-accessibility-on-m.html
+  To unblock Mac loop builds, we need to temporarily disable integration tests since they consistently fail without proper access. Once the ticket is resolved, we can uncomment the tests below.
+ */
+/*
 @implementation RCTLoggingTests
 {
   RCTBridge *_bridge;
@@ -126,3 +132,4 @@
 }
 
 @end
+*/


### PR DESCRIPTION
…e into sdx-platform

- [ X] I am making a fix / change for the macOS implementation of react-native
- [ X] I am making a change required for Microsoft usage of react-native

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

(give an overview)
SDX-Platform references these header files, but since they're not in the copy build phase, polyester can't access them.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/181)