### PR TITLE
Send mouse up notifications for all enabled NSControls

### DIFF
--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -128,6 +128,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
 #else // [TODO(macOS ISS#2323203)
     CGPoint touchLocation = [self.view convertPoint:touch.locationInWindow fromView:nil];
     NSView *targetView = [self.view hitTest:touchLocation];
+    // Pair the mouse down events with mouse up events so our _nativeTouches cache doesn't get stale
     if ([targetView isKindOfClass:[NSControl class]]) {
       _shouldSendMouseUpOnSystemBehalf = [(NSControl*)targetView isEnabled];
     } else if ([targetView isKindOfClass:[NSText class]]) {

--- a/React/Base/RCTTouchHandler.m
+++ b/React/Base/RCTTouchHandler.m
@@ -128,7 +128,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)coder)
 #else // [TODO(macOS ISS#2323203)
     CGPoint touchLocation = [self.view convertPoint:touch.locationInWindow fromView:nil];
     NSView *targetView = [self.view hitTest:touchLocation];
-    if ([targetView isKindOfClass:NSText.class]) {
+    if ([targetView isKindOfClass:[NSControl class]]) {
+      _shouldSendMouseUpOnSystemBehalf = [(NSControl*)targetView isEnabled];
+    } else if ([targetView isKindOfClass:[NSText class]]) {
       _shouldSendMouseUpOnSystemBehalf = [(NSText*)targetView isSelectable];
     } else {
       _shouldSendMouseUpOnSystemBehalf = NO;


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ X] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

When controls such as NSButton don't send the mouse up signal after a mouse down click, the mouse event gets stored in our cache and becomes stale. On the next click, we fail an assert that there are no stale events in our cache and no action is executed.

What we need to do is send the mouse up signal for all controls that can receive one so we clear out our cache properly. We need to pair the mouse down events 1:1 with the mouse up events we send.

#### Focus areas to test

Tested in a downstream app (Polyester). Clicking every time registers and sends the correct event (dropping a menu in this case). Tested with both soft trackpad and hard trackpad clicks.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/263)