### PR TITLE
Use $buildNumber$ token for NuGet

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -5,6 +5,7 @@ trigger: none # will disable CI builds entirely
 
 pr:
 - master
+- 0.59-stable
 
 jobs:
   - job: AndroidRNPR

--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -118,6 +118,7 @@ jobs:
           command: pack
           packagesToPack: 'ReactAndroid/ReactAndroid.nuspec'
           packDestination: '$(System.DefaultWorkingDirectory)'
+          buildProperties: buildNumber=$(buildNumber);commitId=$(Build.SourceVersion)
 
       - task: Gradle@1
         displayName: gradlew clean

--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -22,6 +22,10 @@ jobs:
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
+      - task: UseNode@1
+        inputs:
+          version: '10.x'
+
       - task: CmdLine@2
         displayName: npm install
         inputs:

--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -26,6 +26,11 @@ jobs:
         inputs:
           version: '10.x'
 
+      # Install NuGet v4.6.4+
+      - task: NuGetToolInstaller@1
+        inputs:
+          versionSpec: '>=4.6.4'
+
       - task: CmdLine@2
         displayName: npm install
         inputs:

--- a/.ado/apple-pr.yml
+++ b/.ado/apple-pr.yml
@@ -5,6 +5,7 @@ trigger: none # will disable CI builds entirely
 
 pr:
 - master
+- 0.59-stable
 
 jobs:
   - job: AppleRNPR

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -111,6 +111,7 @@ jobs:
           command: pack
           packagesToPack: 'ReactAndroid/ReactAndroid.nuspec'
           packDestination: '$(Build.StagingDirectory)\final'
+          buildProperties: buildNumber=$(buildNumber);commitId=$(Build.SourceVersion)
 
       - task: CmdLine@2
         displayName: Do Publish

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -29,6 +29,11 @@ jobs:
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
+      # Install NuGet v4.6.4+
+      - task: NuGetToolInstaller@1
+        inputs:
+          versionSpec: '>=4.6.4'
+
       - task: CmdLine@2
         displayName: npm install
         inputs:

--- a/.ado/templates/prep-android-nuget.yml
+++ b/.ado/templates/prep-android-nuget.yml
@@ -1,12 +1,12 @@
 steps:
   - task: PowerShell@2
-    displayName: Extract version from package.json, and put it in nuspec
+    displayName: Extract version from package.json, and put it in `buildNumber` variable
     inputs:
       targetType: inline # filePath | inline
       script: |
         $lines = Get-Content package.json | Where {$_ -match '^\s*"version":.*'} 
         $npmVersion = $lines.Trim().Split()[1].Trim('",');
-        (Get-Content ReactAndroid/ReactAndroid.nuspec).replace('__BuildBuildNumber__', $npmVersion) | Set-Content ReactAndroid/ReactAndroid.nuspec
+        echo "##vso[task.setvariable variable=buildNumber]$npmVersion"
 
   # Pretty yucky - but we dont want devmain to have to update versions _all_ over the place
   - task: PowerShell@2

--- a/ReactAndroid/ReactAndroid.nuspec
+++ b/ReactAndroid/ReactAndroid.nuspec
@@ -2,10 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>OfficeReact.Android</id>
-    <version>__BuildBuildNumber__</version>
+    <version>$buildNumber$</version>
     <description>Contains Android Implementation of React-Native</description>
     <authors>Microsoft</authors>
     <projectUrl>https://github.com/microsoft/react-native</projectUrl>
+    <repository type="git" url="https://github.com/microsoft/react-native.git" commit="$commitId$" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
   </metadata>
 

--- a/ReactApple/ReactApple.nuspec
+++ b/ReactApple/ReactApple.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>OfficeReact.Apple</id>
-    <version>__BuildBuildNumber__</version>
+    <version>$buildNumber$</version>
     <description>Contains Mac and iOS Implementations of React-Native</description>
     <authors>Microsoft</authors>
     <projectUrl>https://github.com/microsoft/react-native</projectUrl>


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

(TSIA) Use proper token, `$buildNumber$`, in ReactAndroid.nuspec and ReactApple.nuspec.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/199)