### PR TITLE
Revert an RTL change we made that FB fixed at a lower level, making t…

### DIFF
--- a/React/Views/SafeAreaView/RCTSafeAreaShadowView.m
+++ b/React/Views/SafeAreaView/RCTSafeAreaShadowView.m
@@ -11,7 +11,6 @@
 #import <yoga/Yoga.h>
 
 #import "RCTSafeAreaViewLocalData.h"
-#import "RCTI18nUtil.h"
 
 @implementation RCTSafeAreaShadowView
 
@@ -22,24 +21,12 @@
 
   UIEdgeInsets insets = localData.insets;
 
+  super.paddingLeft = (YGValue){insets.left, YGUnitPoint};
+  super.paddingRight = (YGValue){insets.right, YGUnitPoint};
   super.paddingTop = (YGValue){insets.top, YGUnitPoint};
   super.paddingBottom = (YGValue){insets.bottom, YGUnitPoint};
-  // [TODO(OSS OC#2726827)
-  if ([[RCTI18nUtil sharedInstance] doLeftAndRightSwapInRTL]) {
-    if ([[RCTI18nUtil sharedInstance] isRTL]) {
-      super.paddingStart = (YGValue){insets.right, YGUnitPoint};
-      super.paddingEnd = (YGValue){insets.left, YGUnitPoint};
-    } else {
-      super.paddingStart = (YGValue){insets.left, YGUnitPoint};
-      super.paddingEnd = (YGValue){insets.right, YGUnitPoint};
-    }
-    [self didSetProps:@[@"paddingStart", @"paddingEnd", @"paddingTop", @"paddingBottom"]];
-  } else {
-    super.paddingLeft = (YGValue){insets.left, YGUnitPoint};
-    super.paddingRight = (YGValue){insets.right, YGUnitPoint};
-    [self didSetProps:@[@"paddingLeft", @"paddingRight", @"paddingTop", @"paddingBottom"]];
-  }
-  // ]TODO(OSS OC#2726827)
+
+  [self didSetProps:@[@"paddingLeft", @"paddingRight", @"paddingTop", @"paddingBottom"]];
 }
 
 /**


### PR DESCRIPTION
…his obsolete. This file now aligns with what FB has in their repo

#### Please select one of the following
- [X] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:

This was added back in January 2019 to get RTL support in safe views. Facebook has since added their own logic to do this at the Yoga layer, which is a more fundamental layer. Facebook's fix is more central and should be kept, while this one is now superfluous.

https://github.com/facebook/react-native/commit/21363add69684e9afbb4523ba2539b908112bac7

#### Focus areas to test

1) Launch SafeView on notched iOS device in portrait and landscape
2) Examine what sides the view padding is on
3) Turn on RTL and repeat 1 & 2

The padding switches sides between RTL/LTR with or without this code, making this code obsolete.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/194)