### PR TITLE
Manually update our xcschemes to have our build action entries for de…

### DIFF
--- a/RNTester/RNTester.xcodeproj/xcshareddata/xcschemes/iosDeviceBuild.xcscheme
+++ b/RNTester/RNTester.xcodeproj/xcshareddata/xcschemes/iosDeviceBuild.xcscheme
@@ -34,6 +34,188 @@
                ReferencedContainer = "container:RNTester.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "0CF68AC01AF0540F00FF9E5C"
+                BuildableName = "libART.a"
+                BlueprintName = "ART"
+                ReferencedContainer = "container:../Libraries/ART/ART.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+                BuildableName = "libRCTActionSheet.a"
+                BlueprintName = "RCTActionSheet"
+                ReferencedContainer = "container:../Libraries/ActionSheetIOS/RCTActionSheet.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+                BuildableName = "libRCTAnimation.a"
+                BlueprintName = "RCTAnimation"
+                ReferencedContainer = "container:../Libraries/NativeAnimation/RCTAnimation.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "358F4ED61D1E81A9004DF814"
+                BuildableName = "libRCTBlob.a"
+                BlueprintName = "RCTBlob"
+                ReferencedContainer = "container:../Libraries/Blob/RCTBlob.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "58B5115C1A9E6B3D00147676"
+                BuildableName = "libRCTCameraRoll.a"
+                BlueprintName = "RCTCameraRoll"
+                ReferencedContainer = "container:../Libraries/CameraRoll/RCTCameraRoll.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "58B5115C1A9E6B3D00147676"
+                BuildableName = "libRCTImage.a"
+                BlueprintName = "RCTImage"
+                ReferencedContainer = "container:../Libraries/Image/RCTImage.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+                BuildableName = "libRCTLinking.a"
+                BlueprintName = "RCTLinking"
+                ReferencedContainer = "container:../Libraries/LinkingIOS/RCTLinking.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+                BuildableName = "libRCTNetwork.a"
+                BlueprintName = "RCTNetwork"
+                ReferencedContainer = "container:../Libraries/Network/RCTNetwork.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+                BuildableName = "libRCTPushNotification.a"
+                BlueprintName = "RCTPushNotification"
+                ReferencedContainer = "container:../Libraries/PushNotificationIOS/RCTPushNotification.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+                BuildableName = "libRCTSettings.a"
+                BlueprintName = "RCTSettings"
+                ReferencedContainer = "container:../Libraries/Settings/RCTSettings.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "58B5119A1A9E6C1200147676"
+                BuildableName = "libRCTText.a"
+                BlueprintName = "RCTText"
+                ReferencedContainer = "container:../Libraries/Text/RCTText.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "832C817F1AAF6DEF007FA2F7"
+                BuildableName = "libRCTVibration.a"
+                BlueprintName = "RCTVibration"
+                ReferencedContainer = "container:../Libraries/Vibration/RCTVibration.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
+          <BuildActionEntry
+             buildForTesting = "YES"
+             buildForRunning = "YES"
+             buildForProfiling = "YES"
+             buildForArchiving = "YES"
+             buildForAnalyzing = "YES">
+             <BuildableReference
+                BuildableIdentifier = "primary"
+                BlueprintIdentifier = "3C86DF451ADF2C930047B81A"
+                BuildableName = "libRCTWebSocket.a"
+                BlueprintName = "RCTWebSocket"
+                ReferencedContainer = "container:../Libraries/WebSocket/RCTWebSocket.xcodeproj">
+             </BuildableReference>
+          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -41,8 +223,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -52,8 +232,8 @@
             ReferencedContainer = "container:RNTester.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -74,8 +254,6 @@
             ReferencedContainer = "container:RNTester.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/RNTester/RNTester.xcodeproj/xcshareddata/xcschemes/iosSimulatorBuild.xcscheme
+++ b/RNTester/RNTester.xcodeproj/xcshareddata/xcschemes/iosSimulatorBuild.xcscheme
@@ -34,6 +34,188 @@
                ReferencedContainer = "container:RNTester.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0CF68AC01AF0540F00FF9E5C"
