### PR TITLE
Remove "bytecodeFileName" concept from "microsoft/react-native"

### DIFF
--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -1337,8 +1337,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithBundleURL:(__unused NSURL *)bundleUR
                                             sourceUrlStr.UTF8String, !async);
       }
     } else if (reactInstance) {
-      reactInstance->loadScriptFromString(std::make_unique<NSDataBigString>(script), 0,
-                                                 sourceUrlStr.UTF8String, !async, ""); // TODO(OSS Candidate ISS#2710739)
+      reactInstance->loadScriptFromString(std::make_unique<NSDataBigString>(script), 0, // TODO(OSS Candidate ISS#2710739)
+                                                 sourceUrlStr.UTF8String, !async);
     } else {
       std::string methodName = async ? "loadApplicationScript" : "loadApplicationScriptSync";
       throw std::logic_error("Attempt to call " + methodName + ": on uninitialized bridge");

--- a/React/CxxBridge/RCTObjcExecutor.mm
+++ b/React/CxxBridge/RCTObjcExecutor.mm
@@ -77,8 +77,7 @@ public:
   void loadApplicationScript(
       std::unique_ptr<const JSBigString> script,
       uint64_t /*scriptVersion*/, // TODO(OSS Candidate ISS#2710739)
-      std::string sourceURL,
-      std::string&& /*bytecodeFileName*/) override { // TODO(OSS Candidate ISS#2710739)
+      std::string sourceURL) override {
     RCTProfileBeginFlowEvent();
     [m_jse executeApplicationScript:[NSData dataWithBytes:script->c_str() length:script->size()]
            sourceURL:[[NSURL alloc]

--- a/ReactAndroid/src/main/java/com/facebook/react/v8executor/InstanceManager.cpp
+++ b/ReactAndroid/src/main/java/com/facebook/react/v8executor/InstanceManager.cpp
@@ -78,7 +78,7 @@ std::shared_ptr<Instance> CreateReactInstance(
 				// Load from Assets.
 				script = loadScriptFromAssets(assetManager, platformBundle.BundleUrl);
 			}
-			instance->loadScriptFromString(std::move(script), platformBundle.Version, std::move(platformBundle.BundleUrl), true /*synchronously*/, "" /*bytecodeFileName*/);
+			instance->loadScriptFromString(std::move(script), platformBundle.Version, std::move(platformBundle.BundleUrl), true /*synchronously*/);
 		}
 	}
 
@@ -94,7 +94,7 @@ std::shared_ptr<Instance> CreateReactInstance(
 		// Load from Assets.
 		script = loadScriptFromAssets(assetManager, jsBundleFile);
 	}
-	instance->loadScriptFromString(std::move(script), 0 /*bundleVersion*/, jsBundleFile, false, "" /*bytecodeFileName*/);
+	instance->loadScriptFromString(std::move(script), 0 /*bundleVersion*/, jsBundleFile, false);
 	return instance;
 }
 

--- a/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
@@ -211,7 +211,7 @@ void CatalystInstanceImpl::jniLoadScriptFromAssets(
   } else if (Instance::isIndexedRAMBundle(&script)) {
     instance_->loadRAMBundleFromString(std::move(script), sourceURL);
   } else {
-    instance_->loadScriptFromString(std::move(script), 0 /*bundleVersion*/, sourceURL, loadSynchronously, "" /*bytecodeFileName*/);
+    instance_->loadScriptFromString(std::move(script), 0 /*bundleVersion*/, sourceURL, loadSynchronously);
   }
 }
 
@@ -226,7 +226,7 @@ void CatalystInstanceImpl::jniLoadScriptFromFile(const std::string& fileName,
       [&fileName, &script]() {
         script = JSBigFileString::fromPath(fileName);
       });
-    instance_->loadScriptFromString(std::move(script), 0 /*bundleVersion*/, sourceURL, loadSynchronously, "" /*bytecodeFileName*/);
+    instance_->loadScriptFromString(std::move(script), 0 /*bundleVersion*/, sourceURL, loadSynchronously);
   }
 }
 

