### PR TITLE
docs: specify exact React Native version to avoid peer dependency conflicts

### DIFF
--- a/docsite/docs/getting-started.md
+++ b/docsite/docs/getting-started.md
@@ -13,10 +13,10 @@ For information around how to set up:
 
 ## Install React Native for macOS
 
-Remember to call `@react-native-community/cli init` from the place you want your project directory to live. Be sure to use the same minor version between React Native and React Native macOS. We'll use `^0.79.0`
+Remember to call `@react-native-community/cli init` from the place you want your project directory to live. Be sure to use the same minor version between React Native and React Native macOS. We'll use `^0.79.6`
 
 ```
-npx @react-native-community/cli init <projectName> --version 0.79
+npx @react-native-community/cli init <projectName> --version 0.79.6
 ```
 
 ### Navigate into this newly created directory


### PR DESCRIPTION
## Summary:
Using `--version 0.79` installs the latest 0.79.x patch (e.g., 0.79.7), which causes npm peer dependency conflicts because `react-native-macos@0.79.1` requires `react-native@0.79.6` exactly.

Updated the documentation to use the exact version (0.79.6) that matches the `react-native-macos` peer dependency requirement.