### PR TITLE
Restore macOS <Image> and ActionSheetIOS.  Cherry pick multi windows UIScene support from upstream.

### DIFF
--- a/Libraries/Image/RCTImageView.m
+++ b/Libraries/Image/RCTImageView.m
@@ -162,9 +162,11 @@ static NSDictionary *onLoadParamsForSource(RCTImageSource *source)
                    name:UIApplicationDidEnterBackgroundNotification
                  object:nil];
     _imageView = [[UIImageView alloc] init];
+#else
+    _imageView = [[NSImageView alloc] init];
+#endif // TODO(macOS ISS#2323203)
     _imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self addSubview:_imageView];
-#endif // TODO(macOS ISS#2323203)
   }
   return self;
 }

--- a/Libraries/react-native/react-native-implementation.macos.js
+++ b/Libraries/react-native/react-native-implementation.macos.js
@@ -187,16 +187,14 @@ module.exports = {
   get VirtualizedList() {
     return require('VirtualizedList');
   },
-  /*
   get VirtualizedSectionList() {
     return require('VirtualizedSectionList');
-  },*/
+  },
 
   // APIs
-  /*
   get ActionSheetIOS() {
     return require('ActionSheetIOS');
-  },*/
+  },
   get Alert() {
     return require('Alert');
   },

--- a/React/Base/RCTUtils.m
+++ b/React/Base/RCTUtils.m
@@ -524,7 +524,12 @@ UIWindow *__nullable RCTKeyWindow(void)
   }
 
   // TODO: replace with a more robust solution
-  return RCTSharedApplication().keyWindow;
+  for (UIWindow *window in RCTSharedApplication().windows) {
+    if (window.keyWindow) {
+      return window;
+    }
+  }
+  return nil;
 }
 
 UIViewController *__nullable RCTPresentedViewController(void)
@@ -835,7 +840,7 @@ UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL)
 #if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
       image = [UIImage imageNamed:imageName inBundle:bundle compatibleWithTraitCollection:nil];
 #else // [TODO(macOS ISS#2323203)
-			image = [bundle imageForResource:imageName];
+      image = [bundle imageForResource:imageName];
 #endif // ]TODO(macOS ISS#2323203)
       if (image) {
         RCTLogWarn(@"Image %@ not found in mainBundle, but found in %@", imageName, bundle);

--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -873,6 +873,7 @@ RCT_EXPORT_METHOD(dismiss)
 #else // ]TODO(macOS ISS#2323203)
     dispatch_async(dispatch_get_main_queue(), ^{
         [self->_window dismiss];
+        self->_window = nil; // TODO(OSS Candidate ISS#2710739): release _window now to ensure its UIKit ivars are dealloc'd on the main thread as the RCTRedBox can be dealloc'd on a background thread.
     });
 #endif // TODO(macOS ISS#2323203)
 }

--- a/React/Modules/RCTRedBox.m
+++ b/React/Modules/RCTRedBox.m
@@ -29,7 +29,8 @@
 @end
 
 #if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
-@interface RCTRedBoxWindow : UIWindow <UITableViewDelegate, UITableViewDataSource>
+@interface RCTRedBoxWindow : NSObject <UITableViewDelegate, UITableViewDataSource>
+@property (nonatomic, strong) UIViewController *rootViewController;
 @property (nonatomic, weak) id<RCTRedBoxWindowActionDelegate> actionDelegate;
 @end
 
