### PR TITLE
Deforking - Cleaning up android gradle build script

### DIFF
--- a/.ado/android-pr.yml
+++ b/.ado/android-pr.yml
@@ -75,6 +75,11 @@ jobs:
           #arguments: # Required when command == Custom
 
       - task: CmdLine@2
+        displayName: Setup Build Dependencies
+        inputs:
+          script: .ado\setup_droid_deps.bat
+
+      - task: CmdLine@2
         displayName: Remove RNTesterApp.android.bundle
         inputs:
           script: del RNTesterApp.android.bundle
@@ -86,6 +91,8 @@ jobs:
 
       - task: Gradle@1
         displayName: gradlew installArchives
+        env:
+          REACT_NATIVE_DEPENDENCIES: $(System.DefaultWorkingDirectory)\build_deps
         inputs:
           gradleWrapperFile: gradlew
           # workingDirectory: src\react-native\

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -81,8 +81,15 @@ jobs:
           #verbosityPack: 'Detailed' # Options: quiet, normal, detailed
           #arguments: # Required when command == Custom
 
+      - task: CmdLine@2
+        displayName: Setup Build Dependencies
+        inputs:
+          script: .ado\setup_droid_deps.bat
+
       - task: Gradle@1
         displayName: gradlew installArchives
+        env:
+          REACT_NATIVE_DEPENDENCIES: $(System.DefaultWorkingDirectory)\build_deps
         inputs:
           gradleWrapperFile: gradlew
           # workingDirectory: src\react-native\

--- a/.ado/setup_droid_deps.bat
+++ b/.ado/setup_droid_deps.bat
@@ -1,0 +1,20 @@
+@if "%DEBUG%" == "" @echo off
+
+REM Assuming the script is run from the root directory of a local clone of Microsoft fork of react-native. i.e. http:\\github.com\Microsoft\react-native
+
+set BUILD_DEPS_DIR=build_deps
+
+IF EXIST %BUILD_DEPS_DIR% (
+    rmdir /s /q %BUILD_DEPS_DIR%
+    if errorlevel 1 echo "Cleaning up the build dependency directory failed !" 1>&2
+)
+
+mkdir %BUILD_DEPS_DIR%
+
+mklink /D /J %BUILD_DEPS_DIR%\boost ReactAndroid\packages\boost.1.68.0.0\lib\native\include\boost
+mklink /D /J %BUILD_DEPS_DIR%\double-conversion double-conversion\double-conversion
+mklink /D /J %BUILD_DEPS_DIR%\Folly Folly\
+mklink /D /J %BUILD_DEPS_DIR%\glog glog
+
+REM When setting up locally, set the environement variable as follows.
+REM set REACT_NATIVE_DEPENDENCIES=%CD%\%BUILD_DEPS_DIR%

--- a/ReactAndroid/build.gradle
+++ b/ReactAndroid/build.gradle
@@ -13,10 +13,7 @@ import de.undercouch.gradle.tasks.download.Download
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.apache.tools.ant.filters.ReplaceTokens
 
-// In FB react-native, we are downloading all third dependencies source code during build time and then build and consume it.
-// We got rid of this due to anti-compliance and other requirements like building on other environment like clang.
-// Now we have all third party dependencies as separate git repo which are then sub modules of react-native.
-// For boost, we are getting source though nuget. After this we are following the same approach.
+// We download various C++ open-source dependencies into downloads.
 // We then copy both the downloaded code and our custom makefiles and headers into third-party-ndk.
 // After that we build native code from src/main/jni with module path pointing at third-party-ndk.
 
@@ -35,11 +32,8 @@ def dependenciesPath = System.getenv("REACT_NATIVE_DEPENDENCIES")
 // The Boost library is a very large download (>100MB).
 // If Boost is already present on your system, define the REACT_NATIVE_BOOST_PATH env variable
 // and the build will use that.
-def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH") ?: 'packages/boost.1.68.0.0/lib/native/include'
+def boostPath = dependenciesPath ?: System.getenv("REACT_NATIVE_BOOST_PATH")
 
