### PR TITLE
Adding the new jsiinspector shared module to the nuget package export…

### DIFF
--- a/ReactAndroid/ReactAndroid.nuspec
+++ b/ReactAndroid/ReactAndroid.nuspec
@@ -31,6 +31,11 @@
     <file src="build\react-ndk\all\x86\libglog_init.so" target="lib\droidx86"/>
     <file src="build\react-ndk\all\arm64-v8a\libglog_init.so" target="lib\droidarm64"/>
 
+    <file src="build\react-ndk\all\x86_64\libjsinspector.so" target="lib\droidx64"/>
+    <file src="build\react-ndk\all\armeabi-v7a\libjsinspector.so" target="lib\droidarm"/>
+    <file src="build\react-ndk\all\x86\libjsinspector.so" target="lib\droidx86"/>
+    <file src="build\react-ndk\all\arm64-v8a\libjsinspector.so" target="lib\droidarm64"/>
+
     <file src="build\react-ndk\all\x86_64\libprivatedata.so" target="lib\droidx64"/>
     <file src="build\react-ndk\all\armeabi-v7a\libprivatedata.so" target="lib\droidarm"/>
     <file src="build\react-ndk\all\x86\libprivatedata.so" target="lib\droidx86"/>
@@ -76,6 +81,11 @@
     <file src="build\tmp\buildReactNdkLib\local\armeabi-v7a\libglog_init.so" target="lib\droidarm\unstripped"/>
     <file src="build\tmp\buildReactNdkLib\local\x86\libglog_init.so" target="lib\droidx86\unstripped"/>
     <file src="build\tmp\buildReactNdkLib\local\arm64-v8a\libglog_init.so" target="lib\droidarm64\unstripped"/>
+
+    <file src="build\tmp\buildReactNdkLib\local\x86_64\libjsinspector.so" target="lib\droidx64\unstripped"/>
+    <file src="build\tmp\buildReactNdkLib\local\armeabi-v7a\libjsinspector.so" target="lib\droidarm\unstripped"/>
+    <file src="build\tmp\buildReactNdkLib\local\x86\libjsinspector.so" target="lib\droidx86\unstripped"/>
+    <file src="build\tmp\buildReactNdkLib\local\arm64-v8a\libjsinspector.so" target="lib\droidarm64\unstripped"/>
 
     <file src="build\tmp\buildReactNdkLib\local\x86_64\libprivatedata.so" target="lib\droidx64\unstripped"/>
     <file src="build\tmp\buildReactNdkLib\local\armeabi-v7a\libprivatedata.so" target="lib\droidarm\unstripped"/>


### PR DESCRIPTION

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

(give an overview)

Updating the nuspec for OfficeReact package to be exorted to Office devmain to include a newly added shared library in react native. Technically, this nuspec file doesn't need to be checked into this repository, but ideally, i'd want to worry about deforking separately, and worry only about getting the RN apps in office working over 0.60.

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/200)