### PR TITLE
MacOS mouse events show up at wrong locations

### DIFF
--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -157,9 +157,9 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions:(NSDictionary *)options
     view = [self.bridge.uiManager viewForReactTag:anchorViewTag];
     event = [view.window currentEvent];
   }
-  NSView *superView = [view superview];
+  NSView *superview = [view superview];
   if (event && view) {
-    // On a MacOS trackpad, soft taps are received as sysDefined event types. SysDefined event locations are relative to the screen so we have to convert those separately.
+    // On a macOS trackpad, soft taps are received as sysDefined event types. SysDefined event locations are relative to the screen so we have to convert those separately.
     NSPoint eventLocationRelativeToWindow = NSZeroPoint;
     CGPoint eventLocationInWindow = [event locationInWindow];
     if ([event type] == NSEventTypeSystemDefined) { // light tap event relative to screen
@@ -169,13 +169,13 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions:(NSDictionary *)options
     }
     origin = [view convertPoint:eventLocationRelativeToWindow fromView:nil];
   } else if (view) {
-    CGRect superviewFrame = [superView frame];
+    CGRect superviewFrame = [superview frame];
     origin = NSMakePoint(NSMidX(superviewFrame), NSMidY(superviewFrame));
   } else {
     origin = [NSEvent mouseLocation];
   }
   
-  [menu popUpMenuPositioningItem:menu.itemArray.firstObject atLocation:origin inView:superView];
+  [menu popUpMenuPositioningItem:menu.itemArray.firstObject atLocation:origin inView:superview];
 #endif // ]TODO(macOS ISS#2323203)
 }
 

--- a/Libraries/ActionSheetIOS/RCTActionSheetManager.m
+++ b/Libraries/ActionSheetIOS/RCTActionSheetManager.m
@@ -157,22 +157,25 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions:(NSDictionary *)options
     view = [self.bridge.uiManager viewForReactTag:anchorViewTag];
     event = [view.window currentEvent];
   }
+  NSView *superView = [view superview];
   if (event && view) {
     // On a MacOS trackpad, soft taps are received as sysDefined event types. SysDefined event locations are relative to the screen so we have to convert those separately.
     NSPoint eventLocationRelativeToWindow = NSZeroPoint;
+    CGPoint eventLocationInWindow = [event locationInWindow];
     if ([event type] == NSEventTypeSystemDefined) { // light tap event relative to screen
-      eventLocationRelativeToWindow = [[view window] convertRectFromScreen:NSMakeRect(event.locationInWindow.x, event.locationInWindow.y, 0, 0)].origin;
+      eventLocationRelativeToWindow = [[view window] convertRectFromScreen:NSMakeRect(eventLocationInWindow.x, eventLocationInWindow.y, 0, 0)].origin;
     } else { // full click events are relative to the window
-      eventLocationRelativeToWindow = [event locationInWindow];
+      eventLocationRelativeToWindow = eventLocationInWindow;
     }
     origin = [view convertPoint:eventLocationRelativeToWindow fromView:nil];
-  } else if (event) {
-    origin = event.locationInWindow; // NSMakePoint(NSMidX(view.superview.frame), NSMidY(view.superview.frame));
+  } else if (view) {
+    CGRect superviewFrame = [superView frame];
+    origin = NSMakePoint(NSMidX(superviewFrame), NSMidY(superviewFrame));
   } else {
     origin = [NSEvent mouseLocation];
   }
   
-  [menu popUpMenuPositioningItem:menu.itemArray.firstObject atLocation:origin inView:[view superview]];
+  [menu popUpMenuPositioningItem:menu.itemArray.firstObject atLocation:origin inView:superView];
 #endif // ]TODO(macOS ISS#2323203)
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [X ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

There's a bug where mac os events are received with locations relative to either the screen or the window. Different click styles (light trackpad tap vs. harder trackpad click) appear to dictate which event type we have and thus, which coordinate system we're receiving events in. Right now we were treating every click as if the event location is relative to the window, but we receive some click events relative to the screen. We need to handle those and convert them properly to the right coordinate system.

There's an unknown of _why_ these aren't just MouseDown/MouseUp events. It's possible React Native is gobbling up the OS events somewhere and giving these back, but a search of the repo found no obvious NSEventType manipulation. This did reveal a tangential bug in RNTester where every other mouse down event is throwing an RCTAssert on MacOS which eats up that event. I'm looking into that bug next.

#### Focus areas to test

- Soft tap the CommandButton in a downstream app (Polyester) to test dropping a menu at the correct location
- Click the CommandButton in a downstream app (Polyester) to test dropping a menu at the correct location
- Tweak the RNTester code so our ActionSheetExample on MacOS passes in an anchor ref we can trigger events off of. From there, soft tap and click a button and verify the menu drops in the correct location

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/260)