### PR TITLE
fix: avoid reallocating views on RCTDevLoadingView showMessage calls

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -128,33 +128,21 @@ RCT_EXPORT_MODULE()
     self->_window = [[UIWindow alloc] initWithWindowScene:mainWindow.windowScene];
     self->_window.windowLevel = UIWindowLevelStatusBar + 1;
     self->_window.rootViewController = [UIViewController new];
-#else // [macOS
-    self->_window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 375, 20)
-                                               styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskFullSizeContentView
-                                                 backing:NSBackingStoreBuffered
-                                                   defer:YES];
-    [self->_window setIdentifier:sRCTDevLoadingViewWindowIdentifier];
-#endif // macOS]
 
-    self->_container = [[RCTUIView alloc] init]; // [macOS]
+    self->_container = [[UIView alloc] init];
     self->_container.backgroundColor = backgroundColor;
     self->_container.translatesAutoresizingMaskIntoConstraints = NO;
 
-    self->_label = [[RCTUILabel alloc] init]; // [macOS]
+    self->_label = [[UILabel alloc] init];
     self->_label.translatesAutoresizingMaskIntoConstraints = NO;
     self->_label.font = [UIFont monospacedDigitSystemFontOfSize:12.0 weight:UIFontWeightRegular];
     self->_label.textAlignment = NSTextAlignmentCenter;
     self->_label.textColor = color;
     self->_label.text = message;
 
-#if !TARGET_OS_OSX // [macOS]
     [self->_window.rootViewController.view addSubview:self->_container];
-#else // [macOS
-    [self->_window.contentView addSubview:self->_container];
-#endif // macOS]
     [self->_container addSubview:self->_label];
 
-#if !TARGET_OS_OSX // [macOS]
     CGFloat topSafeAreaHeight = mainWindow.safeAreaInsets.top;
     CGFloat height = topSafeAreaHeight + 25;
     self->_window.frame = CGRectMake(0, 0, mainWindow.frame.size.width, height);
@@ -175,6 +163,31 @@ RCT_EXPORT_MODULE()
       [self->_label.bottomAnchor constraintEqualToAnchor:self->_container.bottomAnchor constant:-5],
     ]];
 #else // [macOS
+    if (!self->_label) {
+      self->_label = [[RCTUILabel alloc] init]; // [macOS]
+      self->_label.translatesAutoresizingMaskIntoConstraints = NO;
+      self->_label.font = [UIFont monospacedDigitSystemFontOfSize:12.0 weight:UIFontWeightRegular];
+      self->_label.textAlignment = NSTextAlignmentCenter;
+    }
+    self->_label.textColor = color;
+    self->_label.text = message;
+
+    if (!self->_container) {
+      self->_container = [[RCTUIView alloc] init]; // [macOS]
+      self->_container.translatesAutoresizingMaskIntoConstraints = NO;
+      [self->_container addSubview:self->_label];
+    }
+    self->_container.backgroundColor = backgroundColor;
+    
+    if (!self->_window) {
+      self->_window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 375, 20)
+                                                styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskFullSizeContentView
+                                                  backing:NSBackingStoreBuffered
+                                                    defer:YES];
+      [self->_window setIdentifier:sRCTDevLoadingViewWindowIdentifier];
+      [self->_window.contentView addSubview:self->_container];
+    }
+    
     // Container constraints
     [NSLayoutConstraint activateConstraints:@[
       [self->_container.topAnchor constraintEqualToAnchor:self->_window.contentView.topAnchor],


### PR DESCRIPTION
This PR is equivalent to the upstream PR https://github.com/facebook/react-native/pull/54608. Actually, the upstream PR is a _little_ different, as I had to handle the new `self->_dismissButton` that was addeed in https://github.com/facebook/react-native/pull/54445 as well. When I came to handle `self->_dismissButton`, I took the opportunity to optimise the `NSConstraintLayout` bit while I was there, so be ready for both of those changes in `react-native-macos@0.84.0`!

## Summary:

As this PR regards the dev loading view, this issue of course affects only **debug** builds. The issue is that, each time a Metro progress update triggers the `showMessage:withColor:withBackgroundColor:` method on `RCTDevLoadingView`, we end up allocating a new `UIWindow` (iOS) or `NSWindow` (macOS), rather than reusing the existing window stored on `self->_window` from any previous progress updates. These unnecessary allocations are particularly expensive on macOS, as I show below.

### Demo of the issue on macOS

On `react-native-macos`, the impact of this issue is dramatic (so much so that **the Microsoft Office team disable `RCTDevLoadingView`** in their Mac app). On the first connection to Metro (as first-time connections can produce nearly 100 progress updates), we end up allocating nearly 100 `NSWindow`s. Allocating `NSWindow`s is so expensive that it blocks the UI thread and **adds 30 seconds to app launch** (see 00:40 -> 01:15 of the below video clip).

What's more, as we can see in the view debugger, these `NSWindow`s **never get released**, so they remain in the view graph and just leak memory (see 01:15 -> 01:30 of the below video clip).

(This clip is from 1:15:00 of a [livestream](https://www.youtube.com/live/amRWVbfbknM?si=KmDBXjrQXdxnmf1E&t=4500) where I dug into this problem – sorry for the poor quality clips, that's the best the servers allow me to download)

https://github.com/user-attachments/assets/65bb7c9b-dc18-4e54-8369-d0c611c59439

## Solution

Each of these views (the window, the container, and the label) need only be allocated once. Thereafter, they can be modified. This PR adds conditionals to lazily-allocate them, and reorders them in order of dependency (e.g. the label is the most nested, so needs to be handled first).

## Changelog:

[MACOS] [FIXED] - Avoid reallocating views on RCTDevLoadingView progress updates

## Test Plan:

I am unable to run `RNTester` on the latest commit of the `main` branch; I've tried [five different versions](https://x.com/birch_js/status/1991129150728642679?s=20) of Ruby, but the `bundle install` always fails. If someone could please guide me how to get RNTester, Ruby, and Bundler happy, I'd be happy to use that app to test it on `main`.

So my testing so far has been based on patching an existing `react-native-macos@0.79.0` app live on stream. This version of React Native macOS has the exact same bug as current `main`, so it should be representative.