### PR TITLE
Update scripts to publish react-native-macos-init

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -49,6 +49,39 @@ jobs:
           command: 'publish'
           publishEndpoint: 'npmjs'
 
+  - job: RNMacOSInitNpmJSPublish
+    displayName: react-native-macos-init Publish to npmjs.org
+    pool:
+      vmImage: vs2017-win2016
+    timeoutInMinutes: 90 # how long to run the job before automatically cancelling
+    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+    steps:
+      - checkout: self # self represents the repo where the initial Pipelines YAML file was found
+        clean: true # whether to fetch clean each time
+        # fetchDepth: 2 # the depth of commits to ask Git to fetch
+        lfs: false # whether to download Git-LFS files
+        submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
+        persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
+
+      - task: CmdLine@2
+        displayName: npm install
+        inputs:
+          script: |
+            cd packages/react-native-macos-init
+            npm install
+
+      - task: CmdLine@2
+        displayName: Bump package version
+        inputs:
+          script: node .ado/bumpFileVersions.js
+
+      - task: Npm@1
+        displayName: "Publish react-native-macos-init to npmjs.org"
+        inputs:
+          command: 'publish'
+          workingDir: 'packages/react-native-macos-init'
+          publishEndpoint: 'npmjs'
+
   - job: RNGithubOfficePublish
     displayName: React-Native GitHub Publish to Office
     pool:

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -71,16 +71,11 @@ jobs:
             npm install
 
       - task: CmdLine@2
-        displayName: Bump package version
-        inputs:
-          script: node .ado/bumpFileVersions.js
-
-      - task: Npm@1
         displayName: "Publish react-native-macos-init to npmjs.org"
         inputs:
-          command: 'publish'
-          workingDir: 'packages/react-native-macos-init'
-          publishEndpoint: 'npmjs'
+          script: |
+            cd packages/react-native-macos-init
+            npx --no-install beachball publish --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --access public
 
   - job: RNGithubOfficePublish
     displayName: React-Native GitHub Publish to Office

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -71,6 +71,13 @@ jobs:
             yarn install
 
       - task: CmdLine@2
+        displayName: yarn build
+        inputs:
+          script: |
+            cd packages/react-native-macos-init
+            yarn build
+
+      - task: CmdLine@2
         displayName: "Publish react-native-macos-init to npmjs.org"
         inputs:
           script: |

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -64,11 +64,11 @@ jobs:
         persistCredentials: true # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
       - task: CmdLine@2
-        displayName: npm install
+        displayName: yarn install
         inputs:
           script: |
             cd packages/react-native-macos-init
-            npm install
+            yarn install
 
       - task: CmdLine@2
         displayName: "Publish react-native-macos-init to npmjs.org"

--- a/.ado/versionUtils.js
+++ b/.ado/versionUtils.js
@@ -14,6 +14,23 @@ function gatherVersionInfo() {
     return {pkgJson, releaseVersion, branchVersionSuffix};
 }
 
