### PR TITLE
fix: Suppress deprecation warnings for minimum of OS 26

### DIFF
--- a/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
+++ b/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
@@ -155,6 +155,8 @@ RCT_EXPORT_METHOD(canOpenURL
 RCT_EXPORT_METHOD(getInitialURL : (RCTPromiseResolveBlock)resolve reject : (__unused RCTPromiseRejectBlock)reject)
 {
   NSURL *initialURL = nil;
+#pragma clang diagnostic push // [macOS]
+#pragma clang diagnostic ignored "-Wdeprecated-declarations" // [macOS]
   if (self.bridge.launchOptions[UIApplicationLaunchOptionsURLKey]) {
     initialURL = self.bridge.launchOptions[UIApplicationLaunchOptionsURLKey];
   } else {
@@ -164,6 +166,7 @@ RCT_EXPORT_METHOD(getInitialURL : (RCTPromiseResolveBlock)resolve reject : (__un
       initialURL = ((NSUserActivity *)userActivityDictionary[@"UIApplicationLaunchOptionsUserActivityKey"]).webpageURL;
     }
   }
+#pragma clang diagnostic pop // [macOS]
   resolve(RCTNullIfNil(initialURL.absoluteString));
 }
 


### PR DESCRIPTION
## Summary:

While Microsoft is still far away from dropping support for iOS 18, we want to get a head-start on handling deprecated APIs for the latest OS releases. Silence these deprecated API warnings when making macOS 26, iOS 26, and watchOS 26 our minimums.

## Test Plan:

There is no change to actual code.