### PR TITLE
fix(macos-init): add --legacy-peer-deps to npm install command

### DIFF
--- a/packages/react-native-macos-init/src/cli.ts
+++ b/packages/react-native-macos-init/src/cli.ts
@@ -299,7 +299,7 @@ You can either downgrade your version of ${chalk.yellow(RNPKG)} to ${chalk.cyan(
 
       const pkgmgr = isProjectUsingYarn(process.cwd())
         ? `yarn add${verbose ? '' : ' --silent'}`
-        : `npm install --save${verbose ? '' : ' --silent'}`;
+        : `npm install --save --legacy-peer-deps${verbose ? '' : ' --silent'}`;
       const execOptions = verbose ? {stdio: 'inherit' as const} : {};
       execSync(`${pkgmgr} "${MACOSPKG}@${version}"`, execOptions);
 


### PR DESCRIPTION
## Summary

This PR fixes the installation failure when running `npx react-native-macos-init` on projects with newer patch versions of React Native.

## Problem

When following the official Getting Started guide:

```bash
npx @react-native-community/cli init myProject --version 0.79
cd myProject
npx react-native-macos-init
```

The last command fails with:

```
Command failed: npm install --save --silent "react-native-macos@^0.79.0-0"
```

### Root Cause

1. The published `react-native-macos@0.79.1` declares an exact peer dependency: `"react-native": "0.79.6"`
2. The React Native CLI installs the latest patch version (e.g., `react-native@0.79.7`)
3. npm 7+ enforces strict peer dependency checking by default
4. npm refuses to install due to the version mismatch (0.79.6 vs 0.79.7)
5. The `--silent` flag hides the actual error message, making debugging difficult

## Solution

Add `--legacy-peer-deps` to the npm install command. This flag:
- Makes npm behave like npm 6, ignoring peer dependency version mismatches
- Is safe for patch version differences (0.79.x) which are backward-compatible by semver convention
- Does not create duplicate installations of react-native

## Changes

- `packages/react-native-macos-init/src/cli.ts`: Added `--legacy-peer-deps` flag to the npm install command

## Test Plan

1. Create a new React Native project: `npx @react-native-community/cli init TestApp --version 0.79`
2. Verify that `react-native@0.79.7` (or newer patch) is installed
3. Run `npx react-native-macos-init` with this fix
4. Confirm installation succeeds without errors

## Related

I'll open a separate issue to discuss using a caret range (`^0.79.0`) instead of exact versions for the react-native peer dependency in release branches.