### PR TITLE
Add memory management and concurrency tests plans to our fork of Reac…

### DIFF
--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.h
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.h
@@ -5,13 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import "RCTBackedTextInputViewProtocol.h"
-#import "RCTBackedTextInputDelegate.h"
 #import "../RCTTextUIKit.h" // TODO(macOS ISS#2323203)
 
 NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - RCTBackedTextFieldDelegateAdapter (for UITextField)
+
+@protocol RCTBackedTextInputViewProtocol; // TODO(OSS Candidate ISS#2710739)
+@protocol RCTBackedTextInputDelegate; // TODO(OSS Candidate ISS#2710739)
 
 @interface RCTBackedTextFieldDelegateAdapter : NSObject
 

--- a/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+++ b/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
@@ -6,6 +6,8 @@
  */
 
 #import "RCTBackedTextInputDelegateAdapter.h"
+#import "RCTBackedTextInputViewProtocol.h" // TODO(OSS Candidate ISS#2710739)
+#import "RCTBackedTextInputDelegate.h" // TODO(OSS Candidate ISS#2710739)
 #import "../RCTTextUIKit.h" // TODO(macOS ISS#2323203)
 
 #pragma mark - RCTBackedTextFieldDelegateAdapter (for UITextField)

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.m
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.m
@@ -11,6 +11,7 @@
 #import <React/UIView+React.h>
 
 #import "RCTBackedTextInputDelegateAdapter.h"
+#import "RCTBackedTextInputDelegate.h" // TODO(OSS Candidate ISS#2710739)
 #import "RCTTextAttributes.h"
 
 #if TARGET_OS_OSX // [TODO(macOS ISS#2323203)

