### PR TITLE
Console.assert doesn't exist in the simulator, so this will always re…

### DIFF
--- a/Libraries/polyfills/console.js
+++ b/Libraries/polyfills/console.js
@@ -559,13 +559,13 @@ if (global.nativeLoggingHook) {
         console[methodName] = function() {
           // TODO(T43930203): remove this special case once originalConsole.assert properly checks
           // the condition
-          // if (methodName === 'assert') {
-          //   if (!arguments[0]) {
-          //     originalConsole.assert(...arguments);
-          //   }
-          // } else {
+          if (methodName === 'assert') {
+            if (!arguments[0] && originalConsole.hasOwnProperty('assert')) {
+              originalConsole.assert(...arguments);
+            }
+          } else {
             originalConsole[methodName](...arguments);
-          // }
+          }
           reactNativeMethod.apply(console, arguments);
         };
       }

--- a/Libraries/polyfills/console.js
+++ b/Libraries/polyfills/console.js
@@ -559,13 +559,13 @@ if (global.nativeLoggingHook) {
         console[methodName] = function() {
           // TODO(T43930203): remove this special case once originalConsole.assert properly checks
           // the condition
-          if (methodName === 'assert') {
-            if (!arguments[0]) {
-              originalConsole.assert(...arguments);
-            }
-          } else {
+          // if (methodName === 'assert') {
+          //   if (!arguments[0]) {
+          //     originalConsole.assert(...arguments);
+          //   }
+          // } else {
             originalConsole[methodName](...arguments);
-          }
+          // }
           reactNativeMethod.apply(console, arguments);
         };
       }


### PR DESCRIPTION
…dbox unless the debugger is attached (in which case it runs through chrome which has all the console methods already defined)

- [ X] I am making a change required for Microsoft usage of react-native

#### Overview
Add a check that assert exists. This is also a problem several people are reporting in the community so we should push this back to facebook as well.

#### Focus areas to test
Launching RNC and Polyester no longer redbox and tests can run without the remote debugger attached.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/184)