### PR TITLE
Fix Flow check for macos

### DIFF
--- a/.ado/templates/apple-job-javascript.yml
+++ b/.ado/templates/apple-job-javascript.yml
@@ -13,8 +13,11 @@ steps:
   - script: 'yarn test-ci'
     displayName: 'yarn test-ci'
 
-  - script: 'yarn flow'
-    displayName: 'yarn flow'
+  - script: 'yarn flow-check-ios'
+    displayName: 'yarn flow-check-ios'
+
+  - script: 'yarn flow-check-macos'
+    displayName: 'yarn flow-check-macos'
 
   - script: 'yarn lint'
     displayName: 'yarn lint'

--- a/.ado/templates/apple-job-javascript.yml
+++ b/.ado/templates/apple-job-javascript.yml
@@ -19,6 +19,9 @@ steps:
   - script: 'yarn flow-check-macos'
     displayName: 'yarn flow-check-macos'
 
+  - script: 'yarn flow-check-android'
+    displayName: 'yarn flow-check-android'
+
   - script: 'yarn lint'
     displayName: 'yarn lint'
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 ; We fork some components by platform
 .*/*[.]android.js
+; TODO(macOS ISS#2323203):
 .*/*[.]macos.js
 
 ; Ignore templates for 'react-native init'
@@ -61,6 +62,7 @@ module.system.haste.name_reducers='^.*/\([a-zA-Z0-9$_.-]+\.js\(\.flow\)?\)$' -> 
 module.system.haste.name_reducers='^\(.*\)\.js\(\.flow\)?$' -> '\1'
 # strip .ios suffix
 module.system.haste.name_reducers='^\(.*\)\.ios$' -> '\1'
+# TODO(macOS ISS#2323203):
 module.system.haste.name_reducers='^\(.*\)\.macos$' -> '\1'
 module.system.haste.name_reducers='^\(.*\)\.android$' -> '\1'
 module.system.haste.name_reducers='^\(.*\)\.native$' -> '\1'

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 ; We fork some components by platform
 .*/*[.]android.js
+.*/*[.]macos.js
 
 ; Ignore templates for 'react-native init'
 <PROJECT_ROOT>/template/.*
@@ -60,6 +61,7 @@ module.system.haste.name_reducers='^.*/\([a-zA-Z0-9$_.-]+\.js\(\.flow\)?\)$' -> 
 module.system.haste.name_reducers='^\(.*\)\.js\(\.flow\)?$' -> '\1'
 # strip .ios suffix
 module.system.haste.name_reducers='^\(.*\)\.ios$' -> '\1'
+module.system.haste.name_reducers='^\(.*\)\.macos$' -> '\1'
 module.system.haste.name_reducers='^\(.*\)\.android$' -> '\1'
 module.system.haste.name_reducers='^\(.*\)\.native$' -> '\1'
 module.system.haste.paths.blacklist=.*/__tests__/.*

--- a/.flowconfig.android
+++ b/.flowconfig.android
@@ -23,6 +23,9 @@
 ; Ignore polyfills
 .*/Libraries/polyfills/.*
 
+; Ignore metro.config.js
+<PROJECT_ROOT>/metro.config.js
+
 ; Ignore files that have a base platform file and an android file
 <PROJECT_ROOT>/Libraries/Image/Image.js
 <PROJECT_ROOT>/Libraries/Network/RCTNetworking.js

--- a/.flowconfig.android
+++ b/.flowconfig.android
@@ -1,6 +1,7 @@
 [ignore]
 ; We fork some components by platform
 .*/*[.]ios.js
+; TODO(macOS ISS#2323203):
 .*/*[.]macos.js
 
 ; Ignore templates for 'react-native init'
@@ -23,7 +24,7 @@
 ; Ignore polyfills
 .*/Libraries/polyfills/.*
 