--- a/RNTester/RNTester.xcodeproj/project.pbxproj
+++ b/RNTester/RNTester.xcodeproj/project.pbxproj
@@ -915,6 +915,7 @@
 		8385CF031B87479200C6273E /* RCTImageLoaderHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTImageLoaderHelpers.m; sourceTree = "<group>"; };
 		8385CF051B8747A000C6273E /* RCTImageLoaderHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTImageLoaderHelpers.h; sourceTree = "<group>"; };
 		9F1534BD233AB44F006DFE44 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+		9F1C4D00236CB06B0022EC0D /* RNTesterTestPlan_iOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = RNTesterTestPlan_iOS.xctestplan; sourceTree = "<group>"; };
 		9F5C1923230F46CB00E3E5A7 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 		9FBFA513233C7E4C003D9A8D /* RNTesterBundle-macOS.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RNTesterBundle-macOS.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9FBFA515233C7E4C003D9A8D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1452,6 +1453,7 @@
 		3D13F83F1D6F6AE000E69E0E /* RNTesterBundle */ = {
 			isa = PBXGroup;
 			children = (
+				9F1C4D00236CB06B0022EC0D /* RNTesterTestPlan_iOS.xctestplan */,
 				3D13F8401D6F6AE000E69E0E /* Info.plist */,
 				3D13F8441D6F6AF200E69E0E /* ImageInBundle.png */,
 				3D13F8451D6F6AF200E69E0E /* OtherImages.xcassets */,

--- a/RNTester/RNTester.xcodeproj/xcshareddata/xcschemes/RNTester.xcscheme
+++ b/RNTester/RNTester.xcodeproj/xcshareddata/xcschemes/RNTester.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0940"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
@@ -83,6 +83,21 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
+            BuildableName = "RNTester.app"
+            BlueprintName = "RNTester"
+            ReferencedContainer = "container:RNTester.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:RNTester/RNTesterBundle/RNTesterTestPlan_iOS.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -110,17 +125,6 @@
             </SkippedTests>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "13B07F861A680F5B00A75B9A"
-            BuildableName = "RNTester.app"
-            BlueprintName = "RNTester"
-            ReferencedContainer = "container:RNTester.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -154,8 +158,6 @@
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/RNTester/RNTester/RNTesterBundle/RNTesterTestPlan_iOS.xctestplan
+++ b/RNTester/RNTester/RNTesterBundle/RNTesterTestPlan_iOS.xctestplan
@@ -1,0 +1,74 @@
+{
+  "configurations" : [
+    {
+      "id" : "8505E0BC-7E4D-4320-A0AB-AA632872F9B6",
+      "name" : "Default",
+      "options" : {
+
+      }
+    },
+    {
+      "id" : "37D31EEF-8FEF-4078-89E7-6BA48A640995",
+      "name" : "Memory Checking",
+      "options" : {
+        "addressSanitizer" : {
+          "detectStackUseAfterReturn" : true,
+          "enabled" : true
+        },
+        "nsZombieEnabled" : true
+      }
+    },
+    {
+      "id" : "B79DCEC6-8538-44AF-B29F-2F45036E8EE2",
+      "name" : "Concurrency",
+      "options" : {
+        "testExecutionOrdering" : "random",
+        "undefinedBehaviorSanitizerEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "environmentVariableEntries" : [
+      {
+        "key" : "CI_USE_PACKAGER",
+        "value" : "1"
+      },
+      {
+        "key" : "RN_BUNDLE_PREFIX",
+        "value" : ""
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:RNTester.xcodeproj",
+      "identifier" : "13B07F861A680F5B00A75B9A",
+      "name" : "RNTester"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "skippedTests" : [
+        "RCTModuleInitTests\/testCustomInitModuleInitializedAtBridgeStartup",
+        "RCTModuleInitTests\/testLazyInitModuleNotInitializedDuringBridgeInit"
+      ],
+      "target" : {
+        "containerPath" : "container:RNTester.xcodeproj",
+        "identifier" : "004D289D1AAF61C70097A701",
+        "name" : "RNTesterUnitTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "skippedTests" : [
+        "RNTesterIntegrationTests\/testAccessibilityManagerTest",
+        "RNTesterIntegrationTests\/testWebSocketTest"
+      ],
+      "target" : {
+        "containerPath" : "container:RNTester.xcodeproj",
+        "identifier" : "143BC5941B21E3E100462512",
+        "name" : "RNTesterIntegrationTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/RNTester/RNTester/RNTesterBundle/RNTesterTestPlan_iOS.xctestplan
+++ b/RNTester/RNTester/RNTesterBundle/RNTesterTestPlan_iOS.xctestplan
@@ -61,6 +61,8 @@
       "parallelizable" : true,
       "skippedTests" : [
         "RNTesterIntegrationTests\/testAccessibilityManagerTest",
+        "RNTesterIntegrationTests\/testAppEventsTest",
+        "RNTesterIntegrationTests\/testSyncMethodTest",
         "RNTesterIntegrationTests\/testWebSocketTest"
       ],
       "target" : {

--- a/RNTester/RNTester/RNTesterBundle/RNTesterTestPlan_iOS.xctestplan
+++ b/RNTester/RNTester/RNTesterBundle/RNTesterTestPlan_iOS.xctestplan
@@ -1,13 +1,6 @@
 {
   "configurations" : [
     {
-      "id" : "8505E0BC-7E4D-4320-A0AB-AA632872F9B6",
-      "name" : "Default",
-      "options" : {
-
-      }
-    },
-    {
       "id" : "37D31EEF-8FEF-4078-89E7-6BA48A640995",
       "name" : "Memory Checking",
       "options" : {
@@ -47,10 +40,6 @@
   "testTargets" : [
     {
       "parallelizable" : true,
-      "skippedTests" : [
-        "RCTModuleInitTests\/testCustomInitModuleInitializedAtBridgeStartup",
-        "RCTModuleInitTests\/testLazyInitModuleNotInitializedDuringBridgeInit"
-      ],
       "target" : {
         "containerPath" : "container:RNTester.xcodeproj",
         "identifier" : "004D289D1AAF61C70097A701",
@@ -60,10 +49,7 @@
     {
       "parallelizable" : true,
       "skippedTests" : [
-        "RNTesterIntegrationTests\/testAccessibilityManagerTest",
-        "RNTesterIntegrationTests\/testAppEventsTest",
-        "RNTesterIntegrationTests\/testSyncMethodTest",
-        "RNTesterIntegrationTests\/testWebSocketTest"
+        "RNTesterIntegrationTests\/testAccessibilityManagerTest"
       ],
       "target" : {
         "containerPath" : "container:RNTester.xcodeproj",

--- a/React/CxxBridge/RCTMessageThread.h
+++ b/React/CxxBridge/RCTMessageThread.h
@@ -15,7 +15,7 @@
 namespace facebook {
 namespace react {
 
-class RCTMessageThread : public MessageQueueThread {
+class RCTMessageThread : public MessageQueueThread, public std::enable_shared_from_this<RCTMessageThread> { // TODO(OSS Candidate ISS#2710739)
  public:
   RCTMessageThread(NSRunLoop *runLoop, RCTJavaScriptCompleteBlock errorBlock);
   ~RCTMessageThread() override;


### PR DESCRIPTION
…t Native

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X ] I am making a change required for Microsoft usage of react-native

React Native has limited tooling running as it executes tests. We should perform more rigorous memory management checks given the memory issues we've seen in the past with RN. While we're at it, let's add a test plan for code concurrency. RN has a lot of multithreadedness that should have race conditions and execution various orders verified.

1) Run all tests with main thread checker on to get us a baseline. This is what we already have on all the time.
2) Run all tests with ASan and Zombie objects on
3) Run all tests with a random execution order

We should enable TSan as well, but right now so many tests crash with TSan on, it makes more sense to leave it off for now and then go through the tests one at a time and get them working with TSan before turning it on permanently.

#### Focus areas to test

Only impacts our tests.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/186)