+function updateReactNativeMacOSInitVersionInFile() {
+    const rnMacOSInitPkgJsonPath = path.resolve(__dirname, "../packages/react-native-macos-init/package.json");
+    const rnMacOSInitPkgJson = JSON.parse(fs.readFileSync(rnMacOSInitPkgJsonPath, "utf8"));
+    let rnMacOSInitReleaseVersion = rnMacOSInitPkgJson.version;
+    const rnMacOSInitVersionStringRegEx = new RegExp(`([0-9]*)\\.([0-9]*)\\.([0-9]*)`);
+    const rnMacOSInitVersionGroups = rnMacOSInitVersionStringRegEx.exec(rnMacOSInitReleaseVersion);
+    if (rnMacOSInitVersionGroups) {
+      rnMacOSInitReleaseVersion = rnMacOSInitVersionGroups[1] + '.' + rnMacOSInitVersionGroups[2] + '.' + (parseInt(rnMacOSInitVersionGroups[3]) + 1);
+    } else {
+      console.log("Invalid react-native-macos-init version to publish");
+      process.exit(1);
+    }
+    rnMacOSInitPkgJson.version = rnMacOSInitReleaseVersion;
+    fs.writeFileSync(rnMacOSInitPkgJsonPath, JSON.stringify(rnMacOSInitPkgJson, null, 2));
+    console.log(`Updating ${rnMacOSInitPkgJsonPath} to version ${rnMacOSInitReleaseVersion}`);
+}
+
 function updateVersionsInFiles() {
 
     let {pkgJson, releaseVersion, branchVersionSuffix} = gatherVersionInfo();
@@ -34,6 +51,9 @@ function updateVersionsInFiles() {
     pkgJson.version = releaseVersion;
     fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
     console.log(`Updating package.json to version ${releaseVersion}`);
+
+    updateReactNativeMacOSInitVersionInFile();
+  
     return {releaseVersion, branchVersionSuffix};
 }
 

--- a/.ado/versionUtils.js
+++ b/.ado/versionUtils.js
@@ -14,23 +14,6 @@ function gatherVersionInfo() {
     return {pkgJson, releaseVersion, branchVersionSuffix};
 }
 
-function updateReactNativeMacOSInitVersionInFile() {
-    const rnMacOSInitPkgJsonPath = path.resolve(__dirname, "../packages/react-native-macos-init/package.json");
-    const rnMacOSInitPkgJson = JSON.parse(fs.readFileSync(rnMacOSInitPkgJsonPath, "utf8"));
-    let rnMacOSInitReleaseVersion = rnMacOSInitPkgJson.version;
-    const rnMacOSInitVersionStringRegEx = new RegExp(`([0-9]*)\\.([0-9]*)\\.([0-9]*)`);
-    const rnMacOSInitVersionGroups = rnMacOSInitVersionStringRegEx.exec(rnMacOSInitReleaseVersion);
-    if (rnMacOSInitVersionGroups) {
-      rnMacOSInitReleaseVersion = rnMacOSInitVersionGroups[1] + '.' + rnMacOSInitVersionGroups[2] + '.' + (parseInt(rnMacOSInitVersionGroups[3]) + 1);
-    } else {
-      console.log("Invalid react-native-macos-init version to publish");
-      process.exit(1);
-    }
-    rnMacOSInitPkgJson.version = rnMacOSInitReleaseVersion;
-    fs.writeFileSync(rnMacOSInitPkgJsonPath, JSON.stringify(rnMacOSInitPkgJson, null, 2));
-    console.log(`Updating ${rnMacOSInitPkgJsonPath} to version ${rnMacOSInitReleaseVersion}`);
-}
-
 function updateVersionsInFiles() {
 
     let {pkgJson, releaseVersion, branchVersionSuffix} = gatherVersionInfo();
@@ -51,8 +34,6 @@ function updateVersionsInFiles() {
     pkgJson.version = releaseVersion;
     fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
     console.log(`Updating package.json to version ${releaseVersion}`);
-
-    updateReactNativeMacOSInitVersionInFile();
   
     return {releaseVersion, branchVersionSuffix};
 }

--- a/change/react-native-macos-init-2020-04-03-21-43-14-tomun-publish-react-native-init.json
+++ b/change/react-native-macos-init-2020-04-03-21-43-14-tomun-publish-react-native-init.json
@@ -1,0 +1,8 @@
+{
+  "type": "major",
+  "comment": "Update scripts to publish react-native-macos-init",
+  "packageName": "react-native-macos-init",
+  "email": "tomun@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-04T04:43:14.681Z"
+}

--- a/change/react-native-macos-init-2020-04-03-21-47-57-tomun-publish-react-native-init.json
+++ b/change/react-native-macos-init-2020-04-03-21-47-57-tomun-publish-react-native-init.json
@@ -1,8 +1,0 @@
-{
-  "type": "major",
-  "comment": "Update scripts to publish react-native-macos-init",
-  "packageName": "react-native-macos-init",
-  "email": "tomun@microsoft.com",
-  "dependentChangeType": "patch",
-  "date": "2020-04-04T04:47:57.682Z"
-}

--- a/change/react-native-macos-init-2020-04-03-21-47-57-tomun-publish-react-native-init.json
+++ b/change/react-native-macos-init-2020-04-03-21-47-57-tomun-publish-react-native-init.json
@@ -1,0 +1,8 @@
+{
+  "type": "major",
+  "comment": "Update scripts to publish react-native-macos-init",
+  "packageName": "react-native-macos-init",
+  "email": "tomun@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-04T04:47:57.682Z"
+}

--- a/packages/react-native-macos-init/package.json
+++ b/packages/react-native-macos-init/package.json
@@ -7,8 +7,11 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "build": "just-scripts build",
+    "change": "beachball change",
+    "check": "beachball check",
     "clean": "just-scripts clean",
+    "beachball:publish": "beachball publish",
+    "build": "just-scripts build",
     "lint": "just-scripts lint",
     "lint:fix": "just-scripts lint:fix",
     "prepublishOnly": "npm run build"
@@ -18,9 +21,9 @@
   },
   "dependencies": {
     "chalk": "^3",
+    "find-up": "^4.1.0",
     "npm-registry": "^0.1.13",
     "prompts": "^2.3.0",
-    "find-up": "^4.1.0",
     "semver": "^7.1.3",
     "valid-url": "^1.0.9",
     "yargs": "^15.1.0"
@@ -31,6 +34,7 @@
     "@types/semver": "^7.1.0",
     "@types/valid-url": "^1.0.2",
     "@types/yargs": "^15.0.3",
+    "beachball": "^1.27.0",
     "just-scripts": "^0.36.1",
     "typescript": "3.5.3"
   },

--- a/packages/react-native-macos-init/package.json
+++ b/packages/react-native-macos-init/package.json
@@ -1,42 +1,42 @@
 {
-    "name": "react-native-macos-init",
-    "version": "0.0.9",
-    "description": "CLI to add react-native-macos to an existing react-native project",
-    "main": "index.js",
-    "repository": "https://github.com/microsoft/react-native-macos",
-    "license": "MIT",
-    "private": false,
-    "scripts": {
-      "build": "just-scripts build",
-      "clean": "just-scripts clean",
-      "lint": "just-scripts lint",
-      "lint:fix": "just-scripts lint:fix",
-      "prepublishOnly": "npm run build"
-    },
-    "bin": {
-      "react-native-macos-init": "./bin.js"
-    },
-    "dependencies": {
-      "chalk": "^3",
-      "npm-registry": "^0.1.13",
-      "prompts": "^2.3.0",
-      "find-up": "^4.1.0",
-      "semver": "^7.1.3",
-      "valid-url": "^1.0.9",
-      "yargs": "^15.1.0"
-    },
-    "devDependencies": {
-      "@types/chalk": "^2.2.0",
-      "@types/prompts": "^2.0.3",
-      "@types/semver": "^7.1.0",
-      "@types/valid-url": "^1.0.2",
-      "@types/yargs": "^15.0.3",
-      "just-scripts": "^0.36.1",
-      "typescript": "3.5.3"
-     },
-    "files": [
-      "bin.js",
-      "lib-commonjs",
-      "README.md"
-    ]
-  }
+  "name": "react-native-macos-init",
+  "version": "0.0.0",
+  "description": "CLI to add react-native-macos to an existing react-native project",
+  "main": "index.js",
+  "repository": "https://github.com/microsoft/react-native-macos",
+  "license": "MIT",
+  "private": false,
+  "scripts": {
+    "build": "just-scripts build",
+    "clean": "just-scripts clean",
+    "lint": "just-scripts lint",
+    "lint:fix": "just-scripts lint:fix",
+    "prepublishOnly": "npm run build"
+  },
+  "bin": {
+    "react-native-macos-init": "./bin.js"
+  },
+  "dependencies": {
+    "chalk": "^3",
+    "npm-registry": "^0.1.13",
+    "prompts": "^2.3.0",
+    "find-up": "^4.1.0",
+    "semver": "^7.1.3",
+    "valid-url": "^1.0.9",
+    "yargs": "^15.1.0"
+  },
+  "devDependencies": {
+    "@types/chalk": "^2.2.0",
+    "@types/prompts": "^2.0.3",
+    "@types/semver": "^7.1.0",
+    "@types/valid-url": "^1.0.2",
+    "@types/yargs": "^15.0.3",
+    "just-scripts": "^0.36.1",
+    "typescript": "3.5.3"
+  },
+  "files": [
+    "bin.js",
+    "lib-commonjs",
+    "README.md"
+  ]
+}