--- a/ReactAndroid/src/main/jni/react/jni/InstanceManager.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/InstanceManager.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<Instance> CreateReactInstance(
 				// Load from Assets.
 				script = loadScriptFromAssets(assetManager, platformBundle.BundleUrl);
 			}
-			instance->loadScriptFromString(std::move(script), platformBundle.Version, std::move(platformBundle.BundleUrl), true /*synchronously*/, "" /*bytecodeFileName*/);
+			instance->loadScriptFromString(std::move(script), platformBundle.Version, std::move(platformBundle.BundleUrl), true /*synchronously*/);
 		}
 	}
 
@@ -95,7 +95,7 @@ std::shared_ptr<Instance> CreateReactInstance(
 		// Load from Assets.
 		script = loadScriptFromAssets(assetManager, jsBundleFile);
 	}
-	instance->loadScriptFromString(std::move(script), 0 /*bundleVersion*/, jsBundleFile, false, "" /*bytecodeFileName*/);
+	instance->loadScriptFromString(std::move(script), 0 /*bundleVersion*/, jsBundleFile, false);
 	return instance;
 }
 

--- a/ReactAndroid/src/main/jni/react/jni/ProxyExecutor.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/ProxyExecutor.cpp
@@ -52,8 +52,7 @@ ProxyExecutor::~ProxyExecutor() {
 void ProxyExecutor::loadApplicationScript(
     std::unique_ptr<const JSBigString>,
     uint64_t /*scriptVersion*/,
-    std::string sourceURL,
-    std::string&& /*bytecodeFileName*/) {
+    std::string sourceURL) {
 
   folly::dynamic nativeModuleConfig = folly::dynamic::array;
 

--- a/ReactAndroid/src/main/jni/react/jni/ProxyExecutor.h
+++ b/ReactAndroid/src/main/jni/react/jni/ProxyExecutor.h
@@ -38,8 +38,7 @@ public:
   virtual void loadApplicationScript(
     std::unique_ptr<const JSBigString> script,
     uint64_t scriptVersion,
-    std::string sourceURL,
-    std::string&& bytecodeFileName) override;
+    std::string sourceURL) override;
   virtual void setBundleRegistry(
     std::unique_ptr<RAMBundleRegistry> bundle) override;
   virtual void registerBundle(

--- a/ReactCommon/cxxreact/Instance.cpp
+++ b/ReactCommon/cxxreact/Instance.cpp
@@ -70,46 +70,43 @@ void Instance::initializeBridge(
 void Instance::loadApplication(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
                                std::unique_ptr<const JSBigString> bundle,
                                uint64_t bundleVersion, // TODO(OSS Candidate ISS#2710739)
-                               std::string bundleURL,
-                               std::string&& bytecodeFileName) { // TODO(OSS Candidate ISS#2710739)
+                               std::string bundleURL) { // TODO(OSS Candidate ISS#2710739)
   callback_->incrementPendingJSCalls();
   SystraceSection s("Instance::loadApplication", "bundleURL",
                     bundleURL);
   nativeToJsBridge_->loadApplication(std::move(bundleRegistry), std::move(bundle), bundleVersion,
-                                     std::move(bundleURL), std::move(bytecodeFileName));
+                                     std::move(bundleURL));
 }
 
 void Instance::loadApplicationSync(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
                                    std::unique_ptr<const JSBigString> bundle,
                                    uint64_t bundleVersion, // TODO(OSS Candidate ISS#2710739)
-                                   std::string bundleURL,
-                                   std::string&& bytecodeFileName) { // TODO(OSS Candidate ISS#2710739)
+                                   std::string bundleURL) {
   std::unique_lock<std::mutex> lock(m_syncMutex);
   m_syncCV.wait(lock, [this] { return m_syncReady; });
 
   SystraceSection s("Instance::loadApplicationSync", "bundleURL",
                     bundleURL);
   nativeToJsBridge_->loadApplicationSync(std::move(bundleRegistry), std::move(bundle), bundleVersion,
-                                         std::move(bundleURL), std::move(bytecodeFileName)); // TODO(OSS Candidate ISS#2710739)
+                                         std::move(bundleURL));
 }
 
 void Instance::setSourceURL(std::string sourceURL) {
   callback_->incrementPendingJSCalls();
   SystraceSection s("Instance::setSourceURL", "sourceURL", sourceURL);
 
-  nativeToJsBridge_->loadApplication(nullptr, nullptr, 0, std::move(sourceURL), "" /*bytecodeFileName*/); // TODO(OSS Candidate ISS#2710739)
+  nativeToJsBridge_->loadApplication(nullptr, nullptr, 0, std::move(sourceURL)); // TODO(OSS Candidate ISS#2710739)
 }
 
 void Instance::loadScriptFromString(std::unique_ptr<const JSBigString> bundleString,
                                     uint64_t bundleVersion,
                                     std::string bundleURL, // TODO(OSS Candidate ISS#2710739)
-                                    bool loadSynchronously,
-                                    std::string&& bytecodeFileName) { // TODO(OSS Candidate ISS#2710739)
+                                    bool loadSynchronously) {
   SystraceSection s("Instance::loadScriptFromString", "bundleURL", bundleURL); // TODO(OSS Candidate ISS#2710739)
   if (loadSynchronously) {
-    loadApplicationSync(nullptr, std::move(bundleString), bundleVersion, std::move(bundleURL), std::move(bytecodeFileName)); // TODO(OSS Candidate ISS#2710739)
+    loadApplicationSync(nullptr, std::move(bundleString), bundleVersion, std::move(bundleURL)); // TODO(OSS Candidate ISS#2710739)
   } else {
-    loadApplication(nullptr, std::move(bundleString), bundleVersion, std::move(bundleURL), std::move(bytecodeFileName)); // TODO(OSS Candidate ISS#2710739)
+    loadApplication(nullptr, std::move(bundleString), bundleVersion, std::move(bundleURL)); // TODO(OSS Candidate ISS#2710739)
   }
 }
 
@@ -162,10 +159,10 @@ void Instance::loadRAMBundle(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
                              bool loadSynchronously) {
   if (loadSynchronously) {
     loadApplicationSync(std::move(bundleRegistry), std::move(startupScript), 0 /*bundleVersion*/, // TODO(OSS Candidate ISS#2710739)
-                        std::move(startupScriptSourceURL), "" /*bytecodeFileName*/); // TODO(OSS Candidate ISS#2710739)
+                        std::move(startupScriptSourceURL));
   } else {
     loadApplication(std::move(bundleRegistry), std::move(startupScript), 0 /*bundleVersion*/, // TODO(OSS Candidate ISS#2710739)
-                    std::move(startupScriptSourceURL), "" /*bytecodeFileName*/); // TODO(OSS Candidate ISS#2710739)
+                    std::move(startupScriptSourceURL));
   }
 }
 

