### PR TITLE
Remove a stale ref to a deprecated file (UIWebView)

### DIFF
--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -2899,7 +2899,6 @@
 		18B8F97C21431D5F00CE911A /* RCTPlatformDisplayLink.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPlatformDisplayLink.m; sourceTree = "<group>"; };
 		18C2C6662141C86E004314E0 /* JSException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSException.h; sourceTree = "<group>"; };
 		18C2C6702141C955004314E0 /* RCTPlatformDisplayLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTPlatformDisplayLink.h; sourceTree = "<group>"; };
-		18F3BA0E2142F4DB00AD247D /* RCTWebView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTWebView.m; sourceTree = "<group>"; };
 		191E3EBC1C29D9AF00C180A6 /* RCTRefreshControlManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRefreshControlManager.h; sourceTree = "<group>"; };
 		191E3EBD1C29D9AF00C180A6 /* RCTRefreshControlManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRefreshControlManager.m; sourceTree = "<group>"; };
 		191E3EBF1C29DC3800C180A6 /* RCTRefreshControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRefreshControl.h; sourceTree = "<group>"; };
@@ -3951,7 +3950,6 @@
 				6B857F421EC51FCF00A9D063 /* libcxxreact.a */,
 				1882027C1EF48B7E00C9B354 /* libdouble-conversion.a */,
 				188202A21EF48CF700C9B354 /* libthird-party.a */,
-				18F3BA0E2142F4DB00AD247D /* RCTWebView.m */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -296,8 +296,8 @@
 		1854FF5C1EF485C60008DADC /* SystraceSection.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D92B0D51E03699D0018521A /* SystraceSection.h */; };
 		1854FF621EF487C00008DADC /* (null) in Headers */ = {isa = PBXBuildFile; };
 		18572B9F1EF32003007EAD54 /* RCTUIKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BF8B4B21EC550F500061E2F /* RCTUIKit.h */; };
-        18632C021EF495D40010A3BB /* libcxxreact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B857F421EC51FCF00A9D063 /* libcxxreact.a */; };
-        18632C051EF495D40010A3BB /* libthird-party.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 188202A21EF48CF700C9B354 /* libthird-party.a */; };
+		18632C021EF495D40010A3BB /* libcxxreact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B857F421EC51FCF00A9D063 /* libcxxreact.a */; };
+		18632C051EF495D40010A3BB /* libthird-party.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 188202A21EF48CF700C9B354 /* libthird-party.a */; };
 		18632C1A1EF49C9D0010A3BB /* CxxModule.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 3D92B0A71E03699D0018521A /* CxxModule.h */; };
 		18632C1B1EF49C9D0010A3BB /* CxxNativeModule.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 3D92B0A91E03699D0018521A /* CxxNativeModule.h */; };
 		18632C1C1EF49C9D0010A3BB /* JSExecutor.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 3D92B0AB1E03699D0018521A /* JSExecutor.h */; };
@@ -1618,7 +1618,7 @@
 		9FB7D34C224954A600F31D11 /* libjsinspector-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F2AC95E2239D788005C9C14 /* libjsinspector-macOS.a */; };
 		9FB7D34D224954B300F31D11 /* libjsi-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FD21D78224303D900E7F88E /* libjsi-macOS.a */; };
 		9FB7D34E224954CC00F31D11 /* libjsiexecutor-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FD21D94224305AA00E7F88E /* libjsiexecutor-macOS.a */; };
-        9FB7D34F224954EE00F31D11 /* libdouble-conversion.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1882027C1EF48B7E00C9B354 /* libdouble-conversion.a */; };
+		9FB7D34F224954EE00F31D11 /* libdouble-conversion.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1882027C1EF48B7E00C9B354 /* libdouble-conversion.a */; };
 		9FB7D3EB224ABDA400F31D11 /* RCTDatePicker.m in Sources */ = {isa = PBXBuildFile; fileRef = 133CAE8D1B8E5CFD00F6AD92 /* RCTDatePicker.m */; };
 		9FD21D65224303D900E7F88E /* jsi.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEBC6E1214B3F6800DD5AC8 /* jsi.h */; };
 		9FD21D66224303D900E7F88E /* JSCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEBC6DE214B3F6800DD5AC8 /* JSCRuntime.h */; };