--- a/packages/react-native-macos-init/yarn.lock
+++ b/packages/react-native-macos-init/yarn.lock
@@ -2,6 +2,34 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0":
+  version "7.8.3"
+  resolved "http://localhost:4873/@babel%2fcode-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
+  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+  dependencies:
+    "@babel/highlight" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.9.0":
+  version "7.9.0"
+  resolved "http://localhost:4873/@babel%2fhelper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
+  integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
+
+"@babel/highlight@^7.8.3":
+  version "7.9.0"
+  resolved "http://localhost:4873/@babel%2fhighlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
+  integrity sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/runtime@^7.8.7":
+  version "7.9.2"
+  resolved "http://localhost:4873/@babel%2fruntime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
+  integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@microsoft/node-core-library@3.19.3":
   version "3.19.3"
   resolved "https://registry.yarnpkg.com/@microsoft/node-core-library/-/node-core-library-3.19.3.tgz#cf09ddb2905a29b32956d4a88f9d035a00637be9"
@@ -48,6 +76,11 @@
   version "10.17.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.17.tgz#7a183163a9e6ff720d86502db23ba4aade5999b8"
   integrity sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==
+
+"@types/parse-json@^4.0.0":
+  version "4.0.0"
+  resolved "http://localhost:4873/@types%2fparse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prompts@^2.0.3":
   version "2.0.5"
