### PR TITLE
chore(ci): fix "Setup toolchain" xcode path

### DIFF
--- a/.github/actions/microsoft-setup-toolchain/action.yml
+++ b/.github/actions/microsoft-setup-toolchain/action.yml
@@ -18,7 +18,7 @@ inputs:
     default: "22"
   xcode-developer-dir:
     description: Set the path for the active Xcode developer directory
-    default: "/Applications/Xcode_16.4.0.app"
+    default: "/Applications/Xcode.app"
 runs:
   using: composite
   steps:


### PR DESCRIPTION
## Summary:

Since #2694 tests run on macos 26, which used Xcode 26.0.1 [by default](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md) causing the `"/Applications/Xcode_16.4.0.app"` path to fail in the "Setup toolchain" phase 
 

## Test Plan:

CI should not fail in the Setup toolchain phase 