-def DoubleConversionPath = '../double-conversion'
-def FollyPath = '..'
-def GlogPath = '..'
 def V8Path = 'packages/ReactNative.V8.Android.7.0.276.32-v1'
 
 task createNativeDepsDirectories {
@@ -47,7 +41,6 @@ task createNativeDepsDirectories {
     thirdPartyNdkDir.mkdirs()
 }
 
-// For GitHub CI - we use this task
 task downloadBoost(dependsOn: createNativeDepsDirectories, type: Download) {
     src("https://github.com/react-native-community/boost-for-react-native/releases/download/v${BOOST_VERSION.replace("_", ".")}-0/boost_${BOOST_VERSION}.tar.gz")
     onlyIfNewer(true)
@@ -68,16 +61,30 @@ task prepareBoost(dependsOn: boostPath ? [] : [downloadBoost], type: Copy) {
     // }
 }
 
-task prepareDoubleConversion(dependsOn: createNativeDepsDirectories, type: Copy) {
-    from(DoubleConversionPath)
+task downloadDoubleConversion(dependsOn: createNativeDepsDirectories, type: Download) {
+    src("https://github.com/google/double-conversion/archive/v${DOUBLE_CONVERSION_VERSION}.tar.gz")
+    onlyIfNewer(true)
+    overwrite(false)
+    dest(new File(downloadsDir, "double-conversion-${DOUBLE_CONVERSION_VERSION}.tar.gz"))
+}
+
+task prepareDoubleConversion(dependsOn: dependenciesPath ? [] : [downloadDoubleConversion], type: Copy) {
+    from(dependenciesPath ?: tarTree(downloadDoubleConversion.dest))
     from("src/main/jni/third-party/double-conversion/Android.mk")
     include 'double-conversion/**/*', 'Android.mk'
     includeEmptyDirs = false
     into("$thirdPartyNdkDir/double-conversion")
 }
 
-task prepareFolly(dependsOn: createNativeDepsDirectories, type: Copy) {
-    from(FollyPath)
+task downloadFolly(dependsOn: createNativeDepsDirectories, type: Download) {
+    src("https://github.com/facebook/folly/archive/v${FOLLY_VERSION}.tar.gz")
+    onlyIfNewer(true)
+    overwrite(false)
+    dest(new File(downloadsDir, "folly-${FOLLY_VERSION}.tar.gz"))
+}
+
+task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy) {
+    from(dependenciesPath ?: tarTree(downloadFolly.dest))
     from("src/main/jni/third-party/folly/Android.mk")
     include("Folly/folly/**/*", "Android.mk")
     eachFile {fname -> fname.path = (fname.path - "Folly/")}
@@ -85,10 +92,17 @@ task prepareFolly(dependsOn: createNativeDepsDirectories, type: Copy) {
     into("$thirdPartyNdkDir/folly")
 }
 
+task downloadGlog(dependsOn: createNativeDepsDirectories, type: Download) {
+    src("https://github.com/google/glog/archive/v${GLOG_VERSION}.tar.gz")
+    onlyIfNewer(true)
+    overwrite(false)
+    dest(new File(downloadsDir, "glog-${GLOG_VERSION}.tar.gz"))
+}
+
 // Prepare glog sources to be compiled, this task will perform steps that normally should've been
 // executed by automake. This way we can avoid dependencies on make/automake
-task prepareGlog(dependsOn: createNativeDepsDirectories, type: Copy) {
-    from(GlogPath)
+task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) {
+    from(dependenciesPath ?: tarTree(downloadGlog.dest))
     from("src/main/jni/third-party/glog/")
     include("glog/src/**/*", "Android.mk", "config.h")
     includeEmptyDirs = false
@@ -153,6 +167,9 @@ task downloadNdkBuildDependencies {
     if (!boostPath) {
         dependsOn(downloadBoost)
     }
+    dependsOn(downloadDoubleConversion)
+    dependsOn(downloadFolly)
+    dependsOn(downloadGlog)
 }
 
 def getNdkBuildName() {
@@ -216,7 +233,7 @@ def getNdkBuildFullPath() {
     return ndkBuildFullPath
 }
 
-task buildReactNdkLib(dependsOn: [prepareBoost, prepareDoubleConversion, prepareFolly, prepareGlog], type: Exec) {
+task buildReactNdkLib(dependsOn: [prepareJSC, prepareBoost, prepareDoubleConversion, prepareFolly, prepareGlog], type: Exec) {
     inputs.dir("$projectDir/../ReactCommon")
     inputs.dir("src/main/jni")
     outputs.dir("$buildDir/react-ndk/all")


### PR DESCRIPTION
#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

This change is removing a few of the differences in the gradle script used for build setup. Instead of hardcoding our customization, with this change, we make use of the existing mechanisms already available in the open source code. i.e. by using environment variables to specific pre-setup build inputs.

#### Focus areas to test

Build.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/225)