### PR TITLE
[generator-macos] Enable auto-linking of native modules

### DIFF
--- a/local-cli/generator-macos/index.js
+++ b/local-cli/generator-macos/index.js
@@ -134,8 +134,11 @@ function installDependencies(options) {
 
   // Patch package.json to have start:macos
   const projectPackageJsonPath = path.join(cwd, 'package.json');
+  /** @type {{ scripts?: {} }} */
   const projectPackageJson = JSON.parse(fs.readFileSync(projectPackageJsonPath, { encoding: 'UTF8' }));
-  projectPackageJson.scripts['start:macos'] = 'node node_modules/react-native-macos/local-cli/cli.js start --use-react-native-macos';
+  const scripts = projectPackageJson.scripts || {};
+  scripts['start:macos'] = 'node node_modules/react-native-macos/local-cli/cli.js start --use-react-native-macos';
+  projectPackageJson.scripts = scripts;
   fs.writeFileSync(projectPackageJsonPath, JSON.stringify(projectPackageJson, null, 2));
 
   // Install dependencies using correct package manager

--- a/local-cli/generator-macos/templates/macos/Podfile
+++ b/local-cli/generator-macos/templates/macos/Podfile
@@ -1,7 +1,7 @@
-# require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
+require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 abstract_target 'Shared' do
-  # use_native_modules!
+  use_native_modules!
 
   pod 'React', :path => "../node_modules/react-native-macos/"
   pod 'React-Core', :path => "../node_modules/react-native-macos/React"


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

Currently uses `@react-native-communit/cli-platform-ios`, but this is mostly semantics as they work the same. In the future this will move into a `@react-native-communit/cli-platform-apple` package which will hold common iOS and macOS tooling.

⚠️ One issue people might run into right now is that auto-linking tries to use _any_ podspec it finds among `node_modules`, but we’ll need to make it possible in the future to only link podspecs on the platforms they actually support. I.e. right now if you were to auto-link in a project that had iOS _only_ podspecs, `pod install` will fail. This work will all need to happen in the CLI package, though.

Here’s an example of auto-linking for macOS in the react-native-webview repo https://github.com/react-native-community/react-native-webview/pull/1328

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/312)