### PR TITLE
chore(docs): configure prism to style diff blocks

### DIFF
--- a/docsite/docusaurus.config.ts
+++ b/docsite/docusaurus.config.ts
@@ -108,6 +108,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.vsLight,
       darkTheme: prismThemes.vsDark,
+      additionalLanguages: ['diff'],
     },
   } satisfies Preset.ThemeConfig,
 };


### PR DESCRIPTION
## Summary:

In the current docs it's kinda hard to see diffs because there is no styling differenciating additions and removals. This PR fix this by adding diff as an additional language 

## Test Plan:

After: 
<img width="2056" height="1756" alt="image" src="https://github.com/user-attachments/assets/d31c0857-752c-4425-9b27-5c5c4de89a3d" />


Before:
<img width="1012" height="834" alt="image" src="https://github.com/user-attachments/assets/9c39b218-131a-4a3a-84eb-c5ddab6b724c" />