-; Ignore metro.config.js
+; TODO(macOS ISS#2323203): Ignore metro.config.js
 <PROJECT_ROOT>/metro.config.js
 
 ; Ignore files that have a base platform file and an android file
@@ -71,6 +72,7 @@ module.system.haste.name_reducers='^\(.*\)\.js\(\.flow\)?$' -> '\1'
 # strip .android suffix
 module.system.haste.name_reducers='^\(.*\)\.android$' -> '\1'
 module.system.haste.name_reducers='^\(.*\)\.ios$' -> '\1'
+# TODO(macOS ISS#2323203):
 module.system.haste.name_reducers='^\(.*\)\.macos$' -> '\1'
 module.system.haste.name_reducers='^\(.*\)\.native$' -> '\1'
 module.system.haste.paths.blacklist=.*/__tests__/.*

--- a/.flowconfig.macos
+++ b/.flowconfig.macos
@@ -1,7 +1,7 @@
 [ignore]
 ; We fork some components by platform
 .*/*[.]ios.js
-.*/*[.]macos.js
+.*/*[.]android.js
 
 ; Ignore templates for 'react-native init'
 <PROJECT_ROOT>/template/.*
@@ -23,14 +23,8 @@
 ; Ignore polyfills
 .*/Libraries/polyfills/.*
 
-; Ignore files that have a base platform file and an android file
-<PROJECT_ROOT>/Libraries/Image/Image.js
-<PROJECT_ROOT>/Libraries/Network/RCTNetworking.js
-<PROJECT_ROOT>/Libraries/Utilities/HMRLoadingView.js
-<PROJECT_ROOT>/Libraries/Components/Touchable/TouchableNativeFeedback.js
-
-; Ignore rn-cli.config.js
-<PROJECT_ROOT>/rn-cli.config.js
+; Ignore metro.config.js
+<PROJECT_ROOT>/metro.config.js
 
 ; These should not be required directly
 ; require from fbjs/lib instead: require('fbjs/lib/warning')
@@ -56,7 +50,7 @@ esproposal.nullish_coalescing=enable
 
 module.file_ext=.js
 module.file_ext=.json
-module.file_ext=.android.js
+module.file_ext=.macos.js
 
 module.system=haste
 module.system.haste.use_name_reducers=true
@@ -65,10 +59,10 @@ module.system.haste.use_name_reducers=true
 module.system.haste.name_reducers='^.*/\([a-zA-Z0-9$_.-]+\.js\(\.flow\)?\)$' -> '\1'
 # strip .js or .js.flow suffix
 module.system.haste.name_reducers='^\(.*\)\.js\(\.flow\)?$' -> '\1'
-# strip .android suffix
-module.system.haste.name_reducers='^\(.*\)\.android$' -> '\1'
-module.system.haste.name_reducers='^\(.*\)\.ios$' -> '\1'
+# strip .ios suffix
 module.system.haste.name_reducers='^\(.*\)\.macos$' -> '\1'
+module.system.haste.name_reducers='^\(.*\)\.ios$' -> '\1'
+module.system.haste.name_reducers='^\(.*\)\.android$' -> '\1'
 module.system.haste.name_reducers='^\(.*\)\.native$' -> '\1'
 module.system.haste.paths.blacklist=.*/__tests__/.*
 module.system.haste.paths.blacklist=.*/__mocks__/.*
@@ -87,8 +81,8 @@ suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_android\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_android\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(<VERSION>\\)? *\\(site=[a-z,_]*react_native\\(_ios\\)?_\\(oss\\|fb\\)[a-z,_]*\\)?)\\)?:? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 [lints]

--- a/.flowconfig.macos
+++ b/.flowconfig.macos
@@ -1,4 +1,5 @@
 [ignore]