+               BuildableName = "libART.a"
+               BlueprintName = "ART"
+               ReferencedContainer = "container:../Libraries/ART/ART.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+               BuildableName = "libRCTActionSheet.a"
+               BlueprintName = "RCTActionSheet"
+               ReferencedContainer = "container:../Libraries/ActionSheetIOS/RCTActionSheet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+               BuildableName = "libRCTAnimation.a"
+               BlueprintName = "RCTAnimation"
+               ReferencedContainer = "container:../Libraries/NativeAnimation/RCTAnimation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "358F4ED61D1E81A9004DF814"
+               BuildableName = "libRCTBlob.a"
+               BlueprintName = "RCTBlob"
+               ReferencedContainer = "container:../Libraries/Blob/RCTBlob.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58B5115C1A9E6B3D00147676"
+               BuildableName = "libRCTCameraRoll.a"
+               BlueprintName = "RCTCameraRoll"
+               ReferencedContainer = "container:../Libraries/CameraRoll/RCTCameraRoll.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58B5115C1A9E6B3D00147676"
+               BuildableName = "libRCTImage.a"
+               BlueprintName = "RCTImage"
+               ReferencedContainer = "container:../Libraries/Image/RCTImage.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+               BuildableName = "libRCTLinking.a"
+               BlueprintName = "RCTLinking"
+               ReferencedContainer = "container:../Libraries/LinkingIOS/RCTLinking.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+               BuildableName = "libRCTNetwork.a"
+               BlueprintName = "RCTNetwork"
+               ReferencedContainer = "container:../Libraries/Network/RCTNetwork.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+               BuildableName = "libRCTPushNotification.a"
+               BlueprintName = "RCTPushNotification"
+               ReferencedContainer = "container:../Libraries/PushNotificationIOS/RCTPushNotification.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58B511DA1A9E6C8500147676"
+               BuildableName = "libRCTSettings.a"
+               BlueprintName = "RCTSettings"
+               ReferencedContainer = "container:../Libraries/Settings/RCTSettings.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58B5119A1A9E6C1200147676"
+               BuildableName = "libRCTText.a"
+               BlueprintName = "RCTText"
+               ReferencedContainer = "container:../Libraries/Text/RCTText.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "832C817F1AAF6DEF007FA2F7"
+               BuildableName = "libRCTVibration.a"
+               BlueprintName = "RCTVibration"
+               ReferencedContainer = "container:../Libraries/Vibration/RCTVibration.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3C86DF451ADF2C930047B81A"
+               BuildableName = "libRCTWebSocket.a"
+               BlueprintName = "RCTWebSocket"
+               ReferencedContainer = "container:../Libraries/WebSocket/RCTWebSocket.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/RNTester/RNTester.xcodeproj/xcshareddata/xcschemes/macOSBuild.xcscheme
+++ b/RNTester/RNTester.xcodeproj/xcshareddata/xcschemes/macOSBuild.xcscheme
@@ -34,6 +34,160 @@
                ReferencedContainer = "container:RNTester.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "647647611F0BC33500C2D89B"
+               BuildableName = "libART-macOS.a"
+               BlueprintName = "ART-macOS"
+               ReferencedContainer = "container:../Libraries/ART/ART.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "649D87CC1F69D9BC0005AF18"
+               BuildableName = "libRCTActionSheet.a"
+               BlueprintName = "RCTActionSheet-macOS"
+               ReferencedContainer = "container:../Libraries/ActionSheetIOS/RCTActionSheet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "647647861F0BC7F200C2D89B"
+               BuildableName = "libRCTAnimation.a"
+               BlueprintName = "RCTAnimation-macOS"
+               ReferencedContainer = "container:../Libraries/NativeAnimation/RCTAnimation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6484CE4D201A74FA004275A4"
+               BuildableName = "libRCTBlob-macOS.a"
+               BlueprintName = "RCTBlob-macOS"
+               ReferencedContainer = "container:../Libraries/Blob/RCTBlob.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6BDE7ACD1ECB9C4400CC951F"
+               BuildableName = "libRCTImage.a"
+               BlueprintName = "RCTImage-macOS"
+               ReferencedContainer = "container:../Libraries/Image/RCTImage.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D4C812E11F1CC42300FFA059"
+               BuildableName = "libRCTLinking-macOS.a"
+               BlueprintName = "RCTLinking-macOS"
+               ReferencedContainer = "container:../Libraries/LinkingIOS/RCTLinking.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6BDE7A851ECB6E8400CC951F"
+               BuildableName = "libRCTNetwork.a"
+               BlueprintName = "RCTNetwork-macOS"
+               ReferencedContainer = "container:../Libraries/Network/RCTNetwork.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6424F7A41F669A3A0025D741"
+               BuildableName = "libRCTPushNotification-macOS.a"
+               BlueprintName = "RCTPushNotification-macOS"
+               ReferencedContainer = "container:../Libraries/PushNotificationIOS/RCTPushNotification.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6448A5C71F292E63006FF1F5"
+               BuildableName = "libRCTSettings-macOS.a"
+               BlueprintName = "RCTSettings-macOS"
+               ReferencedContainer = "container:../Libraries/Settings/RCTSettings.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6BDE7AB21ECB8D6200CC951F"
+               BuildableName = "libRCTText.a"
+               BlueprintName = "RCTText-macos"
+               ReferencedContainer = "container:../Libraries/Text/RCTText.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6BDE7A4F1ECB6B8200CC951F"
+               BuildableName = "libRCTWebSocket.a"
+               BlueprintName = "RCTWebSocket-macOS"
+               ReferencedContainer = "container:../Libraries/WebSocket/RCTWebSocket.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction


### PR DESCRIPTION
…pendent libraries

- [X ] I am making a fix / change for the macOS implementation of react-native
- [ X] I am making a change required for Microsoft usage of react-native

Publish builds are still broken in sdx-platform. Our xcschemes need the library dependencies and updating it just in the UI didn't update the xcschemes. Here I manually updated the xcschemes with the pertinent dependency data.

Built all 3 schemes and they succeed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/207)