### PR TITLE
Stop OS logging connection refused errors by explicitly setting our j…

### DIFF
--- a/RNTester/RNTester/AppDelegate.mm
+++ b/RNTester/RNTester/AppDelegate.mm
@@ -88,15 +88,12 @@
 - (NSURL *)sourceURLForBridge:(__unused RCTBridge *)bridge
 {
   NSString *bundlePrefix = [[[NSBundle mainBundle] infoDictionary] valueForKey:@"RN_BUNDLE_PREFIX"];
-  NSString *bundleRoot = [NSString stringWithFormat:@"%@RNTester/js/RNTesterApp.ios", bundlePrefix];  
-#if DEBUG
+  NSString *bundleRoot = [NSString stringWithFormat:@"%@RNTester/js/RNTesterApp.ios", bundlePrefix];
   NSURL *jsUrl = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:bundleRoot fallbackResource:nil];
+#if DEBUG
   [[RCTBundleURLProvider sharedSettings] setJsLocation:jsUrl.host];
-  return jsUrl;
-#else
-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:bundleRoot
-                                                        fallbackResource:nil];
- #endif
+#endif
+ return jsUrl;
 }
 
 - (BOOL)application:(UIApplication *)app

--- a/RNTester/RNTester/AppDelegate.mm
+++ b/RNTester/RNTester/AppDelegate.mm
@@ -88,9 +88,15 @@
 - (NSURL *)sourceURLForBridge:(__unused RCTBridge *)bridge
 {
   NSString *bundlePrefix = [[[NSBundle mainBundle] infoDictionary] valueForKey:@"RN_BUNDLE_PREFIX"];
-  NSString *bundleRoot = [NSString stringWithFormat:@"%@RNTester/js/RNTesterApp.ios", bundlePrefix];
+  NSString *bundleRoot = [NSString stringWithFormat:@"%@RNTester/js/RNTesterApp.ios", bundlePrefix];  
+#if DEBUG
+  NSURL *jsUrl = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:bundleRoot fallbackResource:nil];
+  [[RCTBundleURLProvider sharedSettings] setJsLocation:jsUrl.host];
+  return jsUrl;
+#else
   return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:bundleRoot
                                                         fallbackResource:nil];
+ #endif
 }
 
 - (BOOL)application:(UIApplication *)app


### PR DESCRIPTION
…s location

- [X ] I am making a change required for Microsoft usage of react-native

This is a change that should eventually get pushed upstream to Facebook. Only in Debug mode (so no user impact), we're getting a ton of console spew `nw_socket_handle_socket_event`. Explicitly set the js location so the bundle's provider can find the JS host.

#### Focus areas to test

Ran RN in debug and release modes and no console spew.
