### PR TITLE
Build break fix: set XCode version to 11.2.1

### DIFF
--- a/.ado/templates/apple-xcode-build.yml
+++ b/.ado/templates/apple-xcode-build.yml
@@ -17,7 +17,7 @@ steps:
       sdk: ${{ parameters.xcode_sdk }}
       xcWorkspacePath: ${{ parameters.xcode_workspacePath }}
       scheme: ${{ parameters.xcode_scheme }}
-      xcodeVersion: 11
+      xcodeVersion: default
       signingOption: auto
       packageApp: false
       teamId: '$(XCodeSigningMicrosoftTeamID)'

--- a/.ado/templates/apple-xcode-select.yml
+++ b/.ado/templates/apple-xcode-select.yml
@@ -2,37 +2,7 @@
 # Task Group: XCode select proper version
 #
 steps:
-  # The XCODE_11_DEVELOPER_DIR variable is defined in the Hosted Agents and is used by the Xcode@5 tasks.
-  # The 'OE Mac Pool' agents do not define this variable, so manually set it here if it is not defined.
-  - script: |
-      if [ -z $XCODE_11_DEVELOPER_DIR ]; then 
-        DIR='/Applications/Xcode_11_beta.app/Contents/Developer/'
-        if [ ! -d $DIR ]; then
-          DIR='/Applications/Xcode.app/Contents/Developer/'
-        fi
-        if [ -d $DIR ]; then
-          echo "##vso[task.setvariable variable=XCODE_11_DEVELOPER_DIR;]$DIR"
-        else
-          (>&2 echo "No Xcode found.")
-        fi
-      fi
-    displayName: 'Ensure XCODE_11_DEVELOPER_DIR'
-    failOnStderr: true
-
-  # The DEVELOPER_DIR variable is used by xcodebuild to specify the version of Xcode to use.
-  # Set the variable here so that npm components and CMake build steps get the latest XCode version
-  # instead of whatever version is the default on the build agent.
-  - script: |
-      echo "##vso[task.setvariable variable=DEVELOPER_DIR;]$XCODE_11_DEVELOPER_DIR"
-    displayName: 'Set DEVELOPER_DIR'
-
-  - script: |
-      REQUIRED=11.0
-      VER=`xcodebuild -version | head -n1 | cut -d' ' -f2`
-      if (( $(echo "$VER >= $REQUIRED" | bc -l) )); then
-        echo "XCode version $VER is active."
-      else
-        (>&2 echo "Must have XCode $REQUIRED or later.")
-      fi
-    displayName: 'Check XCode version'
+  - bash: |
+      sudo xcode-select --switch '/Applications/Xcode_11.2.1.app'
+    displayName: 'Switch to XCode 11.2.1'
     failOnStderr: true


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

The build pipeline was using XCode 11.0.   A recent change to the build agents broke the script method we used to select the XCode version.

Our old script method was designed to work in both the public build agents and the custom internal build agents.   We no longer use the later, so this change switches to the more conventional method of switching xcode version which is to `sudo xcode-select --switch 'path to xcode'` and then to use `xcodeVersion: default` in the `XCode@5` tasks.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/231)