### PR TITLE
Move FB version merge documentation to the repo it's used in

### DIFF
--- a/KeepingRecent.md
+++ b/KeepingRecent.md
@@ -1,7 +1,7 @@
 
 # Keeping Recent on Facebook's Changes
 
-We aim to keep this forked repository as up to date as possible with [Facebook's repository](https://github.com/facebook/react-native). This document explains guidelines and responsibilities for pulling in the newest changes.
+We aim to keep this forked repository as up to date as possible with [Facebook's repository](https://github.com/facebook/react-native). This document explains guidelines and responsibilities for pulling in the newest changes with the eventual goal of pushing all our changes back to Facebook and the React-Native-Community repos and deforking.
 
 ## Merging a New Version of React Native
 1. Create a reference to a remote to Facebook's repo
@@ -33,9 +33,8 @@ It's likely you'll want to push the initial merge up to github **with** the merg
 	* Why?
 		* This prevents merges from getting stuck in limbo where some platforms aren't done for multiple months and in the meantime we have to maintain two working branches. Faster we merge from start to finish, the exponentially less pain we incur.
 	* Platform owners
-		* Win32- acoates
-		* Android- acoates
-		* iOS- chrishog/tomun
-		* Mac- chrishog/tomun
+		* Win32- acoates-ms
+		* Android- acoates-ms
+		* iOS- HeyImChris/tom-un
+		* Mac- HeyImChris/tom-un
 * Make sure you're pulling in a **stable** [release candidate](https://facebook.github.io/react-native/versions).
-* Note that this *only* gets the newest RN version into [our fork](http://github.com/microsoft/react-native) which will then have to get pushed into downstream repositories such as [SDX-Platform](https://office.visualstudio.com/ISS/_git/sdx-platform) for its consumption. Because we have quite a few code changes in our fork, but not Facebook's master, you should expect some more changes to both downstream clients and [our fork](http://github.com/microsoft/react-native) to keep everything in working order.

--- a/KeepingRecent.md
+++ b/KeepingRecent.md
@@ -1,0 +1,41 @@
+
+# Keeping Recent on Facebook's Changes
+
+We aim to keep this forked repository as up to date as possible with [Facebook's repository](https://github.com/facebook/react-native). This document explains guidelines and responsibilities for pulling in the newest changes.
+
+## Merging a New Version of React Native
+1. Create a reference to a remote to Facebook's repo
+1.1. In terminal: `git remote add facebook https://github.com/facebook/react-native.git`
+1.2. In terminal: `cd react-native/; git pull facebook`
+2.  Create a branch to work in. Below is for merging in Facebook's React Native 0.58 version. 
+2.1. In terminal: e.g. `git branch fb58merge`
+2.2. In terminal: e.g. `git checkout fb58merge`
+3.  Pull the fb contents at the merge point we want. A list of their most recent versions can be found [here](https://facebook.github.io/react-native/versions).
+3.1.  In terminal: e.g. `git fetch facebook v0.58.6`
+4.  Do the merge at the point we want, in this example it's the last version tag of their 0.58 build. Use the name you used in 3.1 here.
+4.1.  In terminal: e.g. `git merge v0.58.6`
+
+## Integration Guidelines
+It's likely you'll want to push the initial merge up to github **with** the merge conflicts. This makes it easier for other people to see where the errors are and help fix their platforms quickly.
+
+1.  Commit all the changes (conflicts and all). There are many resources to do this such as the [Visual Studio Code](https://code.visualstudio.com/) UI or command line.
+2.  After you've committed all the changes, push your merge up.
+2.1.  In terminal: `git push`. This should fail to push, but print out a suggested `git push [more repo specifics here]` command.
+2.2. Copy and run that suggested push command which has the proper upstream repo specified.
+
+#### First Time Merging? Read Below. Otherwise this shouldn't apply to you.
+3.  The first time doing this, terminal may ask for your github credentials after running the `git push` command from 2.2. You'll need to provide your github username and a 2-Factor-Authentication token password. If you don't have this yet, see substeps below. <em>Github doesn't distinguish when you need to use your github password vs. this 2FA token, but for command line github interactions, you'll need to use the token.</em>
+3.1.  Generate your personal access token [here](https://github.com/settings/tokens)
+3.2.  More details [here](https://stackoverflow.com/questions/29297154/github-invalid-username-or-password)
+
+## Best Practices
+* Before pulling in a new React-Native version, verify with platform owners that they're ready to work on the merge.
+	* Why?
+		* This prevents merges from getting stuck in limbo where some platforms aren't done for multiple months and in the meantime we have to maintain two working branches. Faster we merge from start to finish, the exponentially less pain we incur.
+	* Platform owners
+		* Win32- acoates
+		* Android- acoates
+		* iOS- chrishog/tomun
+		* Mac- chrishog/tomun
+* Make sure you're pulling in a **stable** [release candidate](https://facebook.github.io/react-native/versions).
+* Note that this *only* gets the newest RN version into [our fork](http://github.com/microsoft/react-native) which will then have to get pushed into downstream repositories such as [SDX-Platform](https://office.visualstudio.com/ISS/_git/sdx-platform) for its consumption. Because we have quite a few code changes in our fork, but not Facebook's master, you should expect some more changes to both downstream clients and [our fork](http://github.com/microsoft/react-native) to keep everything in working order.


### PR DESCRIPTION

- [X ] I am making a fix / change for the macOS implementation of react-native
- [X ] I am making a change required for Microsoft usage of react-native

Moving the FB version merge documentation here so it's public for anyone to leverage. Adding this file is a small deviation from Fb's repo, but seems worth it as it's fittingly a markdown on how to help us not deviate from Fb's repo.

#### Focus areas to test
Documentation change. Tested the links and markdown at https://stackedit.io/app#


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/208)