### PR TITLE
[RNTester] Make iOS target work with CocoaPods again

### DIFF
--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.h
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.h
@@ -7,7 +7,7 @@
 
 #import <React/RCTUIKit.h> // TODO(macOS ISS#2323203)
 
-#import <RCTText/RCTTextUIKit.h> // TODO(macOS ISS#2323203)
+#import "RCTTextUIKit.h" // TODO(macOS ISS#2323203)
 
 #import "RCTBackedTextInputViewProtocol.h"
 

--- a/Libraries/Text/TextInput/Multiline/RCTUITextView.m
+++ b/Libraries/Text/TextInput/Multiline/RCTUITextView.m
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <RCTText/RCTUITextView.h>
+#import "RCTUITextView.h"
 
 #import <React/RCTUtils.h>
 #import <React/UIView+React.h>

--- a/Libraries/Text/TextInput/Singleline/RCTUITextField.h
+++ b/Libraries/Text/TextInput/Singleline/RCTUITextField.h
@@ -7,7 +7,7 @@
 
 #import <React/RCTUIKit.h> // TODO(macOS ISS#2323203)
 
-#import <RCTText/RCTTextUIKit.h> // TODO(macOS ISS#2323203)
+#import "RCTTextUIKit.h" // TODO(macOS ISS#2323203)
 
 #import "RCTBackedTextInputViewProtocol.h"
 

--- a/RNTester/Podfile
+++ b/RNTester/Podfile
@@ -15,6 +15,7 @@ target 'RNTester' do
   pod 'React-turbomodule-samples', :path => '../ReactCommon/turbomodule/samples'
 
   # Additional Pods which aren't included in the default Podfile
+  pod 'React-RCTCameraRoll', :path => '../Libraries/CameraRoll'
   pod 'React-ART', :path => '../Libraries/ART'
   pod 'React-RCTPushNotification', :path => '../Libraries/PushNotificationIOS'
 

