### PR TITLE
fix: Post NSAccessibilityLayoutChangedNotification when we call setAccessibilityFocus on macOS

### DIFF
--- a/React/Modules/MacOS/RCTAccessibilityManager.m
+++ b/React/Modules/MacOS/RCTAccessibilityManager.m
@@ -99,9 +99,10 @@ RCT_EXPORT_METHOD(getCurrentVoiceOverState:(RCTResponseSenderBlock)callback
 
 RCT_EXPORT_METHOD(setAccessibilityFocus:(nonnull NSNumber *)reactTag)
 {
-   dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_async(dispatch_get_main_queue(), ^{
     NSView *view = [self.bridge.uiManager viewForReactTag:reactTag];
     [[view window] makeFirstResponder:view];
+    NSAccessibilityPostNotification(view, NSAccessibilityLayoutChangedNotification);
   });
 }
 


### PR DESCRIPTION
#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [x] I am making a fix / change for the macOS implementation of react-native
- [ ] I am making a change required for Microsoft usage of react-native

## Summary

On iOS, we post a notification when we call `AccessibilityInfo.setAccessibilityFocus` as per [this line](https://github.com/microsoft/react-native-macos/blob/78a879c8b73247d9f5913d9face91a0b7b1dd04a/React/CoreModules/RCTAccessibilityManager.mm#L284), but we don't yet do the same on macOS. This fixes that issue.

## Changelog

[macOS] [Fixed] - Post NSAccessibilityLayoutChangedNotification when we call setAccessibilityFocus

## Test Plan

Validated by running through RNTester and seeing that the notification gets posted.