+; TODO(macOS ISS#2323203)
 ; We fork some components by platform
 .*/*[.]ios.js
 .*/*[.]android.js

--- a/.flowconfig.macos
+++ b/.flowconfig.macos
@@ -59,7 +59,7 @@ module.system.haste.use_name_reducers=true
 module.system.haste.name_reducers='^.*/\([a-zA-Z0-9$_.-]+\.js\(\.flow\)?\)$' -> '\1'
 # strip .js or .js.flow suffix
 module.system.haste.name_reducers='^\(.*\)\.js\(\.flow\)?$' -> '\1'
-# strip .ios suffix
+# strip .macos suffix
 module.system.haste.name_reducers='^\(.*\)\.macos$' -> '\1'
 module.system.haste.name_reducers='^\(.*\)\.ios$' -> '\1'
 module.system.haste.name_reducers='^\(.*\)\.android$' -> '\1'

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.macos.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.macos.js
@@ -14,8 +14,7 @@
 
 const warning = require('fbjs/lib/warning');
 
-type ChangeEventName = $Keys<{
-}>;
+type ChangeEventName = $Keys<{}>;
 
 const AccessibilityInfo = {
   /**

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.macos.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.macos.js
@@ -8,36 +8,14 @@
  * @flow
  */
 
-// TODO(macOS ISS#2323203): copy of AccessibilityInfo.ios.js
+// TODO(macOS ISS#2323203)
 
 'use strict';
 
-const NativeModules = require('../../BatchedBridge/NativeModules');
-const RCTDeviceEventEmitter = require('../../EventEmitter/RCTDeviceEventEmitter');
-const UIManager = require('../../ReactNative/UIManager');
-
-const RCTAccessibilityInfo = NativeModules.AccessibilityInfo;
-
-const REDUCE_MOTION_EVENT = 'reduceMotionDidChange';
-const TOUCH_EXPLORATION_EVENT = 'touchExplorationDidChange';
+const warning = require('fbjs/lib/warning');
 
 type ChangeEventName = $Keys<{
-  change: string,
-  reduceMotionChanged: string,
-  screenReaderChanged: string,
 }>;
-
-const _subscriptions = new Map();
-
-/**
- * Sometimes it's useful to know whether or not the device has a screen reader
- * that is currently active. The `AccessibilityInfo` API is designed for this
- * purpose. You can use it to query the current state of the screen reader as
- * well as to register to be notified when the state of the screen reader
- * changes.
- *
- * See http://facebook.github.io/react-native/docs/accessibilityinfo.html
- */
 
 const AccessibilityInfo = {
   /**
@@ -61,10 +39,11 @@ const AccessibilityInfo = {
     return Promise.resolve(false);
   },
 
+  /**
+   * Android and iOS only
+   */
   isReduceMotionEnabled: function(): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      RCTAccessibilityInfo.isReduceMotionEnabled(resolve);
-    });
+    return Promise.resolve(false);
   },
 
   /**
@@ -74,10 +53,11 @@ const AccessibilityInfo = {
     return Promise.resolve(false);
   },
 
+  /**
+   * Android and iOS only
+   */
   isScreenReaderEnabled: function(): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      RCTAccessibilityInfo.isTouchExplorationEnabled(resolve);
