### PR TITLE
Do not override `accessibilityRole` on `NSView` for macOS.

### DIFF
--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -335,6 +335,7 @@
   objc_setAssociatedObject(self, @selector(accessibilityActions), accessibilityActions, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+#if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
 - (NSString *)accessibilityRole
 {
   return objc_getAssociatedObject(self, _cmd);
@@ -344,6 +345,7 @@
 {
   objc_setAssociatedObject(self, @selector(accessibilityRole), accessibilityRole, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
+#endif // TODO(macOS ISS#2323203)
 
 - (NSArray<NSString *> *)accessibilityStates
 {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

The `UIView+React` category is overriding the properties `accessibilityRole`, `accessibilityStates`, and `accessibilityActions`.   Despite the naming, these properties are not UIKit or `UIAccessibility` properties, but are react-native specific properties.   In the react-native-macos fork, this same category is applying to `NSView`.   On macOS, `accessibilityRole` *is* an `NSAccessibility` property.   Overriding it breaks macOS accessibility scenarios.   In particular it breaks some Automated tests in Office because `NSToolbarView` and `NSToolbarViewItems` loose their accessibilityRoles making them not reachable by XCUITest queries.

This fix puts `#if !TARGET_OS_OSX` conditions around the `accessibilityRole` overrides.   

Long term the upstream code should either stop overriding these properties in a category, or rename them to something like `reactAccessibilityRole`, or both.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/258)