### PR TITLE
Remove react-native commands from cli when installed as 'react-native-macos'

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -11,8 +11,14 @@
 const ios = require('@react-native-community/cli-platform-ios');
 const android = require('@react-native-community/cli-platform-android');
 
+// Remove commands so that react-native-macos can coexist with react-native in repos that depend on both.
+const path = require("path");
+const isReactNativeMacOS = path.basename(__dirname) === 'react-native-macos'; 
+const iosCommands = isReactNativeMacOS ? [] : ios.commands;
+const androidCommands = isReactNativeMacOS ? [] : android.commands;
+
 module.exports = {
-  commands: [...ios.commands, ...android.commands],
+  commands: [...iosCommands, ...androidCommands],
   platforms: {
     ios: {
       linkConfig: ios.linkConfig,

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -12,8 +12,8 @@ const ios = require('@react-native-community/cli-platform-ios');
 const android = require('@react-native-community/cli-platform-android');
 
 // Remove commands so that react-native-macos can coexist with react-native in repos that depend on both.
-const path = require("path");
-const isReactNativeMacOS = path.basename(__dirname) === 'react-native-macos'; 
+const path = require('path');
+const isReactNativeMacOS = path.basename(__dirname) === 'react-native-macos';
 const iosCommands = isReactNativeMacOS ? [] : ios.commands;
 const androidCommands = isReactNativeMacOS ? [] : android.commands;
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

When react-native-macos is installed alongside react-native in a repo, the react-native CLI scripts will discover both installations and run commands twice.   The react-native.config.js file will eventually refer to macos commands once we have an implementation for them.   In the meantime, and as long as react-native-macos is a fork of facebook/react-native, it is still useful to use the ios and android CLI locally for testing purposes.   But when installed in another repo, such as any of the react-native-community repos along side facebook react-native, we cannot allow the CLI commands to execute twice for each installation.

In react-native.config.js, check the basename of __dirname and if it is 'react-native-macos' as it will be when installed in a 'node_modules' folder, then use empty command arrays for ios and android.

react-native-webview will be the first react-native-community repo that will need this fix in order to preserve `react-native run-ios` and `react-native run-android` functionality (see https://github.com/react-native-community/react-native-webview/pull/1164)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/227)