### PR TITLE
chore: remove clipsToBounds overrides

### DIFF
--- a/packages/react-native/React/Base/RCTUIKit.h
+++ b/packages/react-native/React/Base/RCTUIKit.h
@@ -65,11 +65,6 @@ UIKIT_STATIC_INLINE RCTPlatformView *RCTUIViewHitTestWithEvent(RCTPlatformView *
   return [view hitTest:point withEvent:event];
 }
 
-UIKIT_STATIC_INLINE BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
-{
-  return view.clipsToBounds;
-}
-
 UIKIT_STATIC_INLINE void RCTUIViewSetContentModeRedraw(UIView *view)
 {
   view.contentMode = UIViewContentModeRedraw;
@@ -398,8 +393,6 @@ void UIBezierPathAppendPath(UIBezierPath *path, UIBezierPath *appendPath);
 
 - (void)setNeedsDisplay;
 
-// FUTURE: When Xcode 14 is no longer supported (CI is building with Xcode 15), we can remove this override since it's now declared on NSView
-@property BOOL clipsToBounds;
 @property (nonatomic, copy) NSColor *backgroundColor;
 @property (nonatomic) CGAffineTransform transform;
 
@@ -461,8 +454,6 @@ NS_INLINE RCTPlatformView *RCTUIViewHitTestWithEvent(RCTPlatformView *view, CGPo
   NSPoint pointInSuperview = superview != nil ? [view convertPoint:point toView:superview] : point;
   return [view hitTest:pointInSuperview];
 }
-
-BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view);
 
 NS_INLINE void RCTUIViewSetContentModeRedraw(RCTPlatformView *view)
 {
@@ -604,8 +595,6 @@ typedef UIImageView RCTUIImageView;
 #else
 @interface RCTUIImageView : NSImageView
 NS_ASSUME_NONNULL_BEGIN
-// FUTURE: When Xcode 14 is no longer supported (CI is building with Xcode 15), we can remove this override since it's now declared on NSView
-@property (assign) BOOL clipsToBounds;
 @property (nonatomic, strong) RCTUIColor *tintColor;
 @property (nonatomic, assign) UIViewContentMode contentMode;
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Base/macOS/RCTUIKit.m
+++ b/packages/react-native/React/Base/macOS/RCTUIKit.m
@@ -526,20 +526,6 @@ static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
 
 @end
 
-BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
-{
-  // NSViews are always clipped to bounds
-  BOOL clipsToBounds = YES;
-
-  // But see if UIView overrides that behavior
-  if ([view respondsToSelector:@selector(clipsToBounds)])
-  {
-    clipsToBounds = [(id)view clipsToBounds];
-  }
-
-  return clipsToBounds;
-}
-
 @implementation RCTClipView
 
 - (instancetype)initWithFrame:(NSRect)frameRect
@@ -741,16 +727,6 @@ BOOL RCTUIViewSetClipsToBounds(RCTPlatformView *view)
   }
   
   return self;
-}
-
-- (BOOL)clipsToBounds
-{
-  return [[self layer] masksToBounds];
-}
-
-- (void)setClipsToBounds:(BOOL)clipsToBounds
-{
-  [[self layer] setMasksToBounds:clipsToBounds];
 }
 
 - (void)setContentMode:(UIViewContentMode)contentMode

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -55,7 +55,7 @@ const UIAccessibilityTraits SwitchAccessibilityTrait = 0x20000000000001;
   // we do support clipsToBounds, so if that's enabled
   // we'll update the clipping
 
-  if (RCTUIViewSetClipsToBounds(self) && self.subviews.count > 0) { // [macOS]
+  if (self.clipsToBounds && self.subviews.count > 0) {
     clipRect = [clipView convertRect:clipRect toView:self];
     clipRect = CGRectIntersection(clipRect, self.bounds);
     clipView = self;
@@ -77,7 +77,7 @@ const UIAccessibilityTraits SwitchAccessibilityTrait = 0x20000000000001;
   CGRect clipRect = self.bounds;
   // We will only look for a clipping view up the view hierarchy until we hit the root view.
   while (testView) {
-    if (RCTUIViewSetClipsToBounds(testView)) { // [macOS]
+    if (testView.clipsToBounds) {
       if (clipView) {
         CGRect testRect = [clipView convertRect:clipRect toView:testView];
         if (!CGRectContainsRect(testView.bounds, testRect)) {


### PR DESCRIPTION
## Summary:

Back in macOS 13, Apple made a breaking change to NSView (I know, rare) to set the default of `clipsToBounds` from true to false to match iOS. We did some working around of it (See #1864 ). Now that our minimum is above macOS 13, we can remove this property. 

## Test Plan:

Booting paper and fabric seem fine. 
