### PR TITLE
fix: TextInputFocus state not in sync with View focus

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInputState.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInputState.js
@@ -91,7 +91,6 @@ function blurField(textFieldID: ?number) {
  * noop if the text field was already focused or if the field is not editable
  */
 function focusTextInput(textField: ?HostInstance) {
-  console.log('SAAD focusTextInput');
   if (typeof textField === 'number') {
     if (__DEV__) {
       console.error(


### PR DESCRIPTION
## Summary:

This is fixed upstream with https://github.com/facebook/react-native/pull/52472/ . Let's commit (and backport) a smaller fix for now. 

## Test Plan:

Minimal repro of bug is this code below. Basically, you can't focus on "Pressable Child 2" twice by clicking on the container

```
      <Pressable style={{backgroundColor: 'lightblue', padding: 10, gap: 10}} onPress={() => {myRef.current.focus();}}>
          <Text>Pressable Container</Text>
          <Pressable><Text>Pressable Child 1</Text></Pressable>
          <Pressable ref={myRef}><Text>Pressable Child 2</Text></Pressable>
          <Pressable><Text>Pressable Child 3</Text></Pressable>
      </Pressable>
```
