### PR TITLE
Align with ios here and copy these to the same location on mac

### DIFF
--- a/Libraries/Text/RCTText.xcodeproj/project.pbxproj
+++ b/Libraries/Text/RCTText.xcodeproj/project.pbxproj
@@ -280,7 +280,7 @@
 		6490EA781F683C2000E20046 /* Copy Headers */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = include/React;
+			dstPath = include/RCTText;
 			dstSubfolderSpec = 16;
 			files = (
 				9F4659E42362634A000929DF /* RCTBackedTextInputDelegate.h in Copy Headers */,


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [X ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

iOS is copying these to RCTText, let's do the same on Mac so we don't need an "#ifdef" downstream when we need to reference the headers.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/182)