### PR TITLE
Bring back support for DialogModule over standard Android activities

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
@@ -13,7 +13,6 @@ import android.content.DialogInterface.OnClickListener;
 import android.content.DialogInterface.OnDismissListener;
 import android.os.Bundle;
 import androidx.fragment.app.FragmentActivity;
-import androidx.fragment.app.FragmentManager;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Callback;
@@ -68,13 +67,31 @@ public class DialogModule extends ReactContextBaseJavaModule implements Lifecycl
     return NAME;
   }
 
+  /**
+   * Helper to allow this module to work with both the standard FragmentManager
+   * and the Support/AndroidX FragmentManager (for apps that need to use the former for legacy reasons).
+   * Since the two APIs don't share a common interface there's unfortunately some
+   * code duplication.
+   * Please not that the direct usage of standard FragmentManager is deprecated in API v28
+   */
   private class FragmentManagerHelper {
-    private final @Nonnull FragmentManager mFragmentManager;
+    private final @Nonnull androidx.fragment.app.FragmentManager mFragmentManager;
+    private final @Nullable android.app.FragmentManager mPlatformFragmentManager;
 
     private @Nullable Object mFragmentToShow;
 
-    public FragmentManagerHelper(@Nonnull FragmentManager fragmentManager) {
+    private boolean isUsingPlatformFragmentManager() {
+      return mPlatformFragmentManager != null;
+    }
+
+    public FragmentManagerHelper(android.app.FragmentManager platformFragmentManager) {
+      mFragmentManager = null;
+      mPlatformFragmentManager = platformFragmentManager;
+    }
+
+    public FragmentManagerHelper(@Nonnull androidx.fragment.app.FragmentManager fragmentManager) {
       mFragmentManager = fragmentManager;
+      mPlatformFragmentManager = null;
     }
 
     public void showPendingAlert() {
@@ -85,7 +102,11 @@ public class DialogModule extends ReactContextBaseJavaModule implements Lifecycl
       }
 
       dismissExisting();
-      ((AlertFragment) mFragmentToShow).show(mFragmentManager, FRAGMENT_TAG);
+      if(isUsingPlatformFragmentManager()) {
+        ((PlatformAlertFragment) mFragmentToShow).show(mPlatformFragmentManager, FRAGMENT_TAG);
+      } else {
+        ((AlertFragment) mFragmentToShow).show(mFragmentManager, FRAGMENT_TAG);
+      }
       mFragmentToShow = null;
     }
 
@@ -93,10 +114,19 @@ public class DialogModule extends ReactContextBaseJavaModule implements Lifecycl
       if (!mIsInForeground) {
         return;
       }
-      AlertFragment oldFragment =
-        (AlertFragment) mFragmentManager.findFragmentByTag(FRAGMENT_TAG);
-      if (oldFragment != null && oldFragment.isResumed()) {
-        oldFragment.dismiss();
+
+      if(isUsingPlatformFragmentManager()) {
+        PlatformAlertFragment oldFragment =
+          (PlatformAlertFragment) mPlatformFragmentManager.findFragmentByTag(FRAGMENT_TAG);
+        if (oldFragment != null && oldFragment.isResumed()) {
+          oldFragment.dismiss();
+        }
+      } else {
+        AlertFragment oldFragment =
+          (AlertFragment) mFragmentManager.findFragmentByTag(FRAGMENT_TAG);
+        if (oldFragment != null && oldFragment.isResumed()) {
+          oldFragment.dismiss();
+        }
       }
     }
 
@@ -108,14 +138,26 @@ public class DialogModule extends ReactContextBaseJavaModule implements Lifecycl
       AlertFragmentListener actionListener =
           actionCallback != null ? new AlertFragmentListener(actionCallback) : null;
 
-      AlertFragment alertFragment = new AlertFragment(actionListener, arguments);
-      if (mIsInForeground && !mFragmentManager.isStateSaved()) {
-        if (arguments.containsKey(KEY_CANCELABLE)) {
-          alertFragment.setCancelable(arguments.getBoolean(KEY_CANCELABLE));
+      if(isUsingPlatformFragmentManager()) {
+        PlatformAlertFragment PlatformAlertFragment = new PlatformAlertFragment(actionListener, arguments);
+        if (mIsInForeground && !mPlatformFragmentManager.isStateSaved()) {
+          if (arguments.containsKey(KEY_CANCELABLE)) {
+            PlatformAlertFragment.setCancelable(arguments.getBoolean(KEY_CANCELABLE));
+          }
+          PlatformAlertFragment.show(mPlatformFragmentManager, FRAGMENT_TAG);
+        } else {
+          mFragmentToShow = PlatformAlertFragment;
         }
-        alertFragment.show(mFragmentManager, FRAGMENT_TAG);
       } else {
-        mFragmentToShow = alertFragment;
+        AlertFragment alertFragment = new AlertFragment(actionListener, arguments);
+        if (mIsInForeground && !mFragmentManager.isStateSaved()) {
+          if (arguments.containsKey(KEY_CANCELABLE)) {
+            alertFragment.setCancelable(arguments.getBoolean(KEY_CANCELABLE));
+          }
+          alertFragment.show(mFragmentManager, FRAGMENT_TAG);
+        } else {
+          mFragmentToShow = alertFragment;
+        }
       }
     }
   }
@@ -239,9 +281,16 @@ public class DialogModule extends ReactContextBaseJavaModule implements Lifecycl
    */
   private @Nullable FragmentManagerHelper getFragmentManagerHelper() {
     Activity activity = getCurrentActivity();
-    if (activity == null || !(activity instanceof FragmentActivity)) {
+    if (activity == null) {
       return null;
     }
-    return new FragmentManagerHelper(((FragmentActivity) activity).getSupportFragmentManager());
+
+    if(activity instanceof FragmentActivity) {
+      return new FragmentManagerHelper(((FragmentActivity) activity).getSupportFragmentManager());
+    } else if(activity.getFragmentManager() != null){
+      return new FragmentManagerHelper(activity.getFragmentManager());
+    } else {
+      return null;
+    }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/PlatformAlertFragment.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/PlatformAlertFragment.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.modules.dialog;
+
+import javax.annotation.Nullable;
+
+import android.annotation.SuppressLint;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.DialogInterface;
+import android.content.Context;
+import android.os.Bundle;
+
+/**
+ * A fragment used to display the dialog based on the platform DialogFragment control. Please note that the usage of this control is deprecated in API v28 in favor of the newer Jetpack/Support controls.
+ */
+public class PlatformAlertFragment extends DialogFragment implements DialogInterface.OnClickListener {
+  /* package */ static final String ARG_TITLE = "title";
+  /* package */ static final String ARG_MESSAGE = "message";
+  /* package */ static final String ARG_BUTTON_POSITIVE = "button_positive";
+  /* package */ static final String ARG_BUTTON_NEGATIVE = "button_negative";
+  /* package */ static final String ARG_BUTTON_NEUTRAL = "button_neutral";
+  /* package */ static final String ARG_ITEMS = "items";
+
+  private final @Nullable DialogModule.AlertFragmentListener mListener;
+
+  public PlatformAlertFragment() {
+    mListener = null;
+  }
+
+  @SuppressLint("ValidFragment")
+  public PlatformAlertFragment(@Nullable DialogModule.AlertFragmentListener listener, Bundle arguments) {
+    mListener = listener;
+    setArguments(arguments);
+  }
+
+
+  public static Dialog createDialog(
+    Context activityContext, Bundle arguments, DialogInterface.OnClickListener fragment) {
+    AlertDialog.Builder builder = new AlertDialog.Builder(activityContext)
+      .setTitle(arguments.getString(ARG_TITLE));
+
+    if (arguments.containsKey(ARG_BUTTON_POSITIVE)) {
+      builder.setPositiveButton(arguments.getString(ARG_BUTTON_POSITIVE), fragment);
+    }
+
+    if (arguments.containsKey(ARG_BUTTON_NEGATIVE)) {
+      builder.setNegativeButton(arguments.getString(ARG_BUTTON_NEGATIVE), fragment);
+    }
+
+    if (arguments.containsKey(ARG_BUTTON_NEUTRAL)) {
+      builder.setNeutralButton(arguments.getString(ARG_BUTTON_NEUTRAL), fragment);
+    }
+
+    // if both message and items are set, Android will only show the message
+    // and ignore the items argument entirely
+    if (arguments.containsKey(ARG_MESSAGE)) {
+      builder.setMessage(arguments.getString(ARG_MESSAGE));
+    }
+
+    if (arguments.containsKey(ARG_ITEMS)) {
+      builder.setItems(arguments.getCharSequenceArray(ARG_ITEMS), fragment);
+    }
+
+    return builder.create();
+  }
+
+  @Override
+  public Dialog onCreateDialog(Bundle savedInstanceState) {
+    return createDialog(getActivity(), getArguments(), this);
+  }
+
+  @Override
+  public void onClick(DialogInterface dialog, int which) {
+    if (mListener != null) {
+      mListener.onClick(dialog, which);
+    }
+  }
+
+  @Override
+  public void onDismiss(DialogInterface dialog) {
+    super.onDismiss(dialog);
+    if (mListener != null) {
+      mListener.onDismiss(dialog);
+    }
+  }
+}


### PR DESCRIPTION
This change is essentially a revert of the following commit,

https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmicrosoft%2Freact-native%2Fcommit%2F243070afe2873c09c1149ca3ede3386abb88a529%23diff-8e3b74ad18aa49187acd4240321bc9b9&data=02%7C01%7Canandrag%40microsoft.com%7C11460df4f62b4dcb762b08d793fa26cb%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C637140574925336509&sdata=Ky1sCL4qcv3rO8OUBGYfNDvB0Ew9ib36XQ1oDhZl6XE%3D&reserved=0

With the above change, by design, the react-native stopped support for showing Dialogs over standard Android activities, since the required APIs are deprecated in platform 28, in favor of the newer Jetpack library controls. 

But, Office apps are still using the standard Android activities and it will take a while before the base app infrastructure gets upgraded to use the newer artefacts. This change will allow us to straddle between the modern and historical in the meantime.

Unfortunately this change is bringing new difference between our fork and the open source react-native repository.

<!--
We are working on reducing the diff between Facebook's public version of react-native, and our microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

(give an overview)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/222)