### PR TITLE
chore: Add `focusable` to macOS view config

### DIFF
--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.macos.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.macos.js
@@ -52,6 +52,7 @@ const validAttributesForNonEventProps = {
   cursor: true,
   draggedTypes: true,
   enableFocusRing: true,
+  focusable: true,
   tooltip: true,
   keyDownEvents: true,
   keyUpEvents: true,


### PR DESCRIPTION
## Summary:

Fix a couple of static view config validation warnings by adding `focusable` to the macOS view config.

## Test Plan:

Less warnings in RNTester when I launch it. 