--- a/ReactCommon/cxxreact/Instance.h
+++ b/ReactCommon/cxxreact/Instance.h
@@ -63,8 +63,7 @@ public:
   void setSourceURL(std::string sourceURL);
 
   virtual void loadScriptFromString(std::unique_ptr<const JSBigString> bundleString,
-                            uint64_t bundleVersion, std::string bundleURL, bool loadSynchronously,
-                            std::string&& bytecodeFileName);
+                            uint64_t bundleVersion, std::string bundleURL, bool loadSynchronously);
   static bool isIndexedRAMBundle(const char *sourcePath);
   static bool isIndexedRAMBundle(std::unique_ptr<const JSBigString>* string);
   void loadRAMBundleFromString(std::unique_ptr<const JSBigString> script, const std::string& sourceURL);
@@ -107,13 +106,11 @@ private:
   virtual void loadApplication(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
                        std::unique_ptr<const JSBigString> bundle,
                        uint64_t bundleVersion, // TODO(OSS Candidate ISS#2710739)
-                       std::string bundleURL,
-                       std::string&& bytecodeFileName); // TODO(OSS Candidate ISS#2710739)
+                       std::string bundleURL);
   virtual void loadApplicationSync(std::unique_ptr<RAMBundleRegistry> bundleRegistry,
                            std::unique_ptr<const JSBigString> bundle,
                            uint64_t bundleVersion, // TODO(OSS Candidate ISS#2710739)
-                           std::string bundleURL,
-                           std::string&& bytecodeFileName); // TODO(OSS Candidate ISS#2710739)
+                           std::string bundleURL);
 
   std::shared_ptr<InstanceCallback> callback_;
   std::unique_ptr<NativeToJsBridge> nativeToJsBridge_;