@@ -3185,11 +3185,11 @@
 			files = (
 				9F5C1991230F4F0400E3E5A7 /* libyoga.a in Frameworks */,
 				9FB7D34C224954A600F31D11 /* libjsinspector-macOS.a in Frameworks */,
-                18632C021EF495D40010A3BB /* libcxxreact.a in Frameworks */,
-                9FB7D34D224954B300F31D11 /* libjsi-macOS.a in Frameworks */,
-                9FB7D34E224954CC00F31D11 /* libjsiexecutor-macOS.a in Frameworks */,
-                9FB7D34F224954EE00F31D11 /* libdouble-conversion.a in Frameworks */,
-                18632C051EF495D40010A3BB /* libthird-party.a in Frameworks */,
+				18632C021EF495D40010A3BB /* libcxxreact.a in Frameworks */,
+				9FB7D34D224954B300F31D11 /* libjsi-macOS.a in Frameworks */,
+				9FB7D34E224954CC00F31D11 /* libjsiexecutor-macOS.a in Frameworks */,
+				9FB7D34F224954EE00F31D11 /* libdouble-conversion.a in Frameworks */,
+				18632C051EF495D40010A3BB /* libthird-party.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3944,9 +3944,9 @@
 		9F2AC95C2239D788005C9C14 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
-              6B857F421EC51FCF00A9D063 /* libcxxreact.a */,
-              1882027C1EF48B7E00C9B354 /* libdouble-conversion.a */,
-              188202A21EF48CF700C9B354 /* libthird-party.a */,
+				6B857F421EC51FCF00A9D063 /* libcxxreact.a */,
+				1882027C1EF48B7E00C9B354 /* libdouble-conversion.a */,
+				188202A21EF48CF700C9B354 /* libthird-party.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -296,6 +296,8 @@
 		1854FF5C1EF485C60008DADC /* SystraceSection.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D92B0D51E03699D0018521A /* SystraceSection.h */; };
 		1854FF621EF487C00008DADC /* (null) in Headers */ = {isa = PBXBuildFile; };
 		18572B9F1EF32003007EAD54 /* RCTUIKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BF8B4B21EC550F500061E2F /* RCTUIKit.h */; };
+        18632C021EF495D40010A3BB /* libcxxreact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B857F421EC51FCF00A9D063 /* libcxxreact.a */; };
+        18632C051EF495D40010A3BB /* libthird-party.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 188202A21EF48CF700C9B354 /* libthird-party.a */; };
 		18632C1A1EF49C9D0010A3BB /* CxxModule.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 3D92B0A71E03699D0018521A /* CxxModule.h */; };
 		18632C1B1EF49C9D0010A3BB /* CxxNativeModule.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 3D92B0A91E03699D0018521A /* CxxNativeModule.h */; };
 		18632C1C1EF49C9D0010A3BB /* JSExecutor.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 3D92B0AB1E03699D0018521A /* JSExecutor.h */; };
@@ -1616,6 +1618,7 @@
 		9FB7D34C224954A600F31D11 /* libjsinspector-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F2AC95E2239D788005C9C14 /* libjsinspector-macOS.a */; };
 		9FB7D34D224954B300F31D11 /* libjsi-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FD21D78224303D900E7F88E /* libjsi-macOS.a */; };
 		9FB7D34E224954CC00F31D11 /* libjsiexecutor-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FD21D94224305AA00E7F88E /* libjsiexecutor-macOS.a */; };
+        9FB7D34F224954EE00F31D11 /* libdouble-conversion.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1882027C1EF48B7E00C9B354 /* libdouble-conversion.a */; };
 		9FB7D3EB224ABDA400F31D11 /* RCTDatePicker.m in Sources */ = {isa = PBXBuildFile; fileRef = 133CAE8D1B8E5CFD00F6AD92 /* RCTDatePicker.m */; };
 		9FD21D65224303D900E7F88E /* jsi.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEBC6E1214B3F6800DD5AC8 /* jsi.h */; };
 		9FD21D66224303D900E7F88E /* JSCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEBC6DE214B3F6800DD5AC8 /* JSCRuntime.h */; };