-    });
+    return Promise.resolve(false);
   },
 
   /**
@@ -93,37 +73,14 @@ const AccessibilityInfo = {
     eventName: ChangeEventName,
     handler: Function,
   ): void {
-    let listener;
-
-    if (eventName === 'change' || eventName === 'screenReaderChanged') {
-      listener = RCTDeviceEventEmitter.addListener(
-        TOUCH_EXPLORATION_EVENT,
-        enabled => {
-          handler(enabled);
-        },
-      );
-    } else if (eventName === 'reduceMotionChanged') {
-      listener = RCTDeviceEventEmitter.addListener(
-        REDUCE_MOTION_EVENT,
-        enabled => {
-          handler(enabled);
-        },
-      );
-    }
-
-    _subscriptions.set(handler, listener);
+    warning(false, 'AccessibilityInfo is not supported on this platform.');
   },
 
   removeEventListener: function(
     eventName: ChangeEventName,
     handler: Function,
   ): void {
-    const listener = _subscriptions.get(handler);
-    if (!listener) {
-      return;
-    }
-    listener.remove();
-    _subscriptions.delete(handler);
+    warning(false, 'AccessibilityInfo is not supported on this platform.');
   },
 
   /**
@@ -132,10 +89,7 @@ const AccessibilityInfo = {
    * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#setaccessibilityfocus
    */
   setAccessibilityFocus: function(reactTag: number): void {
-    UIManager.sendAccessibilityEvent(
-      reactTag,
-      UIManager.AccessibilityEventTypes.typeViewFocused,
-    );
+    warning(false, 'AccessibilityInfo is not supported on this platform.');
   },
 
   /**
@@ -144,7 +98,7 @@ const AccessibilityInfo = {
    * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#announceforaccessibility
    */
   announceForAccessibility: function(announcement: string): void {
-    RCTAccessibilityInfo.announceForAccessibility(announcement);
+    warning(false, 'AccessibilityInfo is not supported on this platform.');
   },
 };
 

--- a/Libraries/Components/AccessibilityInfo/AccessibilityInfo.macos.js
+++ b/Libraries/Components/AccessibilityInfo/AccessibilityInfo.macos.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+// TODO(macOS ISS#2323203): copy of AccessibilityInfo.ios.js
+
+'use strict';
+
+const NativeModules = require('../../BatchedBridge/NativeModules');
+const RCTDeviceEventEmitter = require('../../EventEmitter/RCTDeviceEventEmitter');
+const UIManager = require('../../ReactNative/UIManager');
+
+const RCTAccessibilityInfo = NativeModules.AccessibilityInfo;
+
+const REDUCE_MOTION_EVENT = 'reduceMotionDidChange';
+const TOUCH_EXPLORATION_EVENT = 'touchExplorationDidChange';
+
+type ChangeEventName = $Keys<{
+  change: string,
+  reduceMotionChanged: string,
+  screenReaderChanged: string,
+}>;
+
+const _subscriptions = new Map();
+
+/**
+ * Sometimes it's useful to know whether or not the device has a screen reader
+ * that is currently active. The `AccessibilityInfo` API is designed for this
+ * purpose. You can use it to query the current state of the screen reader as
+ * well as to register to be notified when the state of the screen reader
+ * changes.
+ *
+ * See http://facebook.github.io/react-native/docs/accessibilityinfo.html
+ */
+
+const AccessibilityInfo = {
+  /**
+   * iOS only
+   */
+  isBoldTextEnabled: function(): Promise<boolean> {
+    return Promise.resolve(false);
+  },
+
+  /**
+   * iOS only
+   */
+  isGrayscaleEnabled: function(): Promise<boolean> {
+    return Promise.resolve(false);
+  },
+
+  /**
+   * iOS only
+   */
+  isInvertColorsEnabled: function(): Promise<boolean> {
+    return Promise.resolve(false);
+  },
+
+  isReduceMotionEnabled: function(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      RCTAccessibilityInfo.isReduceMotionEnabled(resolve);
+    });
+  },
+
+  /**
+   * iOS only
+   */
+  isReduceTransparencyEnabled: function(): Promise<boolean> {
+    return Promise.resolve(false);
+  },
+
+  isScreenReaderEnabled: function(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      RCTAccessibilityInfo.isTouchExplorationEnabled(resolve);
+    });
+  },
+
+  /**
+   * Deprecated
+   *
+   * Same as `isScreenReaderEnabled`
+   */
+  get fetch() {
+    return this.isScreenReaderEnabled;
+  },
+
+  addEventListener: function(
+    eventName: ChangeEventName,
+    handler: Function,
+  ): void {
+    let listener;
+
+    if (eventName === 'change' || eventName === 'screenReaderChanged') {
+      listener = RCTDeviceEventEmitter.addListener(
+        TOUCH_EXPLORATION_EVENT,
+        enabled => {
+          handler(enabled);
+        },
+      );
+    } else if (eventName === 'reduceMotionChanged') {
+      listener = RCTDeviceEventEmitter.addListener(
+        REDUCE_MOTION_EVENT,
+        enabled => {
+          handler(enabled);
+        },
+      );
+    }
+
+    _subscriptions.set(handler, listener);
+  },
+
+  removeEventListener: function(
+    eventName: ChangeEventName,
+    handler: Function,
+  ): void {
+    const listener = _subscriptions.get(handler);
+    if (!listener) {
+      return;
+    }
+    listener.remove();
+    _subscriptions.delete(handler);
+  },
+
+  /**
+   * Set accessibility focus to a react component.
+   *
+   * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#setaccessibilityfocus
+   */
+  setAccessibilityFocus: function(reactTag: number): void {
+    UIManager.sendAccessibilityEvent(
+      reactTag,
+      UIManager.AccessibilityEventTypes.typeViewFocused,
+    );
+  },
+
+  /**
+   * Post a string to be announced by the screen reader.
+   *
+   * See http://facebook.github.io/react-native/docs/accessibilityinfo.html#announceforaccessibility
+   */
+  announceForAccessibility: function(announcement: string): void {
+    RCTAccessibilityInfo.announceForAccessibility(announcement);
+  },
+};
+
+module.exports = AccessibilityInfo;

--- a/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.macos.js
+++ b/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.macos.js
@@ -1,10 +1,9 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
  * @format
  */
 
@@ -12,4 +11,4 @@
 
 'use strict';
 
-module.exports = require('View');
+module.exports = require('../UnimplementedViews/UnimplementedView');

--- a/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -31,7 +31,8 @@ let exported;
  * limitation of the screen, such as rounded corners or camera notches (aka
  * sensor housing area on iPhone X).
  */
-if (Platform.OS === 'android') {
+if (Platform.OS !== 'ios') {
+  // TODO(macOS ISS#2323203)
   const SafeAreaView = (
     props: Props,
     forwardedRef?: ?React.Ref<typeof View>,

--- a/Libraries/Components/StatusBar/StatusBarIOS.macos.js
+++ b/Libraries/Components/StatusBar/StatusBarIOS.macos.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+// TODO(macOS ISS#2323203): copy of StatusBarIOS.ios.js
+
+'use strict';
+
+const NativeEventEmitter = require('../../EventEmitter/NativeEventEmitter');
+const {StatusBarManager} = require('../../BatchedBridge/NativeModules');
+
+/**
+ * Use `StatusBar` for mutating the status bar.
+ */
+class StatusBarIOS extends NativeEventEmitter {}
+
+module.exports = new StatusBarIOS(StatusBarManager);

--- a/Libraries/Components/StatusBar/StatusBarIOS.macos.js
+++ b/Libraries/Components/StatusBar/StatusBarIOS.macos.js
@@ -8,7 +8,7 @@
  * @flow strict-local
  */
 
-// TODO(macOS ISS#2323203): copy of StatusBarIOS.ios.js
+// TODO(macOS ISS#2323203)
 
 'use strict';
 

--- a/Libraries/Components/TimePickerAndroid/TimePickerAndroid.macos.js
+++ b/Libraries/Components/TimePickerAndroid/TimePickerAndroid.macos.js
@@ -8,7 +8,7 @@
  * @flow strict-local
  */
 
-// TODO(macOS ISS#2323203): copy of TimePickerAndroid.ios.js
+// TODO(macOS ISS#2323203)
 
 'use strict';
 

--- a/Libraries/Components/TimePickerAndroid/TimePickerAndroid.macos.js
+++ b/Libraries/Components/TimePickerAndroid/TimePickerAndroid.macos.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+// TODO(macOS ISS#2323203): copy of TimePickerAndroid.ios.js
+
+'use strict';
+
+import type {
+  TimePickerOptions,
+  TimePickerResult,
+} from './TimePickerAndroidTypes';
+
+const TimePickerAndroid = {
+  async open(options: TimePickerOptions): Promise<TimePickerResult> {
+    return Promise.reject({
+      message: 'TimePickerAndroid is not supported on this platform.',
+    });
+  },
+};
+
+module.exports = TimePickerAndroid;

--- a/Libraries/Components/ToastAndroid/ToastAndroid.macos.js
+++ b/Libraries/Components/ToastAndroid/ToastAndroid.macos.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
+ */
+
+// TODO(macOS ISS#2323203): copy of ToastAndroid.ios.js
+
+'use strict';
+
+const warning = require('fbjs/lib/warning');
+
+const ToastAndroid = {
+  show: function(message: string, duration: number): void {
+    warning(false, 'ToastAndroid is not supported on this platform.');
+  },
+};
+
+module.exports = ToastAndroid;

--- a/Libraries/Components/ToastAndroid/ToastAndroid.macos.js
+++ b/Libraries/Components/ToastAndroid/ToastAndroid.macos.js
@@ -8,7 +8,7 @@
  * @noflow
  */
 
-// TODO(macOS ISS#2323203): copy of ToastAndroid.ios.js
+// TODO(macOS ISS#2323203)
 
 'use strict';
 

--- a/Libraries/Components/ToolbarAndroid/ToolbarAndroid.macos.js
+++ b/Libraries/Components/ToolbarAndroid/ToolbarAndroid.macos.js
@@ -1,15 +1,14 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
- * This is a controlled component version of RCTPickerIOS
  *
  * @format
  */
 
 // TODO(macOS ISS#2323203)
+
+'use strict';
 
 module.exports = require('../UnimplementedViews/UnimplementedView');

--- a/Libraries/Components/ViewPager/ViewPagerAndroid.macos.js
+++ b/Libraries/Components/ViewPager/ViewPagerAndroid.macos.js
@@ -1,15 +1,14 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
- * This is a controlled component version of RCTPickerIOS
  *
  * @format
  */
 
 // TODO(macOS ISS#2323203)
+
+'use strict';
 
 module.exports = require('../UnimplementedViews/UnimplementedView');

--- a/Libraries/Utilities/Platform.macos.js
+++ b/Libraries/Utilities/Platform.macos.js
@@ -32,6 +32,9 @@ const Platform = {
     }
     return false;
   },
+  get isTV() {
+    return false;
+  },
   select: <D, I>(spec: PlatformSelectSpec<D, I>): D | I =>
     'macos' in spec ? spec.macos : spec.default,
 };

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "test-ci": "jest --maxWorkers=2 --ci --reporters=\"default\" --reporters=\"jest-junit\"",
     "flow": "flow",
     "flow-check-ios": "flow check",
+    "flow-check-macos": "flow check --flowconfig-name .flowconfig.macos",
     "flow-check-android": "flow check --flowconfig-name .flowconfig.android",
     "lint": "eslint .",
     "clang-format": "clang-format -i --glob=*/**/*.{h,cpp,m,mm}",


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

There were hidden macOS Flow validation failures. As in the facebook repo this forks has a `.flowconfig` (which is really for ios) and a `.flowconfig.android`. The ios config ignores `*.android.js` files and the android config ignores `*.ios.js` files.   This fork which contains the macOS implementation needs a `.flowconfig.macos` that ignores ios and android and the other two need to ignore macos. 

Also added a `yarn flow-check-macos` to `package.json` and updated the Azure DevOps yaml files to check all three platforms.

Several stub JS files for macOS needed to be added similar to existing stubs for ios and android.

The macos `Platform` API needed a `isTV` method.

The Android `.flowconfig.android` needed to exclude `metro.config.js` the same as ios and macos in order for `yarn flow-check-android` to pass.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/212)