--- a/ReactCommon/cxxreact/JSExecutor.h
+++ b/ReactCommon/cxxreact/JSExecutor.h
@@ -78,8 +78,7 @@ public:
    */
   virtual void loadApplicationScript(std::unique_ptr<const JSBigString> script,
                                      uint64_t scriptVersion, // TODO(OSS Candidate ISS#2710739)
-                                     std::string sourceURL,
-                                     std::string&& bytecodeFileName) = 0; // TODO(OSS Candidate ISS#2710739)
+                                     std::string sourceURL) = 0;
 
   /**
    * Add an application "RAM" bundle registry

--- a/ReactCommon/cxxreact/NativeToJsBridge.cpp
+++ b/ReactCommon/cxxreact/NativeToJsBridge.cpp
@@ -106,16 +106,14 @@ void NativeToJsBridge::loadApplication(
     std::unique_ptr<RAMBundleRegistry> bundleRegistry,
     std::unique_ptr<const JSBigString> startupScript,
     uint64_t bundleVersion, // TODO(OSS Candidate ISS#2710739)
-    std::string startupScriptSourceURL,
-    std::string&& bytecodeFileName) { // TODO(OSS Candidate ISS#2710739)
+    std::string startupScriptSourceURL) {
 
   runOnExecutorQueue(
       [this,
        bundleRegistryWrap=folly::makeMoveWrapper(std::move(bundleRegistry)),
        startupScript=folly::makeMoveWrapper(std::move(startupScript)),
        bundleVersion,
-       startupScriptSourceURL=std::move(startupScriptSourceURL),
-       bytecodeFileName=std::move(bytecodeFileName)]
+       startupScriptSourceURL=std::move(startupScriptSourceURL)]
         (JSExecutor* executor) mutable {
     auto bundleRegistry = bundleRegistryWrap.move();
     if (bundleRegistry) {
@@ -124,8 +122,7 @@ void NativeToJsBridge::loadApplication(
     try {
       executor->loadApplicationScript(std::move(*startupScript),
                                       bundleVersion, // TODO(OSS Candidate ISS#2710739)
-                                      std::move(startupScriptSourceURL),
-                                      std::move(bytecodeFileName)); // TODO(OSS Candidate ISS#2710739)
+                                      std::move(startupScriptSourceURL));
     } catch (...) {
       m_applicationScriptHasFailure = true;
       throw;
@@ -137,16 +134,14 @@ void NativeToJsBridge::loadApplicationSync(
     std::unique_ptr<RAMBundleRegistry> bundleRegistry,
     std::unique_ptr<const JSBigString> startupScript,
     uint64_t bundleVersion,
-    std::string startupScriptSourceURL,
-    std::string&& bytecodeFileName) {
+    std::string startupScriptSourceURL) {
   if (bundleRegistry) {
     m_executor->setBundleRegistry(std::move(bundleRegistry));
   }
   try {
     m_executor->loadApplicationScript(std::move(startupScript),
                                           bundleVersion, // TODO(OSS Candidate ISS#2710739)
-                                          std::move(startupScriptSourceURL),
-                                          std::move(bytecodeFileName)); // TODO(OSS Candidate ISS#2710739)
+                                          std::move(startupScriptSourceURL));
   } catch (...) {
     m_applicationScriptHasFailure = true;
     throw;

--- a/ReactCommon/cxxreact/NativeToJsBridge.h
+++ b/ReactCommon/cxxreact/NativeToJsBridge.h
@@ -68,14 +68,12 @@ public:
     std::unique_ptr<RAMBundleRegistry> bundleRegistry,
     std::unique_ptr<const JSBigString> bundle,
     uint64_t bundleVersion, // TODO(OSS Candidate ISS#2710739)
-    std::string bundleURL,
-    std::string&& bytecodeFileName); // TODO(OSS Candidate ISS#2710739)
+    std::string bundleURL);
   void loadApplicationSync(
     std::unique_ptr<RAMBundleRegistry> bundleRegistry,
     std::unique_ptr<const JSBigString> bundle,
     uint64_t bundleVersion, // TODO(OSS Candidate ISS#2710739)
-    std::string bundleURL,
-    std::string&& bytecodeFileName); // TODO(OSS Candidate ISS#2710739)
+    std::string bundleURL);
 
   void registerBundle(uint32_t bundleId, const std::string& bundlePath);
   void setGlobalVariable(std::string propName, std::unique_ptr<const JSBigString> jsonValue);

--- a/ReactCommon/cxxreact/V8Executor.cpp
+++ b/ReactCommon/cxxreact/V8Executor.cpp
@@ -368,9 +368,9 @@ static std::string simpleBasename(const std::string &path) {
   LOGV("V8Executor::simpleBasename exit");
 }
 
-void V8Executor::loadApplicationScript(std::unique_ptr<const JSBigString> script, uint64_t /*scriptVersion*/, std::string sourceURL, std::string&& bytecodeFileName) {
+void V8Executor::loadApplicationScript(std::unique_ptr<const JSBigString> script, uint64_t /*scriptVersion*/, std::string sourceURL) {
 
-  LOGV("V8Executor::loadApplicationScript entry sourceURL = %s, bytecodeFileName = %s", sourceURL.c_str(), bytecodeFileName.c_str());
+  LOGV("V8Executor::loadApplicationScript entry sourceURL = %s", sourceURL.c_str());
   SystraceSection s("V8Executor::loadApplicationScript", "sourceURL", sourceURL);
   std::string scriptName = simpleBasename(sourceURL);
   ReactMarker::logTaggedMarker(ReactMarker::RUN_JS_BUNDLE_START, scriptName.c_str());

--- a/ReactCommon/cxxreact/V8Executor.h
+++ b/ReactCommon/cxxreact/V8Executor.h
@@ -55,8 +55,7 @@ public:
   virtual void loadApplicationScript(
     std::unique_ptr<const JSBigString> script,
     uint64_t scriptVersion,
-    std::string sourceURL,
-    std::string&& bytecodeFileName) override;
+    std::string sourceURL) override;
     
   virtual void registerBundle(uint32_t bundleId, const std::string& bundlePath) override;
 

--- a/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
+++ b/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
@@ -70,8 +70,7 @@ JSIExecutor::JSIExecutor(
 void JSIExecutor::loadApplicationScript(
       std::unique_ptr<const JSBigString> script,
       uint64_t /*scriptVersion*/, // TODO(OSS Candidate ISS#2710739)
-      std::string sourceURL,
-      std::string&& /*bytecodeFileName*/) { // TODO(OSS Candidate ISS#2710739)
+      std::string sourceURL) {
   SystraceSection s("JSIExecutor::loadApplicationScript");
 
   // TODO: check for and use precompiled HBC

--- a/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
+++ b/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
@@ -77,8 +77,7 @@ class JSIExecutor : public JSExecutor {
       RuntimeInstaller runtimeInstaller);
   void loadApplicationScript(std::unique_ptr<const JSBigString> script,
                              uint64_t scriptVersion, // TODO(OSS Candidate ISS#2710739)
-                             std::string sourceURL,
-                             std::string&& bytecodeFileName) override; // TODO(OSS Candidate ISS#2710739)
+                             std::string sourceURL) override;
   void setBundleRegistry(std::unique_ptr<RAMBundleRegistry>) override;
   void registerBundle(uint32_t bundleId, const std::string &bundlePath)
       override;


### PR DESCRIPTION
## Summary
bytecodeFileName is used excusively by ChakraExecutor in react-native-windows, and diverges us from upstream. Remove the concept in favor of passing bytecodeFileName directly to the ChakraJsExecutorFactory at creation time. We currently use a single bytecode file per-instance , so we see no loss of functionality when moving to a 1:1 relationship between executor and bytecode file.

Locally validated that Android NDK libs still build. Verified we can build react-native-windows after some small changes that must be commited separately.

#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/183)