### PR TITLE
Add support for macOS legacy scroller system setting.

### DIFF
--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -1113,7 +1113,7 @@ class ScrollView extends React.Component<Props, State> {
             ? false
             : this.props.removeClippedSubviews
         }
-        key={this.state.contentKey}
+        key={this.state.contentKey} // TODO(macOS ISS#2323203)
         collapsable={false}>
         {children}
       </ScrollContentContainerViewClass>

--- a/Libraries/Components/ScrollView/ScrollView.js
+++ b/Libraries/Components/ScrollView/ScrollView.js
@@ -569,6 +569,7 @@ export type Props = $ReadOnly<{|
 |}>;
 
 type State = {|
+  contentKey: number, // TODO(macOS ISS#2323203)
   layoutHeight: ?number,
   ...ScrollResponderState,
 |};
@@ -683,6 +684,7 @@ class ScrollView extends React.Component<Props, State> {
   _headerLayoutYs: Map<string, number> = new Map();
 
   state = {
+    contentKey: 1, // TODO(macOS ISS#2323203)
     layoutHeight: null,
     ...ScrollResponder.Mixin.scrollResponderMixinGetInitialState(),
   };
@@ -956,6 +958,10 @@ class ScrollView extends React.Component<Props, State> {
       x: Math.max(0, Math.min(maxX, newOffset.x)),
       y: Math.max(0, Math.min(maxY, newOffset.y)),
     });
+  };
+
+  _handlePreferredScrollerStyleDidChange = (event: ScrollEvent) => {
+    this.setState({contentKey: this.state.contentKey + 1});
   }; // ]TODO(macOS ISS#2323203)
 
   _handleScroll = (e: ScrollEvent) => {
@@ -1107,6 +1113,7 @@ class ScrollView extends React.Component<Props, State> {
             ? false
             : this.props.removeClippedSubviews
         }
+        key={this.state.contentKey}
         collapsable={false}>
         {children}
       </ScrollContentContainerViewClass>
@@ -1138,6 +1145,8 @@ class ScrollView extends React.Component<Props, State> {
       // bubble up from TextInputs
       onContentSizeChange: null,
       onScrollKeyDown: this._handleKeyDown, // TODO(macOS ISS#2323203)
+      onPreferredScrollerStyleDidChange: this
+        ._handlePreferredScrollerStyleDidChange, // TODO(macOS ISS#2323203)
       onLayout: this._handleLayout,
       onMomentumScrollBegin: this._scrollResponder
         .scrollResponderHandleMomentumScrollBegin,

--- a/Libraries/Components/View/ViewPropTypes.js
+++ b/Libraries/Components/View/ViewPropTypes.js
@@ -58,12 +58,18 @@ type DirectEventProps = $ReadOnly<{|
   onDoubleClick?: ?(event: SyntheticEvent<{}>) => mixed, // TODO(macOS ISS#2323203)
 
   /**
+   * This event is fired when the system's preferred scroller style changes.
+   * The `preferredScrollerStyle` key will be `legacy` or `overlay`.
+   */
+  onPreferredScrollerStyleDidChange?: ?(event: ScrollEvent) => mixed, // TODO(macOS ISS#2323203)
+
+  /**
    * When `acceptsKeyboardFocus` is true, the system will try to invoke this function
    * when the user performs accessibility key down gesture.
    */
   onScrollKeyDown?: ?(event: ScrollEvent) => mixed, // TODO(macOS ISS#2323203)
 
-  onMouseEnter?: (event: SyntheticEvent<{}>) => mixed, // [TODO(macOS ISS#2323203)
+  onMouseEnter?: (event: SyntheticEvent<{}>) => mixed, // TODO(macOS ISS#2323203)
 
   /**
    * Invoked on mount and layout changes with:

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1104,7 +1104,9 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       keyEventHandler = this.props.enableSelectionOnKeyPress
         ? this._handleKeyDown
         : null;
-    } // ]TODO(macOS ISS#2323203)
+    }
+    const preferredScrollerStyleDidChangeHandler = this.props
+      .onPreferredScrollerStyleDidChange; // TODO(macOS ISS#2323203)
     const onRefresh = props.onRefresh;
     if (this._isNestedWithSameOrientation()) {
       // $FlowFixMe - Typing ReactNativeComponent revealed errors
@@ -1121,6 +1123,9 @@ class VirtualizedList extends React.PureComponent<Props, State> {
         <ScrollView
           {...props}
           onScrollKeyDown={keyEventHandler} // TODO(macOS ISS#2323203)
+          onPreferredScrollerStyleDidChange={
+            preferredScrollerStyleDidChangeHandler
+          } // TODO(macOS ISS#2323203)
           refreshControl={
             props.refreshControl == null ? (
               <RefreshControl
@@ -1135,11 +1140,18 @@ class VirtualizedList extends React.PureComponent<Props, State> {
         />
       );
     } else {
-      // $FlowFixMe Invalid prop usage
-      return <ScrollView {...props} onScrollKeyDown={keyEventHandler} />; // TODO(macOS ISS#2323203)
+      return (
+        // $FlowFixMe Invalid prop usage
+        <ScrollView
+          {...props}
+          onScrollKeyDown={keyEventHandler}
+          onPreferredScrollerStyleDidChange={
+            preferredScrollerStyleDidChangeHandler
+          }
+        />
+      ); // TODO(macOS ISS#2323203)
     }
   };
-
   _onCellLayout(e, cellKey, index) {
     const layout = e.nativeEvent.layout;
     const next = {

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1106,7 +1106,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
         : null;
     }
     const preferredScrollerStyleDidChangeHandler = this.props
-      .onPreferredScrollerStyleDidChange; // TODO(macOS ISS#2323203)
+      .onPreferredScrollerStyleDidChange; // ]TODO(macOS ISS#2323203)
     const onRefresh = props.onRefresh;
     if (this._isNestedWithSameOrientation()) {
       // $FlowFixMe - Typing ReactNativeComponent revealed errors

--- a/Libraries/Lists/VirtualizedSectionList.js
+++ b/Libraries/Lists/VirtualizedSectionList.js
@@ -345,12 +345,17 @@ class VirtualizedSectionList<
       keyEventHandler = this.props.enableSelectionOnKeyPress
         ? this._handleKeyDown
         : null;
-    } // ]TODO(macOS ISS#2323203)
+    }
+    const preferredScrollerStyleDidChangeHandler = this.props
+      .onPreferredScrollerStyleDidChange; // ]TODO(macOS ISS#2323203)
     return (
       <VirtualizedList
         {...this.state.childProps}
         ref={this._captureRef}
         onScrollKeyDown={keyEventHandler}
+        onPreferredScrollerStyleDidChange={
+          preferredScrollerStyleDidChangeHandler
+        }
         {...this.state.selectedRowIndexPath}
       /> // TODO(macOS ISS#2323203)
     );

--- a/Libraries/Types/CoreEventTypes.js
+++ b/Libraries/Types/CoreEventTypes.js
@@ -133,6 +133,7 @@ export type ScrollEvent = SyntheticEvent<
     zoomScale?: number,
     responderIgnoreScroll?: boolean,
     key?: string, // TODO(macOS)
+    preferredScrollerStyle?: string, // TODO(macOS)
   |}>,
 >;
 

--- a/React/Views/ScrollView/RCTScrollContentView.m
+++ b/React/Views/ScrollView/RCTScrollContentView.m
@@ -29,18 +29,16 @@
     // In such cases the content view layout must shrink accordingly otherwise
     // the contents will overflow causing the scroll indicators to appear unnecessarily.
     NSScrollView *platformScrollView = scrollView.scrollView;
-    CGFloat verticalScrollerWidth = 0;
-    CGFloat horizontalScrollerHeight = 0;
     if (platformScrollView.scrollerStyle == NSScrollerStyleLegacy) {
-      if (!platformScrollView.verticalScroller.isHidden) {
-        verticalScrollerWidth = platformScrollView.verticalScroller.frame.size.width;
+      NSScroller *verticalScroller = platformScrollView.verticalScroller;
+      if (!verticalScroller.isHidden) {
+        frame.size.width -= verticalScroller.frame.size.width;
       }
-      if (!platformScrollView.horizontalScroller.isHidden) {
-        horizontalScrollerHeight = platformScrollView.horizontalScroller.frame.size.height;
+      NSScroller *horizontalScroller = platformScrollView.horizontalScroller;
+      if (!horizontalScroller.isHidden) {
+        frame.size.height -= horizontalScroller.frame.size.height;
       }
     }
-    frame.size.width -= verticalScrollerWidth;
-    frame.size.height -= horizontalScrollerHeight;
   }
 #endif // ]TODO(macOS ISS#2323203)
 

--- a/React/Views/ScrollView/RCTScrollContentView.m
+++ b/React/Views/ScrollView/RCTScrollContentView.m
@@ -16,14 +16,35 @@
 
 - (void)reactSetFrame:(CGRect)frame
 {
-  [super reactSetFrame:frame];
-
 #if !TARGET_OS_OSX // TODO(macOS ISS#2323203)
   RCTScrollView *scrollView = (RCTScrollView *)self.superview.superview;
 #else // [TODO(macOS ISS#2323203)
   // macOS also has a NSClipView in its hierarchy
   RCTScrollView *scrollView = (RCTScrollView *)self.superview.superview.superview;
+
+  if (scrollView != nil) {
+    // On macOS scroll indicators may float over the content view like they do in iOS
+    // or depending on system preferences they may be outside of the content view
+    // which means the clip view will be smaller than the scroll view itself.
+    // In such cases the content view layout must shrink accordingly otherwise
+    // the contents will overflow causing the scroll indicators to appear unnecessarily.
+    NSScrollView *platformScrollView = scrollView.scrollView;
+    CGFloat verticalScrollerWidth = 0;
+    CGFloat horizontalScrollerHeight = 0;
+    if (platformScrollView.scrollerStyle == NSScrollerStyleLegacy) {
+      if (!platformScrollView.verticalScroller.isHidden) {
+        verticalScrollerWidth = platformScrollView.verticalScroller.frame.size.width;
+      }
+      if (!platformScrollView.horizontalScroller.isHidden) {
+        horizontalScrollerHeight = platformScrollView.horizontalScroller.frame.size.height;
+      }
+    }
+    frame.size.width -= verticalScrollerWidth;
+    frame.size.height -= horizontalScrollerHeight;
+  }
 #endif // ]TODO(macOS ISS#2323203)
+
+  [super reactSetFrame:frame];
 
   if (!scrollView) {
     return;

--- a/React/Views/ScrollView/RCTScrollView.h
+++ b/React/Views/ScrollView/RCTScrollView.h
@@ -67,6 +67,7 @@
 @property (nonatomic, copy) RCTDirectEventBlock onMomentumScrollBegin;
 @property (nonatomic, copy) RCTDirectEventBlock onMomentumScrollEnd;
 @property (nonatomic, copy) RCTDirectEventBlock onScrollKeyDown; // TODO(macOS ISS#2323203)
+@property (nonatomic, copy) RCTDirectEventBlock onPreferredScrollerStyleDidChange; // TODO(macOS ISS#2323203)
 
 - (void)flashScrollIndicators; // TODO(macOS ISS#2323203)
 

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -757,24 +757,28 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(RCTPlatformVie
 - (void)viewDidMoveToWindow
 {
   [super viewDidMoveToWindow];
-  
+
+  NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
   if ([self window] == nil) {
     // Unregister for bounds change notifications
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:NSViewBoundsDidChangeNotification object:_scrollView.contentView];
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:NSPreferredScrollerStyleDidChangeNotification object:nil];
-  }
-  else {
+    [defaultCenter removeObserver:self
+                             name:NSViewBoundsDidChangeNotification
+                           object:_scrollView.contentView];
+    [defaultCenter removeObserver:self
+                             name:NSPreferredScrollerStyleDidChangeNotification
+                           object:nil];
+  } else {
     // Register for bounds change notifications so we can track scrolling
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(scrollViewDocumentViewBoundsDidChange:)
-                                                 name:NSViewBoundsDidChangeNotification
-                                               object:_scrollView.contentView];  // NSClipView
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(preferredScrollerStyleDidChange:)
-                                                 name:NSPreferredScrollerStyleDidChangeNotification
-                                               object:nil];
+    [defaultCenter addObserver:self
+                      selector:@selector(scrollViewDocumentViewBoundsDidChange:)
+                          name:NSViewBoundsDidChangeNotification
+                        object:_scrollView.contentView]; // NSClipView
+    [defaultCenter addObserver:self
+                      selector:@selector(preferredScrollerStyleDidChange:)
+                          name:NSPreferredScrollerStyleDidChangeNotification
+                        object:nil];
   }
-  
+
   _notifyDidScroll = ([self window] != nil);
 }
 #endif // ]TODO(macOS ISS#2323203)

--- a/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/React/Views/ScrollView/RCTScrollViewManager.m
@@ -102,7 +102,6 @@ RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollEnd, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(DEPRECATED_sendUpdatedChildFrames, BOOL)
 RCT_EXPORT_OSX_VIEW_PROPERTY(onScrollKeyDown, RCTDirectEventBlock) // TODO(macOS ISS#2323203)
 RCT_EXPORT_OSX_VIEW_PROPERTY(onPreferredScrollerStyleDidChange, RCTDirectEventBlock) // TODO(macOS ISS#2323203)
-
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)
 #endif

--- a/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/React/Views/ScrollView/RCTScrollViewManager.m
@@ -101,6 +101,8 @@ RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollBegin, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollEnd, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(DEPRECATED_sendUpdatedChildFrames, BOOL)
 RCT_EXPORT_OSX_VIEW_PROPERTY(onScrollKeyDown, RCTDirectEventBlock) // TODO(macOS ISS#2323203)
+RCT_EXPORT_OSX_VIEW_PROPERTY(onPreferredScrollerStyleDidChange, RCTDirectEventBlock) // TODO(macOS ISS#2323203)
+
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)
 #endif


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

macOS scroll views are usually like iOS scroll views in that the scroll indicators only appear when scrolling and they overlay the content view.  But in System Preferences > General, the user may choose 'Show scroll bars: Always' in which case the content view shrinks and a horizontal and/or vertical scroll indicator appears to the right and/or below the content view.   In these cases the react-native content area was still being laid out as if the content view was the same size as the scroll view which would could cause the vertical scroll indicator to appear because the content was too wide.

This fix involves a change to the `RCTScrollContentView reactSetFrame:` method.   When the react frame is being set, the method checks if the `scrollerStyle` property on the `NSScrollView` is `NSScrollerStyleLegacy`.   If so it gets the width and height of the scrollers if visible and adjusts the frame size.

When the user changes the setting in System Preferences a `NSPreferredScrollerStyleDidChangeNotification` notification is sent.   When this notification is sent, a react native event is fired to the `onPreferredScrollerStyleDidChange` prop of `<ScrollView>`.   The javascript implementation of `ScrollView` handles the event and forces a re-render.

![scroller](https://user-images.githubusercontent.com/30053638/77268581-aa1fe300-6c63-11ea-9c95-f45d80f05c0b.gif)

#### Focus areas to test

The RNTester app was used to validate the change with attention to the Scroll and List examples.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/262)