### PR TITLE
Add a mac test plan to improve our confidence in fixes going into RN …

### DIFF
--- a/RNTester/RNTester-macOS/RNTesterTestPlan_mac.xctestplan
+++ b/RNTester/RNTester-macOS/RNTesterTestPlan_mac.xctestplan
@@ -1,0 +1,54 @@
+{
+  "configurations" : [
+    {
+      "id" : "AFD9E2BD-E33C-4C4A-A384-5EAE06C9A403",
+      "name" : "Memory Checking",
+      "options" : {
+        "addressSanitizer" : {
+          "detectStackUseAfterReturn" : true,
+          "enabled" : true
+        },
+        "nsZombieEnabled" : true
+      }
+    },
+    {
+      "id" : "25FE48EC-9A2D-4569-A6B2-13F09014C2AB",
+      "name" : "Concurrency",
+      "options" : {
+        "testExecutionOrdering" : "random",
+        "undefinedBehaviorSanitizerEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "environmentVariableEntries" : [
+      {
+        "key" : "CI_USE_PACKAGER",
+        "value" : "1"
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:RNTester.xcodeproj",
+      "identifier" : "18FC77851EF4770B002B3F17",
+      "name" : "RNTester-macOS"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:RNTester.xcodeproj",
+        "identifier" : "18FC779A1EF4770B002B3F17",
+        "name" : "RNTester-macOSUnitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:RNTester.xcodeproj",
+        "identifier" : "18FC77A51EF4770B002B3F17",
+        "name" : "RNTester-macOSIntegrationTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/RNTester/RNTester.xcodeproj/project.pbxproj
+++ b/RNTester/RNTester.xcodeproj/project.pbxproj
@@ -916,6 +916,7 @@
 		8385CF051B8747A000C6273E /* RCTImageLoaderHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTImageLoaderHelpers.h; sourceTree = "<group>"; };
 		9F1534BD233AB44F006DFE44 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 		9F1C4D00236CB06B0022EC0D /* RNTesterTestPlan_iOS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = RNTesterTestPlan_iOS.xctestplan; sourceTree = "<group>"; };
+		9F4D1F022375E7A10012B4A9 /* RNTesterTestPlan_mac.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = RNTesterTestPlan_mac.xctestplan; sourceTree = "<group>"; };
 		9F5C1923230F46CB00E3E5A7 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 		9FBFA513233C7E4C003D9A8D /* RNTesterBundle-macOS.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RNTesterBundle-macOS.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9FBFA515233C7E4C003D9A8D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1362,6 +1363,7 @@
 		18FC77871EF4770B002B3F17 /* RNTester-macOS */ = {
 			isa = PBXGroup;
 			children = (
+				9F4D1F022375E7A10012B4A9 /* RNTesterTestPlan_mac.xctestplan */,
 				18FC77881EF4770B002B3F17 /* AppDelegate.h */,
 				18FC77891EF4770B002B3F17 /* AppDelegate.m */,
 				18FC778E1EF4770B002B3F17 /* ViewController.h */,

--- a/RNTester/RNTester.xcodeproj/xcshareddata/xcschemes/RNTester-macOS.xcscheme
+++ b/RNTester/RNTester.xcodeproj/xcshareddata/xcschemes/RNTester-macOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0830"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
@@ -64,6 +64,12 @@
             ReferencedContainer = "container:RNTester.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:RNTester-macOS/RNTesterTestPlan_mac.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
…moving forward. Check for safe memory usage and concurrency problems

#### Please select one of the following
- [X] I am making a fix / change for the macOS implementation of react-native

Add a Mac test plan to give us more confidence that future RN changes we pull are up to our code quality standards.

Memory Checking configuration- main thread checker, ASan, Zombies
Concurrency configuration- main thread checker, random test order, UBSan

#### Focus areas to test

Only impacts tests.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/190)