### PR TITLE
Resolving VKB not showing up in comments

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -857,7 +857,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
               eventDispatcher.dispatchEvent(
                   new ReactTextInputFocusEvent(
                       editText.getId()));
+              // Show keyboard when a EditText view gains focus
+              editText.showSoftKeyboard();
             } else {
+              // Hide keyboard when a EditText view looses focus
+              editText.hideSoftKeyboard();
               eventDispatcher.dispatchEvent(
                   new ReactTextInputBlurEvent(
                       editText.getId()));


### PR DESCRIPTION
# :warning: Make sure you are targeting microsoft/react-native for your PR :warning:
(then delete these lines)

<!--
We are working on reducing the diff between Facebook's public version of react-native, and our microsoft/react-native.  Long term, we want to remove the need for our version and only depend on Facebook's react-native.  In order to move in the right direction, new changes should be examined to ensure that we are doing the right thing.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to react-native.  Often a change can be made in a layer above react-native instead.
- Create a corresponding PR against [react-native on GitHub](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for GitHub feedback before submitting to ISS, since we want to ensure that ISS doesn't deviate from GitHub.
-->

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

After Rn 0.60 update in sdx-platoform, Virtual Keyboard was not showing up in modern comments when user tries to post a comment. User had to click on the EditText again to bring up VKB.
The issue came up because while updating to RN 0.60 one change in ReactTextInputManager.java was reverted. Making that change now.

#### Focus areas to test

Tested that with this change comments are working fine and also verified the polytester app is working fine.
No other areas to test.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/246)