--- a/RNTester/Podfile
+++ b/RNTester/Podfile
@@ -1,3 +1,5 @@
+source 'https://cdn.cocoapods.org/'
+
 platform :ios, '9.0'
 
 require_relative '../scripts/autolink-ios'

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -144,7 +144,7 @@ DEPENDENCIES:
   - yoga (from `../ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - boost-for-react-native
 
 EXTERNAL SOURCES:

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -11,108 +11,110 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - React (1000.0.0):
-    - React-Core (= 1000.0.0)
-    - React-DevSupport (= 1000.0.0)
-    - React-RCTActionSheet (= 1000.0.0)
-    - React-RCTAnimation (= 1000.0.0)
-    - React-RCTBlob (= 1000.0.0)
-    - React-RCTImage (= 1000.0.0)
-    - React-RCTLinking (= 1000.0.0)
-    - React-RCTNetwork (= 1000.0.0)
-    - React-RCTSettings (= 1000.0.0)
-    - React-RCTText (= 1000.0.0)
-    - React-RCTVibration (= 1000.0.0)
-    - React-RCTWebSocket (= 1000.0.0)
-  - React-ART (1000.0.0):
-    - React-Core (= 1000.0.0)
-  - React-Core (1000.0.0):
+  - React (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+    - React-DevSupport (= 0.60.0-microsoft.31)
+    - React-RCTActionSheet (= 0.60.0-microsoft.31)
+    - React-RCTAnimation (= 0.60.0-microsoft.31)
+    - React-RCTBlob (= 0.60.0-microsoft.31)
+    - React-RCTImage (= 0.60.0-microsoft.31)
+    - React-RCTLinking (= 0.60.0-microsoft.31)
+    - React-RCTNetwork (= 0.60.0-microsoft.31)
+    - React-RCTSettings (= 0.60.0-microsoft.31)
+    - React-RCTText (= 0.60.0-microsoft.31)
+    - React-RCTVibration (= 0.60.0-microsoft.31)
+    - React-RCTWebSocket (= 0.60.0-microsoft.31)
+  - React-ART (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+  - React-Core (0.60.0-microsoft.31):
     - Folly (= 2018.10.22.00)
-    - React-cxxreact (= 1000.0.0)
-    - React-jsiexecutor (= 1000.0.0)
-    - yoga (= 1000.0.0.React)
-  - React-cxxreact (1000.0.0):
+    - React-cxxreact (= 0.60.0-microsoft.31)
+    - React-jsiexecutor (= 0.60.0-microsoft.31)
+    - yoga (= 0.60.0-microsoft.31.React)
+  - React-cxxreact (0.60.0-microsoft.31):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-    - React-jsinspector (= 1000.0.0)
-  - React-DevSupport (1000.0.0):
-    - React-Core (= 1000.0.0)
-    - React-RCTWebSocket (= 1000.0.0)
-  - React-fishhook (1000.0.0)
-  - React-jsi (1000.0.0):
+    - React-jsinspector (= 0.60.0-microsoft.31)
+  - React-DevSupport (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+    - React-RCTWebSocket (= 0.60.0-microsoft.31)
+  - React-fishhook (0.60.0-microsoft.31)
+  - React-jscallinvoker (0.60.0-microsoft.31):
+    - Folly (= 2018.10.22.00)
+    - React-cxxreact (= 0.60.0-microsoft.31)
+  - React-jsi (0.60.0-microsoft.31):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-    - React-jsi/Default (= 1000.0.0)
-  - React-jsi/Default (1000.0.0):
+    - React-jsi/Default (= 0.60.0-microsoft.31)
+  - React-jsi/Default (0.60.0-microsoft.31):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-  - React-jsiexecutor (1000.0.0):
+  - React-jsiexecutor (0.60.0-microsoft.31):
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-    - React-cxxreact (= 1000.0.0)
-    - React-jsi (= 1000.0.0)
-  - React-jsinspector (1000.0.0)
-  - React-RCTActionSheet (1000.0.0):
-    - React-Core (= 1000.0.0)
-  - React-RCTAnimation (1000.0.0):
-    - React-Core (= 1000.0.0)
-  - React-RCTBlob (1000.0.0):
-    - React-Core (= 1000.0.0)
-    - React-RCTNetwork (= 1000.0.0)
-    - React-RCTWebSocket (= 1000.0.0)
-  - React-RCTCameraRoll (1000.0.0):
-    - React-Core (= 1000.0.0)
-    - React-RCTImage (= 1000.0.0)
-  - React-RCTImage (1000.0.0):
-    - React-Core (= 1000.0.0)
-    - React-RCTNetwork (= 1000.0.0)
-  - React-RCTLinking (1000.0.0):
-    - React-Core (= 1000.0.0)
-  - React-RCTNetwork (1000.0.0):
-    - React-Core (= 1000.0.0)
-  - React-RCTPushNotification (1000.0.0):
-    - React-Core (= 1000.0.0)
-  - React-RCTSettings (1000.0.0):
-    - React-Core (= 1000.0.0)
-  - React-RCTText (1000.0.0):
-    - React-Core (= 1000.0.0)
-  - React-RCTVibration (1000.0.0):
-    - React-Core (= 1000.0.0)
-  - React-RCTWebSocket (1000.0.0):
-    - React-Core (= 1000.0.0)
-    - React-fishhook (= 1000.0.0)
-  - React-turbomodule-core (1000.0.0):
+    - React-cxxreact (= 0.60.0-microsoft.31)
+    - React-jsi (= 0.60.0-microsoft.31)
+  - React-jsinspector (0.60.0-microsoft.31)
+  - React-RCTActionSheet (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+  - React-RCTAnimation (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+  - React-RCTBlob (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+    - React-RCTNetwork (= 0.60.0-microsoft.31)
+    - React-RCTWebSocket (= 0.60.0-microsoft.31)
+  - React-RCTImage (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+    - React-RCTNetwork (= 0.60.0-microsoft.31)
+  - React-RCTLinking (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+  - React-RCTNetwork (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+  - React-RCTPushNotification (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+  - React-RCTSettings (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+  - React-RCTText (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+  - React-RCTVibration (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+  - React-RCTWebSocket (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+    - React-fishhook (= 0.60.0-microsoft.31)
+  - React-turbomodule-core (0.60.0-microsoft.31):
     - Folly (= 2018.10.22.00)
-    - React-Core (= 1000.0.0)
-    - React-cxxreact (= 1000.0.0)
-    - React-jsi (= 1000.0.0)
-    - React-turbomodule-core/core-ios (= 1000.0.0)
-  - React-turbomodule-core/core-ios (1000.0.0):
+    - React-Core (= 0.60.0-microsoft.31)
+    - React-cxxreact (= 0.60.0-microsoft.31)
+    - React-jscallinvoker (= 0.60.0-microsoft.31)
+    - React-jsi (= 0.60.0-microsoft.31)
+    - React-turbomodule-core/core-ios (= 0.60.0-microsoft.31)
+  - React-turbomodule-core/core-ios (0.60.0-microsoft.31):
     - Folly (= 2018.10.22.00)
-    - React-Core (= 1000.0.0)
-    - React-cxxreact (= 1000.0.0)
-    - React-jsi (= 1000.0.0)
-  - React-turbomodule-samples (1000.0.0):
+    - React-Core (= 0.60.0-microsoft.31)
+    - React-cxxreact (= 0.60.0-microsoft.31)
+    - React-jscallinvoker (= 0.60.0-microsoft.31)
+    - React-jsi (= 0.60.0-microsoft.31)
+  - React-turbomodule-samples (0.60.0-microsoft.31):
     - Folly (= 2018.10.22.00)
-    - React-Core (= 1000.0.0)
-    - React-cxxreact (= 1000.0.0)
-    - React-jsi (= 1000.0.0)
-    - React-turbomodule-core (= 1000.0.0)
-    - React-turbomodule-samples/samples-ios (= 1000.0.0)
-  - React-turbomodule-samples/samples-ios (1000.0.0):
+    - React-Core (= 0.60.0-microsoft.31)
+    - React-cxxreact (= 0.60.0-microsoft.31)
+    - React-jsi (= 0.60.0-microsoft.31)
+    - React-turbomodule-core (= 0.60.0-microsoft.31)
+    - React-turbomodule-samples/samples-ios (= 0.60.0-microsoft.31)
+  - React-turbomodule-samples/samples-ios (0.60.0-microsoft.31):
     - Folly (= 2018.10.22.00)
-    - React-Core (= 1000.0.0)
-    - React-cxxreact (= 1000.0.0)
-    - React-jsi (= 1000.0.0)
-    - React-turbomodule-core (= 1000.0.0)
-  - yoga (1000.0.0.React)
+    - React-Core (= 0.60.0-microsoft.31)
+    - React-cxxreact (= 0.60.0-microsoft.31)
+    - React-jsi (= 0.60.0-microsoft.31)
+    - React-turbomodule-core (= 0.60.0-microsoft.31)
+  - yoga (0.60.0-microsoft.31.React)
 
 DEPENDENCIES:
   - DoubleConversion (from `../third-party-podspecs/DoubleConversion.podspec`)
@@ -124,13 +126,13 @@ DEPENDENCIES:
   - React-cxxreact (from `../ReactCommon/cxxreact`)
   - React-DevSupport (from `../React`)
   - React-fishhook (from `../Libraries/fishhook`)
+  - React-jscallinvoker (from `../ReactCommon/jscallinvoker`)
   - React-jsi (from `../ReactCommon/jsi`)
   - React-jsiexecutor (from `../ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../ReactCommon/jsinspector`)
   - React-RCTActionSheet (from `../Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../Libraries/NativeAnimation`)
   - React-RCTBlob (from `../Libraries/Blob`)
-  - React-RCTCameraRoll (from `../Libraries/CameraRoll`)
   - React-RCTImage (from `../Libraries/Image`)
   - React-RCTLinking (from `../Libraries/LinkingIOS`)
   - React-RCTNetwork (from `../Libraries/Network`)
@@ -166,6 +168,8 @@ EXTERNAL SOURCES:
     :path: "../React"
   React-fishhook:
     :path: "../Libraries/fishhook"
+  React-jscallinvoker:
+    :path: "../ReactCommon/jscallinvoker"
   React-jsi:
     :path: "../ReactCommon/jsi"
   React-jsiexecutor:
@@ -178,8 +182,6 @@ EXTERNAL SOURCES:
     :path: "../Libraries/NativeAnimation"
   React-RCTBlob:
     :path: "../Libraries/Blob"
-  React-RCTCameraRoll:
-    :path: "../Libraries/CameraRoll"
   React-RCTImage:
     :path: "../Libraries/Image"
   React-RCTLinking:
@@ -205,34 +207,34 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
-  Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
-  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  React: e7b61c9123f89c4cd9becea2122af02568be6e13
-  React-ART: 3dba78ec04b585a82456d1df4bda7a08dbc83a8d
-  React-Core: d1c3aa4b1c5c57bf839de3c83396b59c1efbf1ba
-  React-cxxreact: 5f2b678adbe8ff5256801603e1b496e481bc2430
-  React-DevSupport: 9bde3ce4f7707d9487759101ea3188f4f07c9003
-  React-fishhook: a9a43c2c84ab2519809810bcdd363e2774007c69
-  React-jsi: cdf32eb002ff3e243364a1abb71925e0e93003db
-  React-jsiexecutor: 6e53c44a5371297f0c9cc39780f12cb3efba3b81
-  React-jsinspector: 2f42a591151e828d0422cbd3b609eedcb920d58e
-  React-RCTActionSheet: 4ad4bfac1ba9ec020edf278362855448d607cafd
-  React-RCTAnimation: f050e9fbe85e5616f74cea7a2557bdfb6be73cee
-  React-RCTBlob: 9f907aab3417a43bbda84aef76f88ee528e877d4
-  React-RCTCameraRoll: 288b1007d8e540771b917f89d7d99118a3477ee1
-  React-RCTImage: 4234a754ebdb922416f5f77cff121c680fd3ccbe
-  React-RCTLinking: 3a52500942cc73999df19f541b7bda5887c3c43d
-  React-RCTNetwork: 2042d2648e1160770ac0e5068bb5b648c03296a5
-  React-RCTPushNotification: 3cfbf863d0597b5da80a15c9a9285a0ad89b23ba
-  React-RCTSettings: 8099c9d904c0fbe46c463de8791478b5bc72809e
-  React-RCTText: c4a643a08fce4727316366fea5ad17fa14f72f54
-  React-RCTVibration: c5933466242187bffe55fa5496f841e04db66c8a
-  React-RCTWebSocket: 233c66a6394de3816ee46861bbe0dba9f83e45a0
-  React-turbomodule-core: 7ae77c38b85f6f81be40c0c3dc456d3a5fda4797
-  React-turbomodule-samples: 483f2c80e81b89197737828405a0ac27c77f58b5
-  yoga: 56698cdff46e3dbb7aa71fd2fd7dc0ce650dc0fb
+  DoubleConversion: a1bc12a74baa397a2609e0f10e19b8062d864053
+  Folly: feff29ba9d0b7c2e4f793a94942831d6cc5bbad7
+  glog: b3f6d74f3e2d33396addc0ee724d2b2b79fc3e00
+  React: b5a3398fce30ef63a15fa4c909fcc1cd9fdf8e37
+  React-ART: e98935ffbd67852fcffa965db1ac02fd77202036
+  React-Core: 61a52828fcbe458ede989812e58ae62fd6434796
+  React-cxxreact: 661878b284460f711e02b267c9ce50eecd7683f9
+  React-DevSupport: b513ed36ee2e05a0964e829d57e6d39550048de2
+  React-fishhook: d7094ee5cac1a8a49ace9319e2568666be81e7f8
+  React-jscallinvoker: 6bf052d499320324d9153a9425e692c8250928f5
+  React-jsi: 86164349713bb31a45bf4db21492681d88e3b586
+  React-jsiexecutor: 71675f24ac9519d540e123054d40f630afeb4997
+  React-jsinspector: f2a63105da46a2b7c53888d338d20cdff1de0018
+  React-RCTActionSheet: 189dcaa5f967c93e673d89d061e899d3217fd292
+  React-RCTAnimation: c54c5b1b66723756f3a7b8b4979a226e6844fea3
+  React-RCTBlob: d3f81fd28e166f932220873ca3ed8a1e63054694
+  React-RCTImage: c1ffad410730573c327c227e4f8da45c9e8bc680
+  React-RCTLinking: 3b6545fdce7ac1df7c29097204b551feb94b7c68
+  React-RCTNetwork: 316be64bb95cf3fcf0fab5898b3ad5b89e09d8d2
+  React-RCTPushNotification: 1a572abe9735a00e31359575bab53c86b69b03ec
+  React-RCTSettings: 4ce3161d982c126c7419624be8a1193e801e3de6
+  React-RCTText: 4de126dbc8253e311ed83bd81317d7cfb573c91c
+  React-RCTVibration: dd431f2f913c34b018267b417831fcd4843b3d2a
+  React-RCTWebSocket: 448fa048c31527da92946944b65b1996c855ff50
+  React-turbomodule-core: 630128e4e3d4bc307931052e069c68a42a52d2fd
+  React-turbomodule-samples: 27cade951858959365b7c3a744b5907a098acb2d
+  yoga: 18681a34e39bf843425427996d459c5e6f5d52b4
 
-PODFILE CHECKSUM: bb578b8286c0068879a41ac092c9690cc3ede523
+PODFILE CHECKSUM: 167c0bf6d341e9be5df54eb5f7b3a00ff99ca43c
 
-COCOAPODS: 1.6.3
+COCOAPODS: 1.8.4

--- a/RNTester/Podfile.lock
+++ b/RNTester/Podfile.lock
@@ -70,6 +70,9 @@ PODS:
     - React-Core (= 0.60.0-microsoft.31)
     - React-RCTNetwork (= 0.60.0-microsoft.31)
     - React-RCTWebSocket (= 0.60.0-microsoft.31)
+  - React-RCTCameraRoll (0.60.0-microsoft.31):
+    - React-Core (= 0.60.0-microsoft.31)
+    - React-RCTImage (= 0.60.0-microsoft.31)
   - React-RCTImage (0.60.0-microsoft.31):
     - React-Core (= 0.60.0-microsoft.31)
     - React-RCTNetwork (= 0.60.0-microsoft.31)
@@ -133,6 +136,7 @@ DEPENDENCIES:
   - React-RCTActionSheet (from `../Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../Libraries/NativeAnimation`)
   - React-RCTBlob (from `../Libraries/Blob`)
+  - React-RCTCameraRoll (from `../Libraries/CameraRoll`)
   - React-RCTImage (from `../Libraries/Image`)
   - React-RCTLinking (from `../Libraries/LinkingIOS`)
   - React-RCTNetwork (from `../Libraries/Network`)
@@ -182,6 +186,8 @@ EXTERNAL SOURCES:
     :path: "../Libraries/NativeAnimation"
   React-RCTBlob:
     :path: "../Libraries/Blob"
+  React-RCTCameraRoll:
+    :path: "../Libraries/CameraRoll"
   React-RCTImage:
     :path: "../Libraries/Image"
   React-RCTLinking:
@@ -223,6 +229,7 @@ SPEC CHECKSUMS:
   React-RCTActionSheet: 189dcaa5f967c93e673d89d061e899d3217fd292
   React-RCTAnimation: c54c5b1b66723756f3a7b8b4979a226e6844fea3
   React-RCTBlob: d3f81fd28e166f932220873ca3ed8a1e63054694
+  React-RCTCameraRoll: 4052d0d3a3e0ecbf8adfc7e58f7a9a208768c4f6
   React-RCTImage: c1ffad410730573c327c227e4f8da45c9e8bc680
   React-RCTLinking: 3b6545fdce7ac1df7c29097204b551feb94b7c68
   React-RCTNetwork: 316be64bb95cf3fcf0fab5898b3ad5b89e09d8d2
@@ -235,6 +242,6 @@ SPEC CHECKSUMS:
   React-turbomodule-samples: 27cade951858959365b7c3a744b5907a098acb2d
   yoga: 18681a34e39bf843425427996d459c5e6f5d52b4
 
-PODFILE CHECKSUM: 167c0bf6d341e9be5df54eb5f7b3a00ff99ca43c
+PODFILE CHECKSUM: 677959aa322a0a559343b5810d7a39e759214b56
 
 COCOAPODS: 1.8.4

--- a/RNTester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/RNTester/RNTesterPods.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		5C60EB1C226440DB0018C04F /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C60EB1B226440DB0018C04F /* AppDelegate.mm */; };
 		5CB07C9B226467E60039471C /* RNTesterTurboModuleProvider.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CB07C99226467E60039471C /* RNTesterTurboModuleProvider.mm */; };
 		68E1E4BC2230DF2F00570185 /* ComponentRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68E1E4BB2230DF2F00570185 /* ComponentRegistry.cpp */; };
-		7DBD3B12498EA276DB551187 /* libPods-RNTester-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B334FFB3ADFDA3CD1AC56276 /* libPods-RNTester-macOS.a */; };
 		9F15345F233AB2C4006DFE44 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 9F15345E233AB2C4006DFE44 /* AppDelegate.m */; };
 		9F153461233AB2C7006DFE44 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9F153460233AB2C7006DFE44 /* Assets.xcassets */; };
 		9F153464233AB2C7006DFE44 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9F153462233AB2C7006DFE44 /* MainMenu.xib */; };
@@ -73,7 +72,6 @@
 		5C60EB1B226440DB0018C04F /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = RNTester/AppDelegate.mm; sourceTree = "<group>"; };
 		5CB07C99226467E60039471C /* RNTesterTurboModuleProvider.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = RNTesterTurboModuleProvider.mm; path = RNTester/RNTesterTurboModuleProvider.mm; sourceTree = "<group>"; };
 		5CB07C9A226467E60039471C /* RNTesterTurboModuleProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNTesterTurboModuleProvider.h; path = RNTester/RNTesterTurboModuleProvider.h; sourceTree = "<group>"; };
-		6496F17D31B774EA32BD0826 /* Pods-RNTester-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester-macOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RNTester-macOS/Pods-RNTester-macOS.debug.xcconfig"; sourceTree = "<group>"; };
 		68E1E4BB2230DF2F00570185 /* ComponentRegistry.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ComponentRegistry.cpp; sourceTree = "<group>"; };
 		8508AD3C1DC3509924E63948 /* libPods-RNTester.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTester.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		98233960D1D6A1977D1C7EAF /* Pods-RNTester.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RNTester/Pods-RNTester.debug.xcconfig"; sourceTree = "<group>"; };
@@ -91,8 +89,6 @@
 		9F153478233AB2C7006DFE44 /* RNTester-macOSUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RNTester-macOSUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F15347C233AB2C7006DFE44 /* RNTester_macOSUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNTester_macOSUITests.m; sourceTree = "<group>"; };
 		9F15347E233AB2C7006DFE44 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B334FFB3ADFDA3CD1AC56276 /* libPods-RNTester-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTester-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		DF4471DC0AC942297AB6F78F /* Pods-RNTester-macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester-macOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-RNTester-macOS/Pods-RNTester-macOS.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,7 +111,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7DBD3B12498EA276DB551187 /* libPods-RNTester-macOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -177,7 +172,6 @@
 			isa = PBXGroup;
 			children = (
 				8508AD3C1DC3509924E63948 /* libPods-RNTester.a */,
-				B334FFB3ADFDA3CD1AC56276 /* libPods-RNTester-macOS.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -198,8 +192,6 @@
 			children = (
 				98233960D1D6A1977D1C7EAF /* Pods-RNTester.debug.xcconfig */,
 				5BEC8567F3741044B6A5EFC5 /* Pods-RNTester.release.xcconfig */,
-				6496F17D31B774EA32BD0826 /* Pods-RNTester-macOS.debug.xcconfig */,
-				DF4471DC0AC942297AB6F78F /* Pods-RNTester-macOS.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -318,7 +310,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9F153485233AB2C7006DFE44 /* Build configuration list for PBXNativeTarget "RNTester-macOS" */;
 			buildPhases = (
-				9A94D591C3930FBAE398B556 /* [CP] Check Pods Manifest.lock */,
 				9F153457233AB2C4006DFE44 /* Sources */,
 				9F153458233AB2C4006DFE44 /* Frameworks */,
 				9F153459233AB2C4006DFE44 /* Resources */,
@@ -500,28 +491,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n$SRCROOT/../scripts/react-native-xcode.sh RNTester/js/RNTesterApp.ios.js";
-		};
-		9A94D591C3930FBAE398B556 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-RNTester-macOS-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
 		};
 		F9CB97B0D9633939D43E75E0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -911,7 +880,6 @@
 		};
 		9F15347F233AB2C7006DFE44 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6496F17D31B774EA32BD0826 /* Pods-RNTester-macOS.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -937,7 +905,6 @@
 		};
 		9F153480233AB2C7006DFE44 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DF4471DC0AC942297AB6F78F /* Pods-RNTester-macOS.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/ReactCommon/turbomodule/core/TurboCxxModule.cpp
+++ b/ReactCommon/turbomodule/core/TurboCxxModule.cpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include <jsi/JSIDynamic.h>
-#include <turbomodule/core/TurboModuleUtils.h>
+#include <jsireact/TurboModuleUtils.h>
 
 using namespace facebook;
 using namespace facebook::xplat::module;

--- a/ReactCommon/turbomodule/core/TurboModuleBinding.cpp
+++ b/ReactCommon/turbomodule/core/TurboModuleBinding.cpp
@@ -10,7 +10,7 @@
 #include <string>
 
 #include <cxxreact/SystraceSection.h>
-#include <turbomodule/core/LongLivedObject.h>
+#include <jsireact/LongLivedObject.h>
 
 using namespace facebook;
 

--- a/ReactCommon/turbomodule/core/TurboModuleBinding.h
+++ b/ReactCommon/turbomodule/core/TurboModuleBinding.h
@@ -10,7 +10,7 @@
 #include <string>
 
 #include <jsi/jsi.h>
-#include <turbomodule/core/TurboModule.h>
+#include <jsireact/TurboModule.h>
 
 namespace facebook {
 namespace react {


### PR DESCRIPTION
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:

## Summary

This brings RNTester‘s setup back in line with upstream v0.60.0, which allows for usage of CocoaPods to bootstrap dependencies of the app. The main changes were reverting header import changes, so this might be breaking MS specific build steps that I’m unaware of.

## Changelog

[iOS] [Fixed] - Make RNTester work with CocoaPods again.

## Test Plan

Both `RNTester.xcodeproj` (sans CocoaPods) and `RNTesterPods.xcworkspace` work, but if there are MS specificities integration tests I can perform to ensure these changes didn’t break anything there, that would be great.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/209)