### PR TITLE
Reverting the hardcoding of version number in the nuget spec

### DIFF
--- a/android-patches/patches-0.61.5/BasicBuild/ReactAndroid/ReactAndroid.nuspec
+++ b/android-patches/patches-0.61.5/BasicBuild/ReactAndroid/ReactAndroid.nuspec
@@ -5,11 +5,11 @@
 +<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
 +  <metadata>
 +    <id>OfficeReact.Android</id>
-+    <version>0.60.0-microsoft.63.mine</version>
++    <version>$buildNumber$</version>
 +    <description>Contains Android Implementation of React-Native</description>
 +    <authors>Microsoft</authors>
 +    <projectUrl>https://github.com/microsoft/react-native</projectUrl>
-+    <repository type="git" url="https://github.com/microsoft/react-native.git"/>
++    <repository type="git" url="https://github.com/microsoft/react-native.git" commit="$commitId$" />
 +    <requireLicenseAcceptance>false</requireLicenseAcceptance>
 +  </metadata>
 +


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

Non-code/functional change. This change is fixing a bug introduced in the last commit, in the Nuget spec that is used for creating packages.

#### Focus areas to test

Nuget Package creation.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native/pull/336)