### PR TITLE
Remove Forked Instance Management APIs

### DIFF
--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -596,7 +596,6 @@ struct RCTInstanceCallback : public InstanceCallback {
     // This is async, but any calls into JS are blocked by the m_syncReady CV in Instance
   _reactInstance->initializeBridge(
       std::make_unique<RCTInstanceCallback>(self),
-      nullptr,  // use default executor delegate // TODO(OSS Candidate ISS#2710739)
       executorFactory,
       _jsMessageThread,
       [self _buildModuleRegistryUnlocked]);

--- a/ReactAndroid/src/main/java/com/facebook/react/v8executor/InstanceManager.cpp
+++ b/ReactAndroid/src/main/java/com/facebook/react/v8executor/InstanceManager.cpp
@@ -55,7 +55,6 @@ std::shared_ptr<Instance> CreateReactInstance(
 
 	// Initialize bridge.
 	instance->initializeBridge(std::make_unique<DefaultInstanceCallback>(),
-		nullptr,
 		std::move(jsExecutorFactory),
 		std::move(jsQueue),
 		std::move(moduleRegistry));

--- a/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
+++ b/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
@@ -165,7 +165,6 @@ void CatalystInstanceImpl::initializeBridge(
     std::make_unique<JInstanceCallback>(
     callback,
     moduleMessageQueue_),
-    nullptr, // Use default executor delegate
     jseh->getExecutorFactory(),
     folly::make_unique<JMessageQueueThread>(jsQueue),
     moduleRegistry_);

--- a/ReactCommon/cxxreact/Instance.cpp
+++ b/ReactCommon/cxxreact/Instance.cpp
@@ -43,21 +43,14 @@ void Instance::setModuleRegistry(
 
 void Instance::initializeBridge(
     std::unique_ptr<InstanceCallback> callback,
-    std::shared_ptr<ExecutorDelegateFactory> edf,
     std::shared_ptr<JSExecutorFactory> jsef,
     std::shared_ptr<MessageQueueThread> jsQueue,
     std::shared_ptr<ModuleRegistry> moduleRegistry) {
   callback_ = std::move(callback);
   moduleRegistry_ = std::move(moduleRegistry);
-  
-  std::shared_ptr<ExecutorDelegate> delegate;
-  if (edf) {
-    delegate = edf->createExecutorDelegate(moduleRegistry_, callback_);
-  }
-
-  jsQueue->runOnQueueSync([this, delegate, &jsef, jsQueue]() mutable {
+  jsQueue->runOnQueueSync([this, &jsef, jsQueue]() mutable {
     nativeToJsBridge_ = folly::make_unique<NativeToJsBridge>(
-        jsef.get(), delegate, moduleRegistry_, jsQueue, callback_);
+        jsef.get(), moduleRegistry_, jsQueue, callback_);
 
     std::lock_guard<std::mutex> lock(m_syncMutex);
     m_syncReady = true;
@@ -196,10 +189,6 @@ void Instance::callJSCallback(uint64_t callbackId, folly::dynamic &&params) {
   nativeToJsBridge_->invokeCallback((double)callbackId, std::move(params));
 }
 
-void Instance::setJSEConfigParams(std::shared_ptr<JSEConfigParams>&& jseConfigParams) {
-  jseConfigParams_ = std::move(jseConfigParams);
-}
-
 void Instance::registerBundle(uint32_t bundleId, const std::string& bundlePath) {
   nativeToJsBridge_->registerBundle(bundleId, bundlePath);
 }
@@ -212,10 +201,6 @@ ModuleRegistry &Instance::getModuleRegistry() { return *moduleRegistry_; }
 
 void Instance::handleMemoryPressure(int pressureLevel) {
   nativeToJsBridge_->handleMemoryPressure(pressureLevel);
-}
-
-int64_t Instance::getPeakJsMemoryUsage() const noexcept {
-  return nativeToJsBridge_->getPeakJsMemoryUsage();
 }
 
 void Instance::invokeAsync(std::function<void()>&& func) {

--- a/ReactCommon/cxxreact/Instance.h
+++ b/ReactCommon/cxxreact/Instance.h
@@ -34,28 +34,13 @@ struct InstanceCallback {
   virtual void decrementPendingJSCalls() {}
 };
 
-enum class CachingType {
-  NoCaching,
-  PartialCaching,
-  PartialCachingWithNoLazy,
-  FullCaching,
-  FullCachingWithNoLazy
-};
-
-struct JSEConfigParams {
-  std::string cachePath;
-  CachingType cacheType;
-  int loggingLevel;
-};
-
 class RN_EXPORT Instance {
 public:
-  virtual ~Instance();
+  ~Instance();
 
   void setModuleRegistry(std::shared_ptr<ModuleRegistry> moduleRegistry);
 
   void initializeBridge(std::unique_ptr<InstanceCallback> callback,
-                        std::shared_ptr<ExecutorDelegateFactory> edf, // if nullptr, will use default delegate (JsToNativeBridge) // TODO(OSS Candidate ISS#2710739)
                         std::shared_ptr<JSExecutorFactory> jsef,
                         std::shared_ptr<MessageQueueThread> jsQueue,
                         std::shared_ptr<ModuleRegistry> moduleRegistry);
@@ -82,7 +67,6 @@ public:
   void callJSFunction(std::string &&module, std::string &&method,
                       folly::dynamic &&params);
   void callJSCallback(uint64_t callbackId, folly::dynamic &&params);
-  virtual void setJSEConfigParams(std::shared_ptr<JSEConfigParams>&& jseConfigParams);
 
   // This method is experimental, and may be modified or removed.
   void registerBundle(uint32_t bundleId, const std::string& bundlePath);
@@ -91,13 +75,6 @@ public:
   ModuleRegistry &getModuleRegistry();
 
   void handleMemoryPressure(int pressureLevel);
-
-   /**
-   * Returns the current peak memory usage due to the JavaScript
-   * execution environment in bytes. If the JavaScript execution
-   * environment does not track this information, return -1.
-   */
-  int64_t getPeakJsMemoryUsage() const noexcept;
 
   void invokeAsync(std::function<void()>&& func);
 
@@ -113,7 +90,6 @@ private:
   std::shared_ptr<InstanceCallback> callback_;
   std::unique_ptr<NativeToJsBridge> nativeToJsBridge_;
   std::shared_ptr<ModuleRegistry> moduleRegistry_;
-  std::shared_ptr<JSEConfigParams> jseConfigParams_;
 
   std::mutex m_syncMutex;
   std::condition_variable m_syncCV;

--- a/ReactCommon/cxxreact/JSBigString.cpp
+++ b/ReactCommon/cxxreact/JSBigString.cpp
@@ -24,7 +24,7 @@ JSBigFileString::JSBigFileString(int fd, size_t size, off_t offset /*= 0*/)
   folly::checkUnixError(m_fd = dup(fd),
     "Could not duplicate file descriptor");
 
-  // Offsets given to mmap must be page aligend. We abstract away that
+  // Offsets given to mmap must be page aligned. We abstract away that
   // restriction by sending a page aligned offset to mmap, and keeping track
   // of the offset within the page that we must alter the mmap pointer by to
   // get the final desired offset.

--- a/ReactCommon/cxxreact/JSExecutor.h
+++ b/ReactCommon/cxxreact/JSExecutor.h
@@ -20,21 +20,11 @@ namespace facebook {
 namespace react {
 
 class JSBigString;
-class ExecutorDelegate;
 class JSExecutor;
 class JSModulesUnbundle;
 class MessageQueueThread;
 class ModuleRegistry;
 class RAMBundleRegistry;
-struct InstanceCallback;
-
-class ExecutorDelegateFactory {
-public:
-  virtual std::unique_ptr<ExecutorDelegate> createExecutorDelegate(
-    std::shared_ptr<ModuleRegistry> registry,
-    std::shared_ptr<InstanceCallback> callback) = 0;
-  virtual ~ExecutorDelegateFactory() {}
-};
 
 // This interface describes the delegate interface required by
 // Executor implementations to call from JS into native code.
@@ -117,15 +107,6 @@ public:
   virtual std::string getDescription() = 0;
 
   virtual void handleMemoryPressure(__unused int pressureLevel) {}
-
-  /**
-   * Returns the current peak memory usage due to the JavaScript
-   * execution environment in bytes. If the JavaScript execution
-   * environment does not track this information, return -1.
-   */
-  virtual int64_t getPeakJsMemoryUsage() const noexcept { // ISS
-    return -1;
-  }
 
   virtual void destroy() {}
   virtual ~JSExecutor() {}

--- a/ReactCommon/cxxreact/ModuleRegistry.h
+++ b/ReactCommon/cxxreact/ModuleRegistry.h
@@ -42,12 +42,6 @@ class RN_EXPORT ModuleRegistry {
   ModuleRegistry(std::vector<std::unique_ptr<NativeModule>> modules, ModuleNotFoundCallback callback = nullptr);
   void registerModules(std::vector<std::unique_ptr<NativeModule>> modules);
 
-  // Remove this after Task #1895397 completed.
-  size_t GetModuleSize()
-  {
-    return modules_.size();
-  }
-
   std::vector<std::string> moduleNames();
 
   folly::Optional<ModuleConfig> getConfig(const std::string& name);

--- a/ReactCommon/cxxreact/NativeToJsBridge.cpp
+++ b/ReactCommon/cxxreact/NativeToJsBridge.cpp
@@ -58,7 +58,7 @@ public:
     if (isEndOfBatch) {
       // onBatchComplete will be called on the native (module) queue, but
       // decrementPendingJSCalls will be called sync. Be aware that the bridge may still
-      // be processing native calls when the birdge idle signaler fires.
+      // be processing native calls when the bridge idle signaler fires.
       if (m_batchHadNativeModuleCalls) {
         m_callback->onBatchComplete();
         m_batchHadNativeModuleCalls = false;
@@ -85,12 +85,11 @@ private:
 
 NativeToJsBridge::NativeToJsBridge(
     JSExecutorFactory *jsExecutorFactory,
-    std::shared_ptr<ExecutorDelegate> delegate, // TODO(OSS Candidate ISS#2710739)
     std::shared_ptr<ModuleRegistry> registry,
     std::shared_ptr<MessageQueueThread> jsQueue,
     std::shared_ptr<InstanceCallback> callback)
     : m_destroyed(std::make_shared<bool>(false)),
-      m_delegate(delegate ? delegate : (std::make_shared<JsToNativeBridge>(registry, callback))),
+      m_delegate(std::make_shared<JsToNativeBridge>(registry, callback)),
       m_executor(jsExecutorFactory->createJSExecutor(m_delegate, jsQueue)),
       m_executorMessageQueueThread(std::move(jsQueue)),
       m_inspectable(m_executor->isInspectable()) {}
@@ -238,10 +237,6 @@ void NativeToJsBridge::handleMemoryPressure(int pressureLevel) {
   runOnExecutorQueue([=] (JSExecutor* executor) {
     executor->handleMemoryPressure(pressureLevel);
   });
-}
-
-int64_t NativeToJsBridge::getPeakJsMemoryUsage() const noexcept {
-  return m_executor->getPeakJsMemoryUsage();
 }
 
 void NativeToJsBridge::destroy() {

--- a/ReactCommon/cxxreact/NativeToJsBridge.h
+++ b/ReactCommon/cxxreact/NativeToJsBridge.h
@@ -40,11 +40,10 @@ public:
    * This must be called on the main JS thread.
    */
   NativeToJsBridge(
-    JSExecutorFactory* jsExecutorFactory,
-    std::shared_ptr<ExecutorDelegate> delegate, // TODO(OSS Candidate ISS#2710739)
-    std::shared_ptr<ModuleRegistry> registry,
-    std::shared_ptr<MessageQueueThread> jsQueue,
-    std::shared_ptr<InstanceCallback> callback);
+      JSExecutorFactory* jsExecutorFactory,
+      std::shared_ptr<ModuleRegistry> registry,
+      std::shared_ptr<MessageQueueThread> jsQueue,
+      std::shared_ptr<InstanceCallback> callback);
   virtual ~NativeToJsBridge();
 
   /**
@@ -81,13 +80,6 @@ public:
   void handleMemoryPressure(int pressureLevel);
 
   /**
-   * Returns the current peak memory usage due to m_executor's JavaScript
-   * execution environment in bytes. If m_executor does not track this
-   * information, return -1.
-   */
-  int64_t getPeakJsMemoryUsage() const noexcept;
-
-  /**
    * Synchronously tears down the bridge and the main executor.
    */
   void destroy();
@@ -100,7 +92,7 @@ private:
   // will try to run the task on m_callback which will have been destroyed
   // within ~NativeToJsBridge(), thus causing a SIGSEGV.
   std::shared_ptr<bool> m_destroyed;
-  std::shared_ptr<react::ExecutorDelegate> m_delegate; // TODO(OSS Candidate ISS#2710739)
+  std::shared_ptr<JsToNativeBridge> m_delegate;
   std::unique_ptr<JSExecutor> m_executor;
   std::shared_ptr<MessageQueueThread> m_executorMessageQueueThread;
 
@@ -115,7 +107,7 @@ private:
   bool m_applicationScriptHasFailure = false;
 
   #ifdef WITH_FBSYSTRACE
-  std::atomic_uint_least32_t m_systraceCookie{};
+  std::atomic_uint_least32_t m_systraceCookie = ATOMIC_VAR_INIT();
   #endif
 };
 


### PR DESCRIPTION
Some research for React Native Windows gave us context on instance management APIs we can remove across the board. Replicate some of what we did in React Native Windows for microsoft/react-native

- `getPeakJsMemoryUsage()` on Instance (not MemoryTracker) was being used for telemtry in devmain and no longer is.
- `ExecutorDelegateFactory` existed for a legacy Win32 specific architecture for sandboxing executors
- `JSEConfigParams` is no longer used anywhere. I think it may have been for a removed V8 executor?
- `GetModuleSize()` is documented as removable, was part of that sandboxing effort, and is not called anywhere
- Removed some diffs around fixing or not fixing typos
- Keep stock `ATOMIC_VAR_INIT()` with no param, which was apparently not an issue on Clang
- Instance APIs used to be virtual so we could mock them on Win32. We should be able to remove the instance virtual destructor if nothing else is virtual and tests still pass.

#### Please select one of the following
- [x] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/facebook/react-native/wiki/Changelog for an example. -->

[General] [Removed] - Removed Instance Management Diffs


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/257)