### PR TITLE
Change publish step to publish react-native-macos npm package.

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -139,3 +139,14 @@ jobs:
         inputs:
           PathtoPublish: '$(Build.StagingDirectory)\final'
           ArtifactName: 'ReactNative-Final'
+
+      - task: CmdLine@2
+        displayName: "Prepare package.json for npm publishing as react-native-macos"
+        inputs:
+          script: node .ado/renamePackageToMac.js
+
+      - task: Npm@1
+        displayName: "Publish react-native-macos to npmjs.org"
+        inputs:
+          command: 'publish'
+          publishEndpoint: 'npmjs'

--- a/.ado/renamePackageToMac.js
+++ b/.ado/renamePackageToMac.js
@@ -1,0 +1,3 @@
+// @ts-check
+const {updatePackageName} = require('./versionUtils');
+updatePackageName('react-native-macos');

--- a/.ado/versionUtils.js
+++ b/.ado/versionUtils.js
@@ -37,9 +37,17 @@ function updateVersionsInFiles() {
     return {releaseVersion, branchVersionSuffix};
 }
 
+function updatePackageName(name) {
+    let pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+    pkgJson.name = name;
+    fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
+    console.log(`Updating package.json to name ${name}`);
+}
+
 module.exports = {
     gatherVersionInfo,
     publishBranchName,
     pkgJsonPath,
-    updateVersionsInFiles
+    updateVersionsInFiles,
+    updatePackageName
 }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

This change begins publishing a `react-native-macos` package to npmjs.org.

At this time we can't just rename the package from `react-native` to `react-native-macos` in the `package.json` because we still publish a `react-native` package to an internal npm feed used widely within Microsoft.   In the meantime a simple node script step renames the name in `package.json` just prior to performing `npm publish` to npmjs.   After we migrate all internal consumers to use the public npm package, this script step can go away and the `package.json` name can be changed to `react-native-macos`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/228)