### PR TITLE
fix: center RNTesterExampleFilter on macOS

### DIFF
--- a/packages/rn-tester/js/components/RNTesterExampleFilter.js
+++ b/packages/rn-tester/js/components/RNTesterExampleFilter.js
@@ -174,6 +174,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     paddingVertical: 0,
     height: 35,
+    ...(Platform.OS === 'macos' && {
+      paddingVertical: 5,
+      height: undefined,
+    }),
     flex: 1,
     alignSelf: 'center',
     paddingLeft: 35,


### PR DESCRIPTION
## Summary:

iOS will center placeholder text and the input field of UITextInput, while macOS will align to top left corner. This causes a visual glitch in RNTester, which we can solve with a macOS only style.

## Test Plan:

Before

<img width="498" height="431" alt="Screenshot 2025-09-09 at 5 06 55 PM" src="https://github.com/user-attachments/assets/5bb366bb-cf8d-4ca2-8ca6-b170997decff" />


After

<img width="498" height="431" alt="Screenshot 2025-09-09 at 5 06 25 PM" src="https://github.com/user-attachments/assets/f905aa01-196a-420b-9c5b-28e6944842cd" />