@@ -296,6 +329,21 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+beachball@^1.27.0:
+  version "1.27.0"
+  resolved "http://localhost:4873/beachball/-/beachball-1.27.0.tgz#219e712c9339f70769d8713455730f73b4e9a45b"
+  integrity sha512-FUI5TJO2FgOlkGfIW2oNB46qsjiW9QBM1hlszvTP1sohpLecbEMDquR1qyTGZuk9fi1HWllaqADzNqchQsx0MA==
+  dependencies:
+    cosmiconfig "^6.0.0"
+    fs-extra "^8.0.1"
+    git-url-parse "^11.1.2"
+    glob "^7.1.4"
+    lodash "^4.17.15"
+    minimatch "^3.0.4"
+    prompts "~2.1.0"
+    semver "^6.1.1"
+    yargs-parser "^13.1.0"
+
 bluebird@^3.5.1, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -339,6 +387,11 @@ cacache@^11.3.3:
     unique-filename "^1.1.1"
     y18n "^4.0.0"
 
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "http://localhost:4873/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
 camelcase@^5.0.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -365,7 +418,7 @@ chalk@*, chalk@^3:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -529,6 +582,17 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cosmiconfig@^6.0.0:
+  version "6.0.0"
+  resolved "http://localhost:4873/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
+  integrity sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.1.0"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.7.2"
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -676,6 +740,13 @@ err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
   integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
+
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "http://localhost:4873/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+  dependencies:
+    is-arrayish "^0.2.1"
 
 es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50:
   version "0.10.53"
@@ -866,6 +937,15 @@ fs-extra@^7.0.1, fs-extra@~7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^8.0.1:
+  version "8.1.0"
+  resolved "http://localhost:4873/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
@@ -935,6 +1015,21 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+git-up@^4.0.0:
+  version "4.0.1"
+  resolved "http://localhost:4873/git-up/-/git-up-4.0.1.tgz#cb2ef086653640e721d2042fe3104857d89007c0"
+  integrity sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==
+  dependencies:
+    is-ssh "^1.3.0"
+    parse-url "^5.0.0"
+
+git-url-parse@^11.1.2:
+  version "11.1.2"
+  resolved "http://localhost:4873/git-url-parse/-/git-url-parse-11.1.2.tgz#aff1a897c36cc93699270587bea3dbcbbb95de67"
+  integrity sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==
+  dependencies:
+    git-up "^4.0.0"
+
 githulk@0.0.x:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/githulk/-/githulk-0.0.7.tgz#d96ca29f0ec43117c538e521d663566ea84b4eff"
@@ -956,7 +1051,7 @@ glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -1054,6 +1149,14 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
+import-fresh@^3.1.0:
+  version "3.2.1"
+  resolved "http://localhost:4873/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
+  integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -1082,6 +1185,11 @@ ip@1.1.5:
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "http://localhost:4873/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
@@ -1103,6 +1211,13 @@ is-number@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
   integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
+
+is-ssh@^1.3.0:
+  version "1.3.1"
+  resolved "http://localhost:4873/is-ssh/-/is-ssh-1.3.1.tgz#f349a8cadd24e65298037a522cf7520f2e81a0f3"
+  integrity sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==
+  dependencies:
+    protocols "^1.1.0"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -1139,12 +1254,17 @@ jju@^1.4.0, jju@~1.4.0:
   resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
   integrity sha1-o6vicYryQaKykE+EpiWXDzia4yo=
 
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "http://localhost:4873/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-json-parse-better-errors@^1.0.0:
+json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
@@ -1247,7 +1367,7 @@ kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-kleur@^3.0.3:
+kleur@^3.0.2, kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
@@ -1284,6 +1404,11 @@ licenses@0.0.x:
     fusing "0.2.x"
     githulk "0.0.x"
     npm-registry "0.1.x"