@@ -42,19 +43,11 @@
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
-    if ((self = [super initWithFrame:frame])) {
-#if TARGET_OS_TV
-        self.windowLevel = UIWindowLevelAlert + 1000;
-#else
-        self.windowLevel = UIWindowLevelStatusBar - 1;
-#endif
-        self.backgroundColor = [UIColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:1];
-        self.hidden = YES;
-
-        UIViewController *rootController = [UIViewController new];
-        self.rootViewController = rootController;
-        UIView *rootView = rootController.view;
-        rootView.backgroundColor = [UIColor clearColor];
+    if ((self = [super init])) {
+        _rootViewController = [UIViewController new];
+        UIView *rootView = _rootViewController.view;
+        rootView.frame = frame;
+        rootView.backgroundColor = [UIColor blackColor];
 
         const CGFloat buttonHeight = 60;
 
@@ -133,8 +126,8 @@
         [extraButton setTitleColor:[UIColor colorWithWhite:1 alpha:0.5] forState:UIControlStateHighlighted];
         [extraButton addTarget:self action:@selector(showExtraDataViewController) forControlEvents:UIControlEventTouchUpInside];
 
-        CGFloat buttonWidth = self.bounds.size.width / 4;
-        CGFloat bottomButtonHeight = self.bounds.size.height - buttonHeight - [self bottomSafeViewHeight];
+        CGFloat buttonWidth = frame.size.width / 4;
+        CGFloat bottomButtonHeight = frame.size.height - buttonHeight - [self bottomSafeViewHeight];
 
         dismissButton.frame = CGRectMake(0, bottomButtonHeight, buttonWidth, buttonHeight);
         reloadButton.frame = CGRectMake(buttonWidth, bottomButtonHeight, buttonWidth, buttonHeight);
@@ -152,7 +145,7 @@
 
         UIView *bottomSafeView = [UIView new];
         bottomSafeView.backgroundColor = [UIColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:1];
-        bottomSafeView.frame = CGRectMake(0, self.bounds.size.height - [self bottomSafeViewHeight], self.bounds.size.width, [self bottomSafeViewHeight]);
+        bottomSafeView.frame = CGRectMake(0, frame.size.height - [self bottomSafeViewHeight], frame.size.width, [self bottomSafeViewHeight]);
 
         [rootView addSubview:bottomSafeView];
     }
@@ -190,7 +183,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     NSString *messageWithoutAnsi = [self stripAnsi:message];
 
     // Show if this is a new message, or if we're updating the previous message
-    if ((self.hidden && !isUpdate) || (!self.hidden && isUpdate && [_lastErrorMessage isEqualToString:messageWithoutAnsi])) {
+    BOOL hidden = !self.rootViewController.isBeingPresented;
+    if ((hidden && !isUpdate) || (!hidden && isUpdate && [_lastErrorMessage isEqualToString:messageWithoutAnsi])) {
         _lastStackTrace = stack;
         // message is displayed using UILabel, which is unable to render text of
         // unlimited length, so we truncate it
@@ -198,22 +192,20 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 
         [_stackTraceTableView reloadData];
 
-        if (self.hidden) {
+        if (hidden) {
             [_stackTraceTableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]
                                         atScrollPosition:UITableViewScrollPositionTop
                                                 animated:NO];
+            [RCTKeyWindow().rootViewController presentViewController:self.rootViewController
+                                                            animated:YES
+                                                          completion:nil];
         }
-
-        [self makeKeyAndVisible];
-        [self becomeFirstResponder];
     }
 }
 
 - (void)dismiss
 {
-    self.hidden = YES;
-    [self resignFirstResponder];
-    [RCTSharedApplication().delegate.window makeKeyWindow];
+    [self.rootViewController dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)reload
@@ -554,13 +546,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
     if (!_visible) {
       _visible = YES;
       [_window center];
-			if (!RCTRunningInTestEnvironment()) {
-				[NSApp runModalForWindow:_window];
-			}
-			else {
-				[NSApp activateIgnoringOtherApps:YES];
-				[[NSApp mainWindow] makeKeyAndOrderFront:_window];
-			}
+      if (!RCTRunningInTestEnvironment()) {
+        [NSApp runModalForWindow:_window];
+      }
+      else {
+        [NSApp activateIgnoringOtherApps:YES];
+        [[NSApp mainWindow] makeKeyAndOrderFront:_window];
+      }
     }
   }
 }


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [x] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

Since the last merge from upstream to the fork two manual merge errors impacted macOS:
- In `RCTImageView.m` the macOS version of the `_imageView` ivar was not being initialized breaking `<Image>` components.
- In `react-native-implementation.macos.js` the `ActionSheetIOS` component was not being exposed.   Although named `ActionSheetIOS` in the fork it creates `NSMenu` popups for macOS and `UIAlertControllers` for iOS.

Since iOS 13 the `RCTKeyWindow()` function is broken in apps that use `UIScene`'s for multi window support.   It also breaks `RCTRedBox`.   If an app that uses `UIScene`'s (like Office apps) show an `RCTRedBox` error message, the red box window is invisible.   Then if a `ActionSheetIOS` presents a `UIAlertController` it is presented on the invisible Red Box windows making the action sheet or alert invisible.   Cherry pick the upstream fix https://github.com/facebook/react-native/pull/28147.   Future merges into this fork from upstream will get the more comprehensive `UIScene` support that started with https://github.com/facebook/react-native/pull/28058.

#### Focus areas to test

The Image test in RNTester was used to verify that <Image> components is restored.   UIScene support was tested by manually integrating this branch into Office.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/256)