### PR TITLE
[generator-macos] Update template for platform specificity during auto-linking

### DIFF
--- a/local-cli/generator-macos/templates/macos/Podfile
+++ b/local-cli/generator-macos/templates/macos/Podfile
@@ -1,8 +1,6 @@
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 abstract_target 'Shared' do
-  use_native_modules!
-
   pod 'React', :path => "../node_modules/react-native-macos/"
   pod 'React-Core', :path => "../node_modules/react-native-macos/React"
   pod 'React-fishhook', :path => "../node_modules/react-native-macos/Libraries/fishhook"
@@ -30,11 +28,13 @@ abstract_target 'Shared' do
 
   target 'HelloWorld-macOS' do
     platform :macos, '10.14'
+    use_native_modules!
     # Pods specifically for macOS target
   end
 
   target 'HelloWorld-iOS' do
     platform :ios, '9'
+    use_native_modules!
     # Pods specifically for iOS target
   end
 end


### PR DESCRIPTION
Setting up our template to work with the changes in https://github.com/react-native-community/cli/pull/1126

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/318)