### PR TITLE
Provide an anchor to our ActionSheetMacOS test

### DIFF
--- a/RNTester/js/ActionSheetMacOSExample.js
+++ b/RNTester/js/ActionSheetMacOSExample.js
@@ -15,6 +15,7 @@ var {
   StyleSheet,
   Text,
   View,
+  findNodeHandle,
 } = ReactNative;
 
 var BUTTONS = [
@@ -32,10 +33,12 @@ class ActionSheetExample extends React.Component<{}, $FlowFixMeState> {
     clicked: 'none',
   };
 
+  anchorRef = React.createRef();
+
   render() {
     return (
       <View>
-        <Text onPress={this.showActionSheet} style={style.button}>
+        <Text onPress={this.showActionSheet} style={style.button} ref={this.anchorRef}>
           Click to show the ActionSheet
         </Text>
         <Text>
@@ -49,6 +52,9 @@ class ActionSheetExample extends React.Component<{}, $FlowFixMeState> {
     ActionSheetIOS.showActionSheetWithOptions({
       options: BUTTONS,
       cancelButtonIndex: CANCEL_INDEX,
+      anchor: this.anchorRef.current
+      ? findNodeHandle(this.anchorRef.current)
+      : undefined,
       destructiveButtonIndex: DESTRUCTIVE_INDEX,
     },
     (buttonIndex) => {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [X ] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

Our macOS actionsheet tests don't have an anchor on the button that drops the action sheet. Without this, we default on some functionality instead of hitting the codepaths that actually replicate how clients use the class (which only happen if we can find the anchor to drop from).

#### Focus areas to test

- I checked programmatically that dropping the contextual menu via the button in the ActionSheetMacOS test passes the anchor through to our ObjC module.
- Ran through the expected code paths and we're no longer providing default values to our action sheet, which also has the user impact that the action sheet appears relative to our anchor (the button that dropped it).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/261)