### PR TITLE
Fix for publishing from stable branches

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -64,8 +64,20 @@ jobs:
           script: node scripts/bump-oss-version.js --nightly
         condition: eq(variables['Build.SourceBranchName'], 'master')
 
+      # Publish will fail if package.json is marked as private
+      - task: CmdLine@2
+        displayName: Remove workspace config from package.json
+        inputs:
+          script: node .ado/removeWorkspaceConfig.js
+
       - script: npm publish --tag $(npmDistTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
         displayName: Publish react-native-macos to npmjs.org
+
+      # Put the private flag back so that the removal does not get committed by the tag release step
+      - task: CmdLine@2
+        displayName: Restore package.json workspace config
+        inputs:
+          script: node .ado/restoreWorkspaceConfig.js
 
       - task: CmdLine@2
         displayName: 'Tag published release'

--- a/.ado/removeWorkspaceConfig.js
+++ b/.ado/removeWorkspaceConfig.js
@@ -1,0 +1,3 @@
+// @ts-check
+const {removeWorkspaceConfig} = require('./versionUtils');
+removeWorkspaceConfig(); 

--- a/.ado/restoreWorkspaceConfig.js
+++ b/.ado/restoreWorkspaceConfig.js
@@ -1,0 +1,3 @@
+// @ts-check
+const {restoreWorkspaceConfig} = require('./versionUtils');
+restoreWorkspaceConfig(); 

--- a/.ado/versionUtils.js
+++ b/.ado/versionUtils.js
@@ -47,9 +47,28 @@ function updateVersionsInFiles(patchVersionPrefix) {
     return {releaseVersion, branchVersionSuffix};
 }
 
+const workspaceJsonPath = path.resolve(require('os').tmpdir(), 'rnpkg.json');
+
+function removeWorkspaceConfig() {
+  let {pkgJson} = gatherVersionInfo();
+  fs.writeFileSync(workspaceJsonPath, JSON.stringify(pkgJson, null, 2));
+  delete pkgJson.private;
+  delete pkgJson.workspaces;
+  fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
+  console.log(`Removing workspace config from package.json to prepare to publish.`);
+}
+
+function restoreWorkspaceConfig() {
+  let pkgJson = JSON.parse(fs.readFileSync(workspaceJsonPath, "utf8"));
+  fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
+  console.log(`Restoring workspace config from package.json`);
+}
+
 module.exports = {
     gatherVersionInfo,
     publishBranchName,
     pkgJsonPath,
+    removeWorkspaceConfig,
+    restoreWorkspaceConfig,
     updateVersionsInFiles
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 # Ensure scripts always have Unix newlines, even on Windows.
 *.command  text eol=lf
 *.sh       text eol=lf
+# Windows files should use crlf line endings
+# https://help.github.com/articles/dealing-with-line-endings/
+*.bat text eol=crlf


### PR DESCRIPTION
When publishing from stable branches there is no step which removes the private flag from package.json. This means that the publish step fails.

This PR will ensure that we always remove the private flag and workspace info right before we publish the package.

We restore the original before we commit any version changes, otherwise removing the workspace config would break the workspace install.