+
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "http://localhost:4873/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -1527,6 +1652,11 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
+normalize-url@^3.3.0:
+  version "3.3.0"
+  resolved "http://localhost:4873/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
+  integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
+
 now-and-later@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/now-and-later/-/now-and-later-2.0.1.tgz#8e579c8685764a7cc02cb680380e94f43ccb1f7c"
@@ -1694,6 +1824,41 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "http://localhost:4873/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
+
+parse-json@^5.0.0:
+  version "5.0.0"
+  resolved "http://localhost:4873/parse-json/-/parse-json-5.0.0.tgz#73e5114c986d143efa3712d4ea24db9a4266f60f"
+  integrity sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+    lines-and-columns "^1.1.6"
+
+parse-path@^4.0.0:
+  version "4.0.1"
+  resolved "http://localhost:4873/parse-path/-/parse-path-4.0.1.tgz#0ec769704949778cb3b8eda5e994c32073a1adff"
+  integrity sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==
+  dependencies:
+    is-ssh "^1.3.0"
+    protocols "^1.4.0"
+
+parse-url@^5.0.0:
+  version "5.0.1"
+  resolved "http://localhost:4873/parse-url/-/parse-url-5.0.1.tgz#99c4084fc11be14141efa41b3d117a96fcb9527f"
+  integrity sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==
+  dependencies:
+    is-ssh "^1.3.0"
+    normalize-url "^3.3.0"
+    parse-path "^4.0.0"
+    protocols "^1.4.0"
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -1718,6 +1883,11 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "http://localhost:4873/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -1756,6 +1926,19 @@ prompts@^2.0.1, prompts@^2.3.0:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.4"
+
+prompts@~2.1.0:
+  version "2.1.0"
+  resolved "http://localhost:4873/prompts/-/prompts-2.1.0.tgz#bf90bc71f6065d255ea2bdc0fe6520485c1b45db"
+  integrity sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==
+  dependencies:
+    kleur "^3.0.2"
+    sisteransi "^1.0.0"
+
+protocols@^1.1.0, protocols@^1.4.0:
+  version "1.4.7"
+  resolved "http://localhost:4873/protocols/-/protocols-1.4.7.tgz#95f788a4f0e979b291ffefcf5636ad113d037d32"
+  integrity sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==
 
 psl@^1.1.28:
   version "1.8.0"
@@ -1817,6 +2000,11 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
+regenerator-runtime@^0.13.4:
+  version "0.13.5"
+  resolved "http://localhost:4873/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
+  integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+
 request@2.x.x:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
@@ -1857,6 +2045,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "http://localhost:4873/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve@^1.8.1:
   version "1.15.1"
@@ -1914,6 +2107,11 @@ semver@^5.5.0, semver@^5.6.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
+semver@^6.1.1:
+  version "6.3.0"
+  resolved "http://localhost:4873/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
 semver@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
@@ -1946,7 +2144,7 @@ signal-exit@^3.0.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-sisteransi@^1.0.4:
+sisteransi@^1.0.0, sisteransi@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
@@ -2325,10 +2523,25 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
+yaml@^1.7.2:
+  version "1.8.3"
+  resolved "http://localhost:4873/yaml/-/yaml-1.8.3.tgz#2f420fca58b68ce3a332d0ca64be1d191dd3f87a"
+  integrity sha512-X/v7VDnK+sxbQ2Imq4Jt2PRUsRsP7UcpSl3Llg6+NRRqWLIvxkMFYtH1FmvwNGYRKKPa+EPA4qDBlI9WVG1UKw==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+
 yargs-parser@^11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
   integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^13.1.0:
+  version "13.1.2"
+  resolved "http://localhost:4873/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

This change adds a job to the existing publish pipeline to publish the `react-native-macos-init` packages to npmjs.org.

This package will allow the `react-native-macos-init` command line to work via `npx`.   See [PR 291](https://github.com/microsoft/react-native/pull/291)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/294)