### PR TITLE
fix(0.76): fix `TextPropsMacOS` using the wrong `MouseEvent` type

### DIFF
--- a/packages/react-native/Libraries/Text/Text.d.ts
+++ b/packages/react-native/Libraries/Text/Text.d.ts
@@ -16,6 +16,7 @@ import {TextStyle} from '../StyleSheet/StyleSheetTypes';
 import {
   GestureResponderEvent,
   LayoutChangeEvent,
+  MouseEvent, // [macOS]
   NativeSyntheticEvent,
   TextLayoutEventData,
 } from '../Types/CoreEventTypes';


### PR DESCRIPTION
## Summary:

`TextPropsMacOS` has been using `MouseEvent` defined by web as opposed to React's.

See #2507.

## Test Plan:

n/a