### PR TITLE
Change the `reactInstance` category method return `weak_ptr`

### DIFF
--- a/React/Base/RCTBridge+Cxx.h
+++ b/React/Base/RCTBridge+Cxx.h
@@ -12,6 +12,6 @@
 
 @interface RCTBridge (Cxx)
 
-- (std::shared_ptr<facebook::react::Instance>)reactInstance;
+- (std::weak_ptr<facebook::react::Instance>)reactInstance;
 
 @end

--- a/React/Base/RCTBridge+Cxx.mm
+++ b/React/Base/RCTBridge+Cxx.mm
@@ -13,8 +13,8 @@
 
 @implementation RCTBridge (Cxx)
 
-- (std::shared_ptr<facebook::react::Instance>)reactInstance {
-	std::shared_ptr<facebook::react::Instance> instance;
+- (std::weak_ptr<facebook::react::Instance>)reactInstance {
+	std::weak_ptr<facebook::react::Instance> instance;
 	RCTBridge *batchBridge = [self batchedBridge];
 	if ([batchBridge isKindOfClass:[RCTCxxBridge class]]) {
 		RCTCxxBridge *cxxBridge = (RCTCxxBridge *)batchBridge;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

The `RCTBridge (Cxx)` category is used internally by Microsoft Office to access the C++ `facebook::react::Instance` within an `RCTBridge`.   It has a `reactInstance` method that exposes the internal `reactInstance` on `RCTBridge`.   The internal `reactInstace` used to return a `shared_ptr` but in **https://github.com/facebook/react-native/commit/71a8944b3946beff7ba7d1e65c38aa56c30227ec** it changed to `weak_ptr`.  Since the category wrapper is returning `shared_ptr` the dtor of the copy passed to the caller can cause the facebook::react::Instance to be deleted which invalidates the bridge and causes crashes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/250)