### PR TITLE
Autorelease pool growth fix

### DIFF
--- a/React/CxxBridge/RCTMessageThread.mm
+++ b/React/CxxBridge/RCTMessageThread.mm
@@ -36,9 +36,14 @@ RCTMessageThread::~RCTMessageThread() {
 
 // This is analogous to dispatch_async
 void RCTMessageThread::runAsync(std::function<void()> func) {
-  CFRunLoopPerformBlock(m_cfRunLoop, kCFRunLoopCommonModes, ^{ func(); });
-  CFRunLoopWakeUp(m_cfRunLoop);
-}
+  CFRunLoopPerformBlock(m_cfRunLoop, kCFRunLoopCommonModes, ^{
+    // Cherry picked from https://github.com/facebook/react-native/pull/27395/files to fix autorelease pool memory growth
+    // Create an autorelease pool each run loop to prevent memory footprint from growing too large, which can lead to performance problems.
+    @autoreleasepool {
+      func();
+    }
+    CFRunLoopWakeUp(m_cfRunLoop);
+  });
 
 // This is analogous to dispatch_sync
 void RCTMessageThread::runSync(std::function<void()> func) {

--- a/React/CxxBridge/RCTMessageThread.mm
+++ b/React/CxxBridge/RCTMessageThread.mm
@@ -36,14 +36,15 @@ RCTMessageThread::~RCTMessageThread() {
 
 // This is analogous to dispatch_async
 void RCTMessageThread::runAsync(std::function<void()> func) {
-  CFRunLoopPerformBlock(m_cfRunLoop, kCFRunLoopCommonModes, ^{
     // Cherry picked from https://github.com/facebook/react-native/pull/27395/files to fix autorelease pool memory growth
+  CFRunLoopPerformBlock(m_cfRunLoop, kCFRunLoopCommonModes, ^{
     // Create an autorelease pool each run loop to prevent memory footprint from growing too large, which can lead to performance problems.
     @autoreleasepool {
       func();
     }
-    CFRunLoopWakeUp(m_cfRunLoop);
   });
+  CFRunLoopWakeUp(m_cfRunLoop);
+}
 
 // This is analogous to dispatch_sync
 void RCTMessageThread::runSync(std::function<void()> func) {


### PR DESCRIPTION
To keep our memory footprint down, we can put each run loop cycle in its own autorelease pool.

#### Please select one of the following
- [X] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [X] I am making a fix / change for the macOS implementation of react-native

Facebook made this fix which we're cherry picking now because it seems pretty far off until we're on the version of RN that has this fix (0.62 RC). We put each run loop in its own autorelease pool so the footprint stays small.

https://github.com/facebook/react-native/pull/27395/files#diff-e2928a0e8ce82f1c15bb062c5a51a407

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/255)