@@ -3182,8 +3185,11 @@
 			files = (
 				9F5C1991230F4F0400E3E5A7 /* libyoga.a in Frameworks */,
 				9FB7D34C224954A600F31D11 /* libjsinspector-macOS.a in Frameworks */,
-				9FB7D34D224954B300F31D11 /* libjsi-macOS.a in Frameworks */,
-				9FB7D34E224954CC00F31D11 /* libjsiexecutor-macOS.a in Frameworks */,
+                18632C021EF495D40010A3BB /* libcxxreact.a in Frameworks */,
+                9FB7D34D224954B300F31D11 /* libjsi-macOS.a in Frameworks */,
+                9FB7D34E224954CC00F31D11 /* libjsiexecutor-macOS.a in Frameworks */,
+                9FB7D34F224954EE00F31D11 /* libdouble-conversion.a in Frameworks */,
+                18632C051EF495D40010A3BB /* libthird-party.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3938,6 +3944,9 @@
 		9F2AC95C2239D788005C9C14 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
+              6B857F421EC51FCF00A9D063 /* libcxxreact.a */,
+              1882027C1EF48B7E00C9B354 /* libdouble-conversion.a */,
+              188202A21EF48CF700C9B354 /* libthird-party.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";

--- a/React/React.xcodeproj/project.pbxproj
+++ b/React/React.xcodeproj/project.pbxproj
@@ -296,8 +296,6 @@
 		1854FF5C1EF485C60008DADC /* SystraceSection.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D92B0D51E03699D0018521A /* SystraceSection.h */; };
 		1854FF621EF487C00008DADC /* (null) in Headers */ = {isa = PBXBuildFile; };
 		18572B9F1EF32003007EAD54 /* RCTUIKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BF8B4B21EC550F500061E2F /* RCTUIKit.h */; };
-		18632C021EF495D40010A3BB /* libcxxreact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B857F421EC51FCF00A9D063 /* libcxxreact.a */; };
-		18632C051EF495D40010A3BB /* libthird-party.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 188202A21EF48CF700C9B354 /* libthird-party.a */; };
 		18632C1A1EF49C9D0010A3BB /* CxxModule.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 3D92B0A71E03699D0018521A /* CxxModule.h */; };
 		18632C1B1EF49C9D0010A3BB /* CxxNativeModule.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 3D92B0A91E03699D0018521A /* CxxNativeModule.h */; };
 		18632C1C1EF49C9D0010A3BB /* JSExecutor.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 3D92B0AB1E03699D0018521A /* JSExecutor.h */; };
@@ -587,7 +585,6 @@
 		18B8F97E21431D6900CE911A /* RCTPlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B7049C81EDF81E3005670F5 /* RCTPlatform.m */; };
 		18B8F97F21431D6F00CE911A /* RCTUIKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BDE7A171ECA38AC00CC951F /* RCTUIKit.m */; };
 		18B8F9CA214335C800CE911A /* RCTLayout.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 591F78D9202ADB22004A668C /* RCTLayout.h */; };
-		18C2C6682141C86E004314E0 /* JSException.h in Headers */ = {isa = PBXBuildFile; fileRef = 18C2C6662141C86E004314E0 /* JSException.h */; };
 		18C2C6712141C955004314E0 /* RCTPlatformDisplayLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 18C2C6702141C955004314E0 /* RCTPlatformDisplayLink.h */; };
 		18C2C6722141C955004314E0 /* RCTPlatformDisplayLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 18C2C6702141C955004314E0 /* RCTPlatformDisplayLink.h */; };
 		18C2C6732141C955004314E0 /* RCTPlatformDisplayLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 18C2C6702141C955004314E0 /* RCTPlatformDisplayLink.h */; };
@@ -1619,7 +1616,6 @@
 		9FB7D34C224954A600F31D11 /* libjsinspector-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F2AC95E2239D788005C9C14 /* libjsinspector-macOS.a */; };
 		9FB7D34D224954B300F31D11 /* libjsi-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FD21D78224303D900E7F88E /* libjsi-macOS.a */; };
 		9FB7D34E224954CC00F31D11 /* libjsiexecutor-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FD21D94224305AA00E7F88E /* libjsiexecutor-macOS.a */; };
-		9FB7D34F224954EE00F31D11 /* libdouble-conversion.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1882027C1EF48B7E00C9B354 /* libdouble-conversion.a */; };
 		9FB7D3EB224ABDA400F31D11 /* RCTDatePicker.m in Sources */ = {isa = PBXBuildFile; fileRef = 133CAE8D1B8E5CFD00F6AD92 /* RCTDatePicker.m */; };
 		9FD21D65224303D900E7F88E /* jsi.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEBC6E1214B3F6800DD5AC8 /* jsi.h */; };
 		9FD21D66224303D900E7F88E /* JSCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = EDEBC6DE214B3F6800DD5AC8 /* JSCRuntime.h */; };
@@ -2897,7 +2893,6 @@
 		1893C5051FB0D9A300D66838 /* RCTBridge+Cxx.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTBridge+Cxx.h"; sourceTree = "<group>"; };
 		1893C5061FB0D9A300D66838 /* RCTBridge+Cxx.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "RCTBridge+Cxx.mm"; sourceTree = "<group>"; };
 		18B8F97C21431D5F00CE911A /* RCTPlatformDisplayLink.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTPlatformDisplayLink.m; sourceTree = "<group>"; };
-		18C2C6662141C86E004314E0 /* JSException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSException.h; sourceTree = "<group>"; };
 		18C2C6702141C955004314E0 /* RCTPlatformDisplayLink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTPlatformDisplayLink.h; sourceTree = "<group>"; };
 		191E3EBC1C29D9AF00C180A6 /* RCTRefreshControlManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTRefreshControlManager.h; sourceTree = "<group>"; };
 		191E3EBD1C29D9AF00C180A6 /* RCTRefreshControlManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTRefreshControlManager.m; sourceTree = "<group>"; };
@@ -3187,11 +3182,8 @@
 			files = (
 				9F5C1991230F4F0400E3E5A7 /* libyoga.a in Frameworks */,
 				9FB7D34C224954A600F31D11 /* libjsinspector-macOS.a in Frameworks */,
-				18632C021EF495D40010A3BB /* libcxxreact.a in Frameworks */,
 				9FB7D34D224954B300F31D11 /* libjsi-macOS.a in Frameworks */,
 				9FB7D34E224954CC00F31D11 /* libjsiexecutor-macOS.a in Frameworks */,
-				9FB7D34F224954EE00F31D11 /* libdouble-conversion.a in Frameworks */,
-				18632C051EF495D40010A3BB /* libthird-party.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3946,10 +3938,6 @@
 		9F2AC95C2239D788005C9C14 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
-				18C2C6662141C86E004314E0 /* JSException.h */,
-				6B857F421EC51FCF00A9D063 /* libcxxreact.a */,
-				1882027C1EF48B7E00C9B354 /* libdouble-conversion.a */,
-				188202A21EF48CF700C9B354 /* libthird-party.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -4191,7 +4179,6 @@
 				1854FE2C1EF484130008DADC /* RCTDefines.h in Headers */,
 				1854FE2A1EF484130008DADC /* RCTConvert.h in Headers */,
 				1854FF111EF484760008DADC /* (null) in Headers */,
-				18C2C6682141C86E004314E0 /* JSException.h in Headers */,
 				1854FF1B1EF484760008DADC /* UIView+React.h in Headers */,
 				1854FE2F1EF484130008DADC /* RCTErrorCustomizer.h in Headers */,
 				1854FE741EF484300008DADC /* RCTCxxModule.h in Headers */,


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [X ] I am making a change required for Microsoft usage of react-native

Apple has a hard deadline of Dec 2020 for all apps to ship without UIWebview. It's been deprecated for a while now, but in our December 2019 release, Apple warned us against using it.

Although we aren't using it, I found a stale ref to a file that doesn't exist in the pbxproj which matches the file in the libReact.a in our internal builds.

Anyone building with pods (read: >=0.61) won't have this problem.

#### Focus areas to test
I printed the contents of libReact.a and it doesn't contain UIWebView.
(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/259)