### PR TITLE
refactor: introduce `RCTPlatformImage` (1/2)

### DIFF
--- a/packages/react-native/Libraries/Image/RCTAnimatedImage.h
+++ b/packages/react-native/Libraries/Image/RCTAnimatedImage.h
@@ -11,12 +11,12 @@
 @property (nonatomic, assign, readonly) NSUInteger animatedImageFrameCount;
 @property (nonatomic, assign, readonly) NSUInteger animatedImageLoopCount;
 
-- (nullable UIImage *)animatedImageFrameAtIndex:(NSUInteger)index;
+- (nullable RCTPlatformImage *)animatedImageFrameAtIndex:(NSUInteger)index; // [macOS]
 - (NSTimeInterval)animatedImageDurationAtIndex:(NSUInteger)index;
 
 @end
 
-@interface RCTAnimatedImage : UIImage <RCTAnimatedImage>
+@interface RCTAnimatedImage : RCTPlatformImage <RCTAnimatedImage> // [macOS]
 // [macOS
 // This is a known initializer for UIImage, but needs to be exposed publicly for macOS since
 // this is not a known initializer for NSImage

--- a/packages/react-native/Libraries/Image/RCTAnimatedImage.mm
+++ b/packages/react-native/Libraries/Image/RCTAnimatedImage.mm
@@ -148,7 +148,7 @@
   return _frames[index].duration;
 }
 
-- (UIImage *)animatedImageFrameAtIndex:(NSUInteger)index
+- (RCTPlatformImage *)animatedImageFrameAtIndex:(NSUInteger)index // [macOS]
 {
   CGImageRef imageRef = CGImageSourceCreateImageAtIndex(_imageSource, index, NULL);
   if (!imageRef) {
@@ -157,7 +157,7 @@
 #if !TARGET_OS_OSX // [macOS]
   UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:_scale orientation:UIImageOrientationUp];
 #else // [macOS
-  UIImage *image = [[NSImage alloc] initWithCGImage:imageRef size:CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef))];
+  NSImage *image = [[NSImage alloc] initWithCGImage:imageRef size:CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef))];
 #endif // macOS]
   CGImageRelease(imageRef);
   return image;

--- a/packages/react-native/Libraries/Image/RCTBundleAssetImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTBundleAssetImageLoader.mm
@@ -49,7 +49,7 @@ RCT_EXPORT_MODULE()
                                          partialLoadHandler:(RCTImageLoaderPartialLoadBlock)partialLoadHandler
                                           completionHandler:(RCTImageLoaderCompletionBlock)completionHandler
 {
-  UIImage *image = RCTImageFromLocalAssetURL(imageURL);
+  RCTPlatformImage *image = RCTImageFromLocalAssetURL(imageURL); // [macOS]
   if (image) {
     if (progressHandler) {
       progressHandler(1, 1);

--- a/packages/react-native/Libraries/Image/RCTImageBlurUtils.h
+++ b/packages/react-native/Libraries/Image/RCTImageBlurUtils.h
@@ -10,4 +10,4 @@
 
 #import <React/RCTDefines.h>
 
-RCT_EXTERN UIImage *RCTBlurredImageWithRadius(UIImage *inputImage, CGFloat radius);
+RCT_EXTERN RCTPlatformImage *RCTBlurredImageWithRadius(RCTPlatformImage *inputImage, CGFloat radius); // [macOS]

--- a/packages/react-native/Libraries/Image/RCTImageBlurUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageBlurUtils.mm
@@ -10,7 +10,7 @@
 #import <React/RCTUIKit.h> // [macOS]
 #import <React/RCTUtils.h> // [macOS]
 
-UIImage *RCTBlurredImageWithRadius(UIImage *inputImage, CGFloat radius)
+RCTPlatformImage *RCTBlurredImageWithRadius(RCTPlatformImage *inputImage, CGFloat radius) // [macOS]
 {
   CGImageRef imageRef = UIImageGetCGImageRef(inputImage); // [macOS]
   CGFloat imageScale = UIImageGetScale(inputImage); // [macOS]

--- a/packages/react-native/Libraries/Image/RCTImageCache.h
+++ b/packages/react-native/Libraries/Image/RCTImageCache.h
@@ -10,7 +10,7 @@
 
 #import <React/RCTResizeMode.h>
 
-@interface UIImage (React)
+@interface RCTPlatformImage (React) // [macOS]
 
 /**
  * Memory bytes of the image with the default calculation of static image or GIF. Custom calculations of decoded bytes
@@ -25,9 +25,9 @@
  */
 @protocol RCTImageCache <NSObject>
 
-- (UIImage *)imageForUrl:(NSString *)url size:(CGSize)size scale:(CGFloat)scale resizeMode:(RCTResizeMode)resizeMode;
+- (RCTPlatformImage *)imageForUrl:(NSString *)url size:(CGSize)size scale:(CGFloat)scale resizeMode:(RCTResizeMode)resizeMode; // [macOS]
 
-- (void)addImageToCache:(UIImage *)image
+- (void)addImageToCache:(RCTPlatformImage *)image // [macOS]
                     URL:(NSString *)url
                    size:(CGSize)size
                   scale:(CGFloat)scale

--- a/packages/react-native/Libraries/Image/RCTImageCache.mm
+++ b/packages/react-native/Libraries/Image/RCTImageCache.mm
@@ -71,7 +71,7 @@ static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat sc
 }
 #endif // [macOS]
 
-- (void)addImageToCache:(UIImage *)image forKey:(NSString *)cacheKey
+- (void)addImageToCache:(RCTPlatformImage *)image forKey:(NSString *)cacheKey // [macOS]
 {
   if (!image) {
     return;
@@ -82,7 +82,7 @@ static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat sc
   }
 }
 
-- (UIImage *)imageForUrl:(NSString *)url size:(CGSize)size scale:(CGFloat)scale resizeMode:(RCTResizeMode)resizeMode
+- (RCTPlatformImage *)imageForUrl:(NSString *)url size:(CGSize)size scale:(CGFloat)scale resizeMode:(RCTResizeMode)resizeMode // [macOS]
 {
   NSString *cacheKey = RCTCacheKeyForImage(url, size, scale, resizeMode);
   @synchronized(_cacheStaleTimes) {
@@ -99,7 +99,7 @@ static NSString *RCTCacheKeyForImage(NSString *imageTag, CGSize size, CGFloat sc
   return [_decodedImageCache objectForKey:cacheKey];
 }
 
-- (void)addImageToCache:(UIImage *)image
+- (void)addImageToCache:(RCTPlatformImage *)image // [macOS]
                     URL:(NSString *)url
                    size:(CGSize)size
                   scale:(CGFloat)scale

--- a/packages/react-native/Libraries/Image/RCTImageEditingManager.mm
+++ b/packages/react-native/Libraries/Image/RCTImageEditingManager.mm
@@ -60,7 +60,7 @@ RCT_EXPORT_METHOD(cropImage
 
   [[_moduleRegistry moduleForName:"ImageLoader"]
       loadImageWithURLRequest:imageRequest
-                     callback:^(NSError *error, UIImage *image) {
+                     callback:^(NSError *error, RCTPlatformImage *image) { // [macOS]
                        if (error) {
                          errorCallback(@[ RCTJSErrorFromNSError(error) ]);
                          return;
@@ -70,7 +70,7 @@ RCT_EXPORT_METHOD(cropImage
                        CGSize targetSize = rect.size;
                        CGRect targetRect = {{-rect.origin.x, -rect.origin.y}, image.size};
                        CGAffineTransform transform = RCTTransformFromTargetRect(image.size, targetRect);
-                       UIImage *croppedImage = RCTTransformImage(image, targetSize, UIImageGetScale(image), transform); // [macOS]
+                       RCTPlatformImage *croppedImage = RCTTransformImage(image, targetSize, UIImageGetScale(image), transform); // [macOS]
 
                        // Scale image
                        if (cropDataCopy.displaySize()) {

--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -26,7 +26,7 @@
 
 using namespace facebook::react;
 
-static NSInteger RCTImageBytesForImage(UIImage *image)
+static NSInteger RCTImageBytesForImage(RCTPlatformImage *image) // [macOS]
 {
   CGFloat imageScale = 1.0;
 #if !TARGET_OS_OSX // [macOS] no .scale prop on NSImage
@@ -89,7 +89,7 @@ static NSError *addResponseHeadersToError(NSError *originalError, NSHTTPURLRespo
 
 @end
 
-@implementation UIImage (React)
+@implementation RCTPlatformImage (React) // [macOS]
 
 - (NSInteger)reactDecodedImageBytes
 {
@@ -345,7 +345,7 @@ RCT_EXPORT_MODULE()
   return nil;
 }
 
-static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scale, RCTResizeMode resizeMode)
+static RCTPlatformImage *RCTResizeImageIfNeeded(RCTPlatformImage *image, CGSize size, CGFloat scale, RCTResizeMode resizeMode) // [macOS]
 {
   if (CGSizeEqualToSize(size, CGSizeZero) || CGSizeEqualToSize(image.size, CGSizeZero) ||
       CGSizeEqualToSize(image.size, size)) {
@@ -419,7 +419,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
       attribution:{}
       progressBlock:progressBlock
       partialLoadBlock:partialLoadBlock
-      completionBlock:^(NSError *error, UIImage *image, id metadata) {
+      completionBlock:^(NSError *error, RCTPlatformImage *image, id metadata) { // [macOS]
         completionBlock(error, image);
       }];
   return ^{
@@ -555,7 +555,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
   }
 
   if (cacheResult && partialLoadHandler) {
-    UIImage *image = [[self imageCache] imageForUrl:request.URL.absoluteString
+    RCTPlatformImage *image = [[self imageCache] imageForUrl:request.URL.absoluteString // [macOS]
                                                size:size
                                               scale:scale
                                          resizeMode:resizeMode];
@@ -577,7 +577,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
 
         // If we've received an image, we should try to set it synchronously,
         // if it's data, do decoding on a background thread.
-        if (RCTIsMainQueue() && ![imageOrData isKindOfClass:[UIImage class]]) {
+        if (RCTIsMainQueue() && ![imageOrData isKindOfClass:[RCTPlatformImage class]]) { // [macOS]
           // Most loaders do not return on the main thread, so caller is probably not
           // expecting it, and may do expensive post-processing in the callback
           dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
@@ -608,7 +608,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
                  attribution:attributionCopy
              progressHandler:progressHandler
           partialLoadHandler:partialLoadHandler
-           completionHandler:^(NSError *error, UIImage *image, id metadata) {
+           completionHandler:^(NSError *error, RCTPlatformImage *image, id metadata) { // [macOS]
              completionHandler(error, image, metadata, nil);
            }];
     }
@@ -618,7 +618,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
                                                            resizeMode:resizeMode
                                                       progressHandler:progressHandler
                                                    partialLoadHandler:partialLoadHandler
-                                                    completionHandler:^(NSError *error, UIImage *image) {
+                                                    completionHandler:^(NSError *error, RCTPlatformImage *image) { // [macOS]
                                                       completionHandler(error, image, nil, nil);
                                                     }];
     return [[RCTImageURLLoaderRequest alloc] initWithRequestId:nil imageURL:request.URL cancellationBlock:cb];
@@ -649,7 +649,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
                    attribution:attributionCopy
                progressHandler:progressHandler
             partialLoadHandler:partialLoadHandler
-             completionHandler:^(NSError *error, UIImage *image, id metadata) {
+             completionHandler:^(NSError *error, RCTPlatformImage *image, id metadata) { // [macOS]
                completionHandler(error, image, metadata, nil);
              }];
         cancelLoadLocal = loaderRequest.cancellationBlock;
@@ -660,7 +660,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
                                             resizeMode:resizeMode
                                        progressHandler:progressHandler
                                     partialLoadHandler:partialLoadHandler
-                                     completionHandler:^(NSError *error, UIImage *image) {
+                                     completionHandler:^(NSError *error, RCTPlatformImage *image) { // [macOS]
                                        completionHandler(error, image, nil, nil);
                                      }];
       }
@@ -668,7 +668,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
       cancelLoad = cancelLoadLocal;
       [cancelLoadLock unlock];
     } else {
-      UIImage *image;
+      RCTPlatformImage *image; // [macOS]
       if (cacheResult) {
         image = [[strongSelf imageCache] imageForUrl:request.URL.absoluteString
                                                 size:size
@@ -858,7 +858,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
           return;
         }
 
-        if (!imageOrData || [imageOrData isKindOfClass:[UIImage class]]) {
+        if (!imageOrData || [imageOrData isKindOfClass:[RCTPlatformImage class]]) { // [macOS]
           [cancelLoadLock lock];
           cancelLoad = nil;
           [cancelLoadLock unlock];
@@ -866,7 +866,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
           return;
         }
 
-        RCTImageLoaderCompletionBlock decodeCompletionHandler = ^(NSError *error_, UIImage *image) {
+        RCTImageLoaderCompletionBlock decodeCompletionHandler = ^(NSError *error_, RCTPlatformImage *image) { // [macOS]
           if (cacheResult && image) {
             // Store decoded image in cache
             [[strongSelf imageCache] addImageToCache:image
@@ -971,7 +971,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
   }
 
   auto cancelled = std::make_shared<std::atomic<int>>(0);
-  void (^completionHandler)(NSError *, UIImage *) = ^(NSError *error, UIImage *image) {
+  void (^completionHandler)(NSError *, RCTPlatformImage *) = ^(NSError *error, RCTPlatformImage *image) { // [macOS]
     if (RCTIsMainQueue()) {
       // Most loaders do not return on the main thread, so caller is probably not
       // expecting it, and may do expensive post-processing in the callback
@@ -1006,7 +1006,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
       dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         if (!std::atomic_load(cancelled.get())) {
           // Decompress the image data (this may be CPU and memory intensive)
-          UIImage *image = RCTDecodeImageWithData(data, size, scale, resizeMode);
+          RCTPlatformImage *image = RCTDecodeImageWithData(data, size, scale, resizeMode); // [macOS]
 
 #if !TARGET_OS_OSX && RCT_DEV // [macOS]
           CGSize imagePixelSize = RCTSizeInPixels(image.size, UIImageGetScale(image)); // [macOS]
@@ -1101,7 +1101,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
               break;
           }
         } else {
-          UIImage *image = imageOrData;
+          RCTPlatformImage *image = imageOrData; // [macOS]
 #if !TARGET_OS_OSX // [macOS]
           CGFloat imageScale = image.scale;
 #else // [macOS
@@ -1195,7 +1195,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
 {
   __block RCTImageLoaderCancellationBlock requestToken;
   requestToken = [self loadImageWithURLRequest:request
-                                      callback:^(NSError *error, UIImage *image) {
+                                      callback:^(NSError *error, RCTPlatformImage *image) { // [macOS]
                                         if (error) {
                                           [delegate URLRequest:requestToken didCompleteWithError:error];
                                           return;
@@ -1305,7 +1305,7 @@ RCT_EXPORT_METHOD(prefetchImageWithMetadata
                                 }
                   progressBlock:nil
                partialLoadBlock:nil
-                completionBlock:^(NSError *error, UIImage *image, id completionMetadata) {
+                completionBlock:^(NSError *error, RCTPlatformImage *image, id completionMetadata) { // [macOS]
                   if (error) {
                     reject(@"E_PREFETCH_FAILURE", nil, error);
                     return;

--- a/packages/react-native/Libraries/Image/RCTImageStoreManager.h
+++ b/packages/react-native/Libraries/Image/RCTImageStoreManager.h
@@ -27,7 +27,7 @@ RCT_EXTERN void RCTEnableImageStoreManagerStorageQueue(BOOL enabled);
  * Convenience method to store an image directly (image is converted to data
  * internally, so any metadata such as scale or orientation will be lost).
  */
-- (void)storeImage:(UIImage *)image withBlock:(void (^)(NSString *imageTag))block;
+- (void)storeImage:(RCTPlatformImage *)image withBlock:(void (^)(NSString *imageTag))block; // [macOS]
 
 @end
 
@@ -36,9 +36,9 @@ RCT_EXTERN void RCTEnableImageStoreManagerStorageQueue(BOOL enabled);
 /**
  * These methods are deprecated - use the data-based alternatives instead.
  */
-- (NSString *)storeImage:(UIImage *)image __deprecated;
-- (UIImage *)imageForTag:(NSString *)imageTag __deprecated;
-- (void)getImageForTag:(NSString *)imageTag withBlock:(void (^)(UIImage *image))block __deprecated;
+- (NSString *)storeImage:(RCTPlatformImage *)image __deprecated; // [macOS]
+- (RCTPlatformImage *)imageForTag:(NSString *)imageTag __deprecated; // [macOS]
+- (void)getImageForTag:(NSString *)imageTag withBlock:(void (^)(RCTPlatformImage *image))block __deprecated; // [macOS]
 
 @end
 

--- a/packages/react-native/Libraries/Image/RCTImageStoreManager.mm
+++ b/packages/react-native/Libraries/Image/RCTImageStoreManager.mm
@@ -108,7 +108,7 @@ RCT_EXPORT_MODULE()
   });
 }
 
-- (void)storeImage:(UIImage *)image withBlock:(void (^)(NSString *imageTag))block
+- (void)storeImage:(RCTPlatformImage *)image withBlock:(void (^)(NSString *imageTag))block // [macOS]
 {
   RCTAssertParam(block);
   dispatch_async([self _getAsyncQueue], ^{
@@ -236,7 +236,7 @@ RCT_EXPORT_METHOD(addImageFromBase64
 
 @implementation RCTImageStoreManager (Deprecated)
 
-- (NSString *)storeImage:(UIImage *)image
+- (NSString *)storeImage:(RCTPlatformImage *)image // [macOS]
 {
   RCTAssertMainQueue();
   RCTLogWarn(
@@ -248,7 +248,7 @@ RCT_EXPORT_METHOD(addImageFromBase64
   return imageTag;
 }
 
-- (UIImage *)imageForTag:(NSString *)imageTag
+- (RCTPlatformImage *)imageForTag:(NSString *)imageTag // [macOS]
 {
   RCTAssertMainQueue();
   RCTLogWarn(
@@ -260,7 +260,7 @@ RCT_EXPORT_METHOD(addImageFromBase64
   return UIImageWithData(imageData); // [macOS]
 }
 
-- (void)getImageForTag:(NSString *)imageTag withBlock:(void (^)(UIImage *image))block
+- (void)getImageForTag:(NSString *)imageTag withBlock:(void (^)(RCTPlatformImage *image))block // [macOS]
 {
   RCTAssertParam(block);
   dispatch_async([self _getAsyncQueue], ^{

--- a/packages/react-native/Libraries/Image/RCTImageURLLoader.h
+++ b/packages/react-native/Libraries/Image/RCTImageURLLoader.h
@@ -13,13 +13,13 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^RCTImageLoaderProgressBlock)(int64_t progress, int64_t total);
-typedef void (^RCTImageLoaderPartialLoadBlock)(UIImage *image);
-typedef void (^RCTImageLoaderCompletionBlock)(NSError *_Nullable error, UIImage *_Nullable image);
+typedef void (^RCTImageLoaderPartialLoadBlock)(RCTPlatformImage *image); // [macOS]
+typedef void (^RCTImageLoaderCompletionBlock)(NSError *_Nullable error, RCTPlatformImage *_Nullable image); // [macOS]
 // Metadata is passed as a id in an additional parameter because there are forks of RN without this parameter,
 // and the complexity of RCTImageLoader would make using protocols here difficult to typecheck.
 typedef void (^RCTImageLoaderCompletionBlockWithMetadata)(
     NSError *_Nullable error,
-    UIImage *_Nullable image,
+    RCTPlatformImage *_Nullable image, // [macOS]
     id _Nullable metadata);
 typedef dispatch_block_t RCTImageLoaderCancellationBlock;
 

--- a/packages/react-native/Libraries/Image/RCTImageUtils.h
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.h
@@ -60,7 +60,7 @@ RCT_EXTERN BOOL RCTUpscalingRequired(
  * width/height of the returned image is guaranteed to be >= destSize.
  * Pass a destSize of CGSizeZero to decode the image at its original size.
  */
-RCT_EXTERN UIImage *__nullable
+RCT_EXTERN RCTPlatformImage *__nullable // [macOS]
 RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode);
 
 /**
@@ -76,15 +76,15 @@ RCT_EXTERN NSDictionary<NSString *, id> *__nullable RCTGetImageMetadata(NSData *
  * conversion, with 1.0 being maximum quality. It has no effect for images
  * using PNG compression.
  */
-RCT_EXTERN NSData *__nullable RCTGetImageData(UIImage *image, float quality);
+RCT_EXTERN NSData *__nullable RCTGetImageData(RCTPlatformImage *image, float quality); // [macOS]
 
 /**
  * This function transforms an image. `destSize` is the size of the final image,
  * and `destScale` is its scale. The `transform` argument controls how the
  * source image will be mapped to the destination image.
  */
-RCT_EXTERN UIImage *__nullable
-RCTTransformImage(UIImage *image, CGSize destSize, CGFloat destScale, CGAffineTransform transform);
+RCT_EXTERN RCTPlatformImage *__nullable // [macOS]
+RCTTransformImage(RCTPlatformImage *image, CGSize destSize, CGFloat destScale, CGAffineTransform transform); // [macOS]
 
 /*
  * Return YES if image has an alpha component
@@ -94,6 +94,6 @@ RCT_EXTERN BOOL RCTImageHasAlpha(CGImageRef image);
 /*
  * Return YES if image has an alpha component
  */
-RCT_EXTERN BOOL RCTUIImageHasAlpha(UIImage *image); // [macOS]
+RCT_EXTERN BOOL RCTUIImageHasAlpha(RCTPlatformImage *image); // [macOS]
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -260,7 +260,7 @@ BOOL RCTUpscalingRequired(
   }
 }
 
-UIImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode)
+RCTPlatformImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode) // [macOS]
 {
   CGImageSourceRef sourceRef = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
   if (!sourceRef) {
@@ -338,7 +338,7 @@ NSDictionary<NSString *, id> *__nullable RCTGetImageMetadata(NSData *data)
   return (__bridge_transfer id)imageProperties;
 }
 
-NSData *__nullable RCTGetImageData(UIImage *image, float quality)
+NSData *__nullable RCTGetImageData(RCTPlatformImage *image, float quality) // [macOS]
 {
 #if !TARGET_OS_OSX // [macOS]
   CGImageRef cgImage = image.CGImage;
@@ -377,7 +377,7 @@ NSData *__nullable RCTGetImageData(UIImage *image, float quality)
   return (__bridge_transfer NSData *)imageData;
 }
 
-UIImage *__nullable RCTTransformImage(UIImage *image, CGSize destSize, CGFloat destScale, CGAffineTransform transform)
+RCTPlatformImage *__nullable RCTTransformImage(RCTPlatformImage *image, CGSize destSize, CGFloat destScale, CGAffineTransform transform) // [macOS]
 {
   if (destSize.width <= 0 | destSize.height <= 0 || destScale <= 0) {
     return nil;
@@ -417,7 +417,7 @@ BOOL RCTUIImageHasAlpha(UIImage *image)
   return RCTImageHasAlpha(image.CGImage);
 }
 #else // [macOS
-BOOL RCTUIImageHasAlpha(UIImage *image)
+BOOL RCTUIImageHasAlpha(NSImage *image)
 {
   for (NSImageRep *imageRep in image.representations) {
     if (imageRep.hasAlpha) {

--- a/packages/react-native/Libraries/Image/RCTImageView.h
+++ b/packages/react-native/Libraries/Image/RCTImageView.h
@@ -17,7 +17,7 @@
 - (instancetype)initWithBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, assign) UIEdgeInsets capInsets;
-@property (nonatomic, strong) UIImage *defaultImage;
+@property (nonatomic, strong) RCTPlatformImage *defaultImage; // [macOS]
 @property (nonatomic, assign) UIImageRenderingMode renderingMode;
 @property (nonatomic, copy) NSArray<RCTImageSource *> *imageSources;
 @property (nonatomic, assign) CGFloat blurRadius;

--- a/packages/react-native/Libraries/Image/RCTImageView.mm
+++ b/packages/react-native/Libraries/Image/RCTImageView.mm
@@ -127,7 +127,7 @@ static NSDictionary *onLoadParamsForSource(RCTImageSource *source)
   // Whether the latest change of props requires the image to be reloaded
   BOOL _needsReload;
 
-  UIImage *_image; // [macOS]
+  RCTPlatformImage *_image; // [macOS]
 
   RCTUIImageViewAnimated *_imageView;
 
@@ -175,7 +175,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 
 RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 
-- (void)updateWithImage:(UIImage *)image
+- (void)updateWithImage:(RCTPlatformImage *)image // [macOS]
 {
   if (!image) {
     _imageView.image = nil;
@@ -223,7 +223,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   _imageView.image = image;
 }
 
-- (void)setImage:(UIImage *)image
+- (void)setImage:(RCTPlatformImage *)image // [macOS]
 {
   image = image ?: _defaultImage;
   if (image != self.image) {
@@ -232,7 +232,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   }
 }
 
-- (UIImage *)image
+- (RCTPlatformImage *)image // [macOS]
 {
   return _image ?: _imageView.image; // [macOS]
 }
@@ -421,7 +421,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
     }
 
     __weak RCTImageView *weakSelf = self;
-    RCTImageLoaderPartialLoadBlock partialLoadHandler = ^(UIImage *image) {
+    RCTImageLoaderPartialLoadBlock partialLoadHandler = ^(RCTPlatformImage *image) { // [macOS]
       [weakSelf imageLoaderLoadedImage:image error:nil forImageSource:source partial:YES];
     };
 
@@ -437,7 +437,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
       imageScale = source.scale;
     }
 
-    RCTImageLoaderCompletionBlockWithMetadata completionHandler = ^(NSError *error, UIImage *loadedImage, id metadata) {
+    RCTImageLoaderCompletionBlockWithMetadata completionHandler = ^(NSError *error, RCTPlatformImage *loadedImage, id metadata) { // [macOS]
       [weakSelf imageLoaderLoadedImage:loadedImage error:error forImageSource:source partial:NO];
     };
 
@@ -464,7 +464,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   }
 }
 
-- (void)imageLoaderLoadedImage:(UIImage *)loadedImage
+- (void)imageLoaderLoadedImage:(RCTPlatformImage *)loadedImage // [macOS]
                          error:(NSError *)error
                 forImageSource:(RCTImageSource *)source
                        partial:(BOOL)isPartialLoad
@@ -494,7 +494,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   }
 
   __weak RCTImageView *weakSelf = self;
-  void (^setImageBlock)(UIImage *) = ^(UIImage *image) {
+  void (^setImageBlock)(RCTPlatformImage *) = ^(RCTPlatformImage *image) { // [macOS]
     RCTImageView *strongSelf = weakSelf;
     if (!strongSelf) {
       return;
@@ -525,7 +525,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
     // Blur on a background thread to avoid blocking interaction
     CGFloat blurRadius = self.blurRadius;
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-      UIImage *blurredImage = RCTBlurredImageWithRadius(loadedImage, blurRadius);
+      RCTPlatformImage *blurredImage = RCTBlurredImageWithRadius(loadedImage, blurRadius); // [macOS]
       RCTExecuteOnMainQueue(^{
         setImageBlock(blurredImage);
       });

--- a/packages/react-native/Libraries/Image/RCTImageViewManager.mm
+++ b/packages/react-native/Libraries/Image/RCTImageViewManager.mm
@@ -100,7 +100,7 @@ RCT_EXPORT_METHOD(prefetchImage
                                                                             lazilyLoadIfNecessary:YES];
   [imageLoader loadImageWithURLRequest:request
                               priority:RCTImageLoaderPriorityPrefetch
-                              callback:^(NSError *error, UIImage *image) {
+                              callback:^(NSError *error, RCTPlatformImage *image) { // [macOS]
                                 if (error) {
                                   reject(@"E_PREFETCH_FAILURE", nil, error);
                                   return;

--- a/packages/react-native/Libraries/Image/RCTLocalAssetImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTLocalAssetImageLoader.mm
@@ -49,7 +49,7 @@ RCT_EXPORT_MODULE()
                                          partialLoadHandler:(RCTImageLoaderPartialLoadBlock)partialLoadHandler
                                           completionHandler:(RCTImageLoaderCompletionBlock)completionHandler
 {
-  UIImage *image = RCTImageFromLocalAssetURL(imageURL);
+  RCTPlatformImage *image = RCTImageFromLocalAssetURL(imageURL); // [macOS]
   if (image) {
     if (progressHandler) {
       progressHandler(1, 1);

--- a/packages/react-native/Libraries/Image/RCTUIImageViewAnimated.mm
+++ b/packages/react-native/Libraries/Image/RCTUIImageViewAnimated.mm
@@ -35,13 +35,13 @@ static NSUInteger RCTDeviceFreeMemory(void)
 @interface RCTUIImageViewAnimated () <CALayerDelegate, RCTDisplayRefreshable>
 
 @property (nonatomic, assign) NSUInteger maxBufferSize;
-@property (nonatomic, strong, readwrite) UIImage *currentFrame;
+@property (nonatomic, strong, readwrite) RCTPlatformImage *currentFrame; // [macOS]
 @property (nonatomic, assign, readwrite) NSUInteger currentFrameIndex;
 @property (nonatomic, assign, readwrite) NSUInteger currentLoopCount;
 @property (nonatomic, assign) NSUInteger totalFrameCount;
 @property (nonatomic, assign) NSUInteger totalLoopCount;
-@property (nonatomic, strong) UIImage<RCTAnimatedImage> *animatedImage;
-@property (nonatomic, strong) NSMutableDictionary<NSNumber *, UIImage *> *frameBuffer;
+@property (nonatomic, strong) RCTPlatformImage<RCTAnimatedImage> *animatedImage; // [macOS]
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, RCTPlatformImage *> *frameBuffer; // [macOS]
 @property (nonatomic, assign) NSTimeInterval currentTime;
 @property (nonatomic, assign) BOOL bufferMiss;
 @property (nonatomic, assign) NSUInteger maxBufferCount;
@@ -90,7 +90,7 @@ static NSUInteger RCTDeviceFreeMemory(void)
   dispatch_semaphore_signal(self.lock);
 }
 
-- (void)setImage:(UIImage *)image
+- (void)setImage:(RCTPlatformImage *)image // [macOS]
 {
   if (self.image == image) {
     return;
@@ -150,7 +150,7 @@ static NSUInteger RCTDeviceFreeMemory(void)
   return _fetchQueue;
 }
 
-- (NSMutableDictionary<NSNumber *, UIImage *> *)frameBuffer
+- (NSMutableDictionary<NSNumber *, RCTPlatformImage *> *)frameBuffer // [macOS]
 {
   if (!_frameBuffer) {
     _frameBuffer = [NSMutableDictionary dictionary];

--- a/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm
@@ -169,10 +169,10 @@
 
 - (NSAttributedString *)attributedTextWithMeasuredAttachmentsThatFitSize:(CGSize)size
 {
-  static UIImage *placeholderImage;
+  static RCTPlatformImage *placeholderImage; // [macOS]
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    placeholderImage = [UIImage new];
+    placeholderImage = [RCTPlatformImage new]; // [macOS]
   });
 
   NSMutableAttributedString *attributedText =

--- a/packages/react-native/React/Base/RCTConvert.h
+++ b/packages/react-native/React/Base/RCTConvert.h
@@ -186,7 +186,7 @@ typedef NSArray UIColorArray __deprecated_msg("Use NSArray<UIColor *>");
  * If you need to pass image references, try to use `RCTImageSource` and then
  * `RCTImageLoader` instead of converting directly to a UIImage.
  */
-+ (UIImage *)UIImage:(id)json;
++ (RCTPlatformImage *)UIImage:(id)json; // [macOS]
 + (CGImageRef)CGImage:(id)json CF_RETURNS_NOT_RETAINED;
 
 @end

--- a/packages/react-native/React/Base/RCTConvert.mm
+++ b/packages/react-native/React/Base/RCTConvert.mm
@@ -1713,7 +1713,7 @@ RCT_ARRAY_CONVERTER(RCTHandledKey);
 @implementation RCTConvert (Deprecated)
 
 /* This method is only used when loading images synchronously, e.g. for tabbar icons */
-+ (UIImage *)UIImage:(id)json
++ (RCTPlatformImage *)UIImage:(id)json // [macOS]
 {
   if (!json) {
     return nil;
@@ -1724,7 +1724,7 @@ RCT_ARRAY_CONVERTER(RCTHandledKey);
     return nil;
   }
 
-  __block UIImage *image;
+  __block RCTPlatformImage *image; // [macOS]
   if (!RCTIsMainQueue()) {
     // It seems that none of the UIImage loading methods can be guaranteed
     // thread safe, so we'll pick the lesser of two evils here and block rather

--- a/packages/react-native/React/Base/RCTUIKit.h
+++ b/packages/react-native/React/Base/RCTUIKit.h
@@ -59,6 +59,8 @@ UIKIT_STATIC_INLINE void UIBezierPathAppendPath(UIBezierPath *path, UIBezierPath
 #define RCTPlatformView UIView
 #define RCTUIView UIView
 #define RCTUIScrollView UIScrollView
+#define RCTPlatformImage UIImage
+
 
 UIKIT_STATIC_INLINE RCTPlatformView *RCTUIViewHitTestWithEvent(RCTPlatformView *view, CGPoint point, __unused UIEvent *__nullable event)
 {
@@ -113,6 +115,8 @@ NS_ASSUME_NONNULL_END
 #import <AppKit/AppKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
+#define RCTPlatformImage NSImage
 
 //
 // semantically equivalent constants
@@ -330,8 +334,6 @@ NS_INLINE NSEdgeInsets UIEdgeInsetsMake(CGFloat top, CGFloat left, CGFloat botto
 #define UIApplication NSApplication
 
 // UIImage
-@compatibility_alias UIImage NSImage;
-
 typedef NS_ENUM(NSInteger, UIImageRenderingMode) {
     UIImageRenderingModeAlwaysOriginal,
     UIImageRenderingModeAlwaysTemplate,
@@ -344,12 +346,12 @@ CGFloat UIImageGetScale(NSImage *image);
 
 CGImageRef UIImageGetCGImageRef(NSImage *image);
 
-NS_INLINE UIImage *UIImageWithContentsOfFile(NSString *filePath)
+NS_INLINE NSImage *UIImageWithContentsOfFile(NSString *filePath)
 {
   return [[NSImage alloc] initWithContentsOfFile:filePath];
 }
 
-NS_INLINE UIImage *UIImageWithData(NSData *imageData)
+NS_INLINE NSImage *UIImageWithData(NSData *imageData)
 {
   return [[NSImage alloc] initWithData:imageData];
 }

--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -162,12 +162,12 @@ RCT_EXTERN BOOL RCTIsLocalAssetURL(NSURL *__nullable imageURL);
 
 // Returns an UIImage for a local image asset. Returns nil if the URL
 // does not correspond to a local asset.
-RCT_EXTERN UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL);
+RCT_EXTERN RCTPlatformImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL); // [macOS]
 
 // Only used in case when RCTImageFromLocalAssetURL fails to get an image
 // This method basically checks for the image in the bundle location, instead
 // of the CodePush location
-RCT_EXTERN UIImage *__nullable RCTImageFromLocalBundleAssetURL(NSURL *imageURL);
+RCT_EXTERN RCTPlatformImage *__nullable RCTImageFromLocalBundleAssetURL(NSURL *imageURL); // [macOS]
 
 // Creates a new, unique temporary file path with the specified extension
 RCT_EXTERN NSString *__nullable RCTTempFilePath(NSString *__nullable extension, NSError **error);

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -874,7 +874,7 @@ static NSBundle *bundleForPath(NSString *key)
   return bundleCache[key];
 }
 
-UIImage *__nullable RCTImageFromLocalBundleAssetURL(NSURL *imageURL)
+RCTPlatformImage *__nullable RCTImageFromLocalBundleAssetURL(NSURL *imageURL) // [macOS]
 {
   if (![imageURL.scheme isEqualToString:@"file"]) {
     // We only want to check for local file assets
@@ -889,7 +889,7 @@ UIImage *__nullable RCTImageFromLocalBundleAssetURL(NSURL *imageURL)
 }
 
 #if TARGET_OS_OSX // [macOS
-static NSCache<NSURL *, UIImage *> *RCTLocalImageCache(void)
+static NSCache<NSURL *, RCTPlatformImage *> *RCTLocalImageCache(void) // [macOS]
 {
   static NSCache *imageCache;
   static dispatch_once_t onceToken;
@@ -901,13 +901,13 @@ static NSCache<NSURL *, UIImage *> *RCTLocalImageCache(void)
 }
 #endif // macOS]
 
-UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL)
+RCTPlatformImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL) // [macOS]
 {
   NSString *imageName = RCTBundlePathForURL(imageURL);
 #if TARGET_OS_OSX // [macOS
   NSURL *bundleImageURL = nil;
 
-  UIImage *cachedImage = [RCTLocalImageCache() objectForKey:imageURL];
+  RCTPlatformImage *cachedImage = [RCTLocalImageCache() objectForKey:imageURL]; // [macOS]
   if (cachedImage) {
     return cachedImage;
   }
@@ -939,7 +939,7 @@ UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL)
   imageName = [imageName stringByDeletingPathExtension];
 #endif // macOS]
 
-  UIImage *image = nil;
+  RCTPlatformImage *image = nil; // [macOS]
   if (imageName) {
     if (bundle) {
 #if !TARGET_OS_OSX // [macOS]
@@ -948,7 +948,7 @@ UIImage *__nullable RCTImageFromLocalAssetURL(NSURL *imageURL)
       image = (bundleImageURL == nil) ? [bundle imageForResource:imageName] : [[NSImage alloc] initWithContentsOfURL:bundleImageURL];
 #endif // macOS]
     } else {
-      image = [UIImage imageNamed:imageName];
+      image = [RCTPlatformImage imageNamed:imageName]; // [macOS]
     }
   }
 

--- a/packages/react-native/React/Base/macOS/RCTUIKit.m
+++ b/packages/react-native/React/Base/macOS/RCTUIKit.m
@@ -756,12 +756,12 @@ static RCTUIView *RCTUIViewCommonInit(RCTUIView *self)
   }
 }
 
-- (UIImage *)image
+- (RCTPlatformImage *)image
 {
   return [[self layer] contents];
 }
 
-- (void)setImage:(UIImage *)image
+- (void)setImage:(RCTPlatformImage *)image
 {
   CALayer *layer = [self layer];
   

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -119,7 +119,7 @@ using namespace facebook::react;
 
 #pragma mark - RCTImageResponseDelegate
 
-- (void)didReceiveImage:(UIImage *)image metadata:(id)metadata fromObserver:(const void *)observer
+- (void)didReceiveImage:(RCTPlatformImage *)image metadata:(id)metadata fromObserver:(const void *)observer // [macOS]
 {
   if (!_eventEmitter || !_state) {
     // Notifications are delivered asynchronously and might arrive after the view is already recycled.
@@ -160,7 +160,7 @@ using namespace facebook::react;
     // Blur on a background thread to avoid blocking interaction.
     CGFloat blurRadius = imageProps.blurRadius;
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-      UIImage *blurredImage = RCTBlurredImageWithRadius(image, blurRadius);
+      RCTPlatformImage *blurredImage = RCTBlurredImageWithRadius(image, blurRadius); // [macOS]
       RCTExecuteOnMainQueue(^{
         self->_imageView.image = blurredImage;
       });

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -839,7 +839,7 @@ static void RCTAddContourEffectToLayer(
     const UIEdgeInsets &contourInsets,
     const RCTBorderStyle &contourStyle)
 {
-  UIImage *image = RCTGetBorderImage(
+  RCTPlatformImage *image = RCTGetBorderImage( // [macOS]
       contourStyle, layer.bounds.size, cornerRadii, contourInsets, contourColors, [RCTUIColor clearColor], NO); // [macOS]
 
   if (image == nil) {
@@ -1292,7 +1292,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     _boxShadowLayer.zPosition = _borderLayer.zPosition;
     _boxShadowLayer.frame = RCTGetBoundingRect(_props->boxShadow, self.layer.bounds.size);
 
-    UIImage *boxShadowImage = RCTGetBoxShadowImage(
+    RCTPlatformImage *boxShadowImage = RCTGetBoxShadowImage( // [macOS]
         _props->boxShadow,
         RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),
         RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths),

--- a/packages/react-native/React/Fabric/RCTImageResponseDelegate.h
+++ b/packages/react-native/React/Fabric/RCTImageResponseDelegate.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol RCTImageResponseDelegate <NSObject>
 
-- (void)didReceiveImage:(UIImage *)image metadata:(id)metadata fromObserver:(const void *)observer;
+- (void)didReceiveImage:(RCTPlatformImage *)image metadata:(id)metadata fromObserver:(const void *)observer; // [macOS]
 - (void)didReceiveProgress:(float)progress
                     loaded:(int64_t)loaded
                      total:(int64_t)total

--- a/packages/react-native/React/Fabric/RCTImageResponseObserverProxy.mm
+++ b/packages/react-native/React/Fabric/RCTImageResponseObserverProxy.mm
@@ -21,7 +21,7 @@ RCTImageResponseObserverProxy::RCTImageResponseObserverProxy(id<RCTImageResponse
 
 void RCTImageResponseObserverProxy::didReceiveImage(const ImageResponse &imageResponse) const
 {
-  UIImage *image = (UIImage *)unwrapManagedObject(imageResponse.getImage());
+  RCTPlatformImage *image = (RCTPlatformImage *)unwrapManagedObject(imageResponse.getImage()); // [macOS]
   id metadata = unwrapManagedObject(imageResponse.getMetadata());
   id<RCTImageResponseDelegate> delegate = delegate_;
   auto this_ = this;

--- a/packages/react-native/React/Fabric/Utils/RCTBoxShadow.h
+++ b/packages/react-native/React/Fabric/Utils/RCTBoxShadow.h
@@ -12,7 +12,7 @@
 #import <React/RCTUIKit.h>
 #import <react/renderer/graphics/BoxShadow.h>
 
-RCT_EXTERN UIImage *RCTGetBoxShadowImage(
+RCT_EXTERN RCTPlatformImage *RCTGetBoxShadowImage( // [macOS]
     const std::vector<facebook::react::BoxShadow> &shadows,
     RCTCornerRadii cornerRadii,
     UIEdgeInsets edgeInsets,

--- a/packages/react-native/React/Fabric/Utils/RCTBoxShadow.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTBoxShadow.mm
@@ -281,7 +281,7 @@ static void renderInsetShadows(
   CGContextRestoreGState(context);
 }
 
-UIImage *RCTGetBoxShadowImage(
+RCTPlatformImage *RCTGetBoxShadowImage( // [macOS]
     const std::vector<BoxShadow> &shadows,
     RCTCornerRadii cornerRadii,
     UIEdgeInsets edgeInsets,
@@ -293,7 +293,7 @@ UIImage *RCTGetBoxShadowImage(
   RCTUIGraphicsImageRenderer *const renderer = [[RCTUIGraphicsImageRenderer alloc] initWithSize:boundingRect.size
                                                                                    format:rendererFormat];
   // macOS]
-  UIImage *const boxShadowImage =
+  RCTPlatformImage *const boxShadowImage = // [macOS]
       [renderer imageWithActions:^(RCTUIGraphicsImageRendererContext *_Nonnull rendererContext) { // [macOS]
         auto [outsetShadows, insetShadows] = splitBoxShadowsByInset(shadows);
         const CGContextRef context = rendererContext.CGContext;

--- a/packages/react-native/React/Fabric/Utils/RCTLinearGradient.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTLinearGradient.mm
@@ -20,7 +20,7 @@ using namespace facebook::react;
 {
   RCTUIGraphicsImageRenderer *renderer = [[RCTUIGraphicsImageRenderer alloc] initWithSize:size]; // [macOS]
   const auto &direction = gradient.direction;
-  UIImage *gradientImage = [renderer imageWithActions:^(RCTUIGraphicsImageRendererContext *_Nonnull rendererContext) { // [macOS]
+  RCTPlatformImage *gradientImage = [renderer imageWithActions:^(RCTUIGraphicsImageRendererContext *_Nonnull rendererContext) { // [macOS]
     CGPoint startPoint;
     CGPoint endPoint;
 

--- a/packages/react-native/React/Views/RCTBorderDrawing.h
+++ b/packages/react-native/React/Views/RCTBorderDrawing.h
@@ -62,7 +62,7 @@ RCTPathCreateWithRoundedRect(CGRect bounds, RCTCornerInsets cornerInsets, const 
  * `borderInsets` defines the border widths for each edge.
  * `scaleFactor` defines the backing scale factor of the device for supporting high-resolution drawing. // [macOS]
  */
-RCT_EXTERN UIImage *RCTGetBorderImage(
+RCT_EXTERN RCTPlatformImage *RCTGetBorderImage( // [macOS]
     RCTBorderStyle borderStyle,
     CGSize viewSize,
     RCTCornerRadii cornerRadii,

--- a/packages/react-native/React/Views/RCTBorderDrawing.m
+++ b/packages/react-native/React/Views/RCTBorderDrawing.m
@@ -191,7 +191,7 @@ RCTMakeUIGraphicsImageRenderer(CGSize size, RCTUIColor *backgroundColor, BOOL ha
   return renderer;
 }
 
-static UIImage *RCTGetSolidBorderImage(
+static RCTPlatformImage *RCTGetSolidBorderImage( // [macOS]
     RCTCornerRadii cornerRadii,
     CGSize viewSize,
     UIEdgeInsets borderInsets,
@@ -231,7 +231,7 @@ static UIImage *RCTGetSolidBorderImage(
 
   RCTUIGraphicsImageRenderer *const imageRenderer =
       RCTMakeUIGraphicsImageRenderer(size, backgroundColor, hasCornerRadii, drawToEdge);
-  UIImage *image = [imageRenderer imageWithActions:^(RCTUIGraphicsImageRendererContext *_Nonnull rendererContext) { // [macOS]
+  RCTPlatformImage *image = [imageRenderer imageWithActions:^(RCTUIGraphicsImageRendererContext *_Nonnull rendererContext) { // [macOS]
     const CGContextRef context = rendererContext.CGContext;
     const CGRect rect = {.size = size};
     CGPathRef path = RCTPathCreateOuterOutline(drawToEdge, rect, cornerRadii);
@@ -461,7 +461,7 @@ static UIImage *RCTGetSolidBorderImage(
 // of gradients _along_ a path (NB: clipping a path and drawing a linear gradient
 // is _not_ equivalent).
 
-static UIImage *RCTGetDashedOrDottedBorderImage(
+static RCTPlatformImage *RCTGetDashedOrDottedBorderImage( // [macOS]
     RCTBorderStyle borderStyle,
     RCTCornerRadii cornerRadii,
     CGSize viewSize,
@@ -525,7 +525,7 @@ static UIImage *RCTGetDashedOrDottedBorderImage(
   }];
 }
 
-UIImage *RCTGetBorderImage(
+RCTPlatformImage *RCTGetBorderImage( // [macOS]
     RCTBorderStyle borderStyle,
     CGSize viewSize,
     RCTCornerRadii cornerRadii,

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -1269,7 +1269,7 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x)
     return;
   }
 
-  UIImage *image = RCTGetBorderImage(
+  RCTPlatformImage *image = RCTGetBorderImage( // [macOS]
       _borderStyle, layer.bounds.size, cornerRadii, borderInsets, borderColors, backgroundColor, self.clipsToBounds);
 
   layer.backgroundColor = NULL;

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.mm
@@ -65,7 +65,7 @@ using namespace facebook::react;
    * T46024425 for more details.
    */
   dispatch_async(_backgroundSerialQueue, ^{
-    auto completionBlock = ^(NSError *error, UIImage *image, id metadata) {
+    auto completionBlock = ^(NSError *error, RCTPlatformImage *image, id metadata) { // [macOS]
       auto observerCoordinator = weakObserverCoordinator.lock();
       if (!observerCoordinator) {
         return;

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
@@ -51,7 +51,7 @@ using namespace facebook::react;
 
   NSURLRequest *request = NSURLRequestFromImageSource(imageSource);
 
-  auto completionBlock = ^(NSError *error, UIImage *image, id metadata) {
+  auto completionBlock = ^(NSError *error, RCTPlatformImage *image, id metadata) { // [macOS]
     auto observerCoordinator = weakObserverCoordinator.lock();
     if (!observerCoordinator) {
       return;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -382,7 +382,7 @@ void RCTApplyBaselineOffset(NSMutableAttributedString *attributedText)
 
 static NSMutableAttributedString *RCTNSAttributedStringFragmentFromFragment(
     const AttributedString::Fragment &fragment,
-    UIImage *placeholderImage)
+    RCTPlatformImage *placeholderImage) // [macOS]
 {
   if (fragment.isAttachment()) {
     auto layoutMetrics = fragment.parentShadowView.layoutMetrics;
@@ -411,7 +411,7 @@ static NSMutableAttributedString *RCTNSAttributedStringFragmentFromFragment(
 
 static NSMutableAttributedString *RCTNSAttributedStringFragmentWithAttributesFromFragment(
     const AttributedString::Fragment &fragment,
-    UIImage *placeholderImage)
+    RCTPlatformImage *placeholderImage) // [macOS]
 {
   auto nsAttributedStringFragment = RCTNSAttributedStringFragmentFromFragment(fragment, placeholderImage);
 
@@ -433,10 +433,10 @@ static NSMutableAttributedString *RCTNSAttributedStringFragmentWithAttributesFro
 
 NSAttributedString *RCTNSAttributedStringFromAttributedString(const AttributedString &attributedString)
 {
-  static UIImage *placeholderImage;
+  static RCTPlatformImage *placeholderImage; // [macOS]
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    placeholderImage = [UIImage new];
+    placeholderImage = [RCTPlatformImage new]; // [macOS]
   });
 
   NSMutableAttributedString *nsAttributedString = [NSMutableAttributedString new];


### PR DESCRIPTION


## Summary:

This PR is split out from #2766 to help make it smaller.

Previously we had the code `@compatibility_alias UIImage NSImage` which is basically an objective C runtime way of doing `#define UIImage NSImage`. We don't quite like this, since we are defining the symbol `UIImage` in an Appkit context. We have a better pattern we can copy from RCTPlatformView --> RCTPlatformImage. The `RCTPlatform` prefix basically means it's NS<blah> on Appkit and UI<blah> on UIKit. This is as opposed to something like RCTUIView, where on iOS it's a typedef, but on macOS it's a subclass that adds stuff to NSView to make it more compatible with UIView.

All in all, this should mostly be a rigorous find/replace to make the code slightly more strict, but have no behavioral changes

## Test Plan:

RNTester runs locally.
