### PR TITLE
Fix up some spacing issues with KeepingRecent doc

### DIFF
--- a/KeepingRecent.md
+++ b/KeepingRecent.md
@@ -5,28 +5,28 @@ We aim to keep this forked repository as up to date as possible with [Facebook's
 
 ## Merging a New Version of React Native
 1. Create a reference to a remote to Facebook's repo
-1.1. In terminal: `git remote add facebook https://github.com/facebook/react-native.git`
-1.2. In terminal: `cd react-native/; git pull facebook`
+    1. In terminal: `git remote add facebook https://github.com/facebook/react-native.git`
+    2. In terminal: `cd react-native/; git pull facebook`
 2.  Create a branch to work in. Below is for merging in Facebook's React Native 0.58 version. 
-2.1. In terminal: e.g. `git branch fb58merge`
-2.2. In terminal: e.g. `git checkout fb58merge`
+    1. In terminal: e.g. `git branch fb58merge`
+    2. In terminal: e.g. `git checkout fb58merge`
 3.  Pull the fb contents at the merge point we want. A list of their most recent versions can be found [here](https://facebook.github.io/react-native/versions).
-3.1.  In terminal: e.g. `git fetch facebook v0.58.6`
+    1.  In terminal: e.g. `git fetch facebook v0.58.6`
 4.  Do the merge at the point we want, in this example it's the last version tag of their 0.58 build. Use the name you used in 3.1 here.
-4.1.  In terminal: e.g. `git merge v0.58.6`
+    1.  In terminal: e.g. `git merge v0.58.6`
 
 ## Integration Guidelines
 It's likely you'll want to push the initial merge up to github **with** the merge conflicts. This makes it easier for other people to see where the errors are and help fix their platforms quickly.
 
 1.  Commit all the changes (conflicts and all). There are many resources to do this such as the [Visual Studio Code](https://code.visualstudio.com/) UI or command line.
 2.  After you've committed all the changes, push your merge up.
-2.1.  In terminal: `git push`. This should fail to push, but print out a suggested `git push [more repo specifics here]` command.
-2.2. Copy and run that suggested push command which has the proper upstream repo specified.
+    1.  In terminal: `git push`. This should fail to push, but print out a suggested `git push [more repo specifics here]` command.
+    2. Copy and run that suggested push command which has the proper upstream repo specified.
 
 #### First Time Merging? Read Below. Otherwise this shouldn't apply to you.
 3.  The first time doing this, terminal may ask for your github credentials after running the `git push` command from 2.2. You'll need to provide your github username and a 2-Factor-Authentication token password. If you don't have this yet, see substeps below. <em>Github doesn't distinguish when you need to use your github password vs. this 2FA token, but for command line github interactions, you'll need to use the token.</em>
-3.1.  Generate your personal access token [here](https://github.com/settings/tokens)
-3.2.  More details [here](https://stackoverflow.com/questions/29297154/github-invalid-username-or-password)
+    1.  Generate your personal access token [here](https://github.com/settings/tokens)
+    2.  More details [here](https://stackoverflow.com/questions/29297154/github-invalid-username-or-password)
 
 ## Best Practices
 * Before pulling in a new React-Native version, verify with platform owners that they're ready to work on the merge.


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [X ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

The second level numbers weren't indented correctly. This should fix that up.

#### Focus areas to test

Checked this fix on commonmark.org since the markdown site I used initially didn't show this problem.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/213)