### PR TITLE
Add 0.59-stable branch to PR build trigger

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -5,6 +5,7 @@ trigger: none # will disable CI builds entirely
 
 pr:
 - master
+- 0.59-stable
 
 jobs:
   - job: AndroidRNPR

--- a/.ado/apple-pr.yml
+++ b/.ado/apple-pr.yml
@@ -5,6 +5,7 @@ trigger: none # will disable CI builds entirely
 
 pr:
 - master
+- 0.59-stable
 
 jobs:
   - job: JavaScriptRNPR


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

To unblock PRs targeting `0.59-stable` branch.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/202)