### PR TITLE
Fixing DialogModule for Android SDK version before 26

### DIFF
--- a/android-patches/patches-droid-office-grouped/DialogModule/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
+++ b/android-patches/patches-droid-office-grouped/DialogModule/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
@@ -89,7 +89,7 @@
 -          alertFragment.setCancelable(arguments.getBoolean(KEY_CANCELABLE));
 +      if(isUsingPlatformFragmentManager()) {
 +        PlatformAlertFragment platformAlertFragment = new PlatformAlertFragment(actionListener, arguments);
-+        if (mIsInForeground) {
++        if (mIsInForeground) { // isStateSaved not available in sdk v25 and lower
 +          if (arguments.containsKey(KEY_CANCELABLE)) {
 +            platformAlertFragment.setCancelable(arguments.getBoolean(KEY_CANCELABLE));
 +          }

--- a/android-patches/patches-droid-office-grouped/DialogModule/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
+++ b/android-patches/patches-droid-office-grouped/DialogModule/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
@@ -88,14 +88,14 @@
 -        if (arguments.containsKey(KEY_CANCELABLE)) {
 -          alertFragment.setCancelable(arguments.getBoolean(KEY_CANCELABLE));
 +      if(isUsingPlatformFragmentManager()) {
-+        PlatformAlertFragment PlatformAlertFragment = new PlatformAlertFragment(actionListener, arguments);
-+        if (mIsInForeground && !mPlatformFragmentManager.isStateSaved()) {
++        PlatformAlertFragment platformAlertFragment = new PlatformAlertFragment(actionListener, arguments);
++        if (mIsInForeground) {
 +          if (arguments.containsKey(KEY_CANCELABLE)) {
-+            PlatformAlertFragment.setCancelable(arguments.getBoolean(KEY_CANCELABLE));
++            platformAlertFragment.setCancelable(arguments.getBoolean(KEY_CANCELABLE));
 +          }
-+          PlatformAlertFragment.show(mPlatformFragmentManager, FRAGMENT_TAG);
++          platformAlertFragment.show(mPlatformFragmentManager, FRAGMENT_TAG);
 +        } else {
-+          mFragmentToShow = PlatformAlertFragment;
++          mFragmentToShow = platformAlertFragment;
          }
 -        alertFragment.show(mFragmentManager, FRAGMENT_TAG);
        } else {


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

We have some custom code in fork to support DialogModule on Office apps. The code uses an API not available before Android sdk version 26. This fixes the code to not call the API.

#### Focus areas to test
Make sure that dialog/alert comes up on devices with new and old android sdks.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/285)