### PR TITLE
Unblock publish pipeline by excluding native libraries in android builds

### DIFF
--- a/.ado/npmOfficePack.js
+++ b/.ado/npmOfficePack.js
@@ -28,7 +28,7 @@ function doPublish(fakeMode) {
   if (!onlyTagSource) {
     // -------- Generating Android Artifacts with JavaDoc
     const depsEnvPrefix = "REACT_NATIVE_BOOST_PATH=" + path.join(process.env.BUILD_SOURCESDIRECTORY, "build_deps");
-    const gradleCommand = path.join(process.env.BUILD_SOURCESDIRECTORY, "gradlew") + " installArchives";
+    const gradleCommand = path.join(process.env.BUILD_SOURCESDIRECTORY, "gradlew") + " installArchives -Pparam=\"excludeLibs\"";
     exec( depsEnvPrefix + " " + gradleCommand );
 
     // undo uncommenting javadoc setting


### PR DESCRIPTION
Unblock publish pipeline by excluding native libraries in android builds
It's fine as Office don't consume android libraries from the npm package.

#### Please select one of the following
- [ ] I am removing an existing difference between facebook/react-native and microsoft/react-native-macos :thumbsup:
- [ ] I am cherry-picking a change from Facebook's react-native into microsoft/react-native-macos :thumbsup:
- [ ] I am making a fix / change for the macOS implementation of react-native
- [x] I am making a change required for Microsoft usage of react-native

## Summary

Unblock publish pipeline by excluding native libraries in android builds

## Changelog

Unblock publish pipeline by excluding native libraries in android builds

[CATEGORY] [TYPE] - Message


