### PR TITLE
fix: adjust content inset behavior for macOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
@@ -47,24 +47,7 @@
     // NSScrollView.automaticallyAdjustsContentInsets (default YES) adds contentInset.top to push content below the toolbar.
     // However, React Native doesn't know about this native contentInset adjustments,causing some caltulation issues  
     self.automaticallyAdjustsContentInsets = NO;
-#if !TARGET_OS_OSX // [macOS]
-// We set the default behavior to "never" so that iOS
-// doesn't do weird things to UIScrollView insets automatically
-// and keeps it as an opt-in behavior.
-self.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
-#else // [macOS
-    // Similar to iOS's contentInsetAdjustmentBehavior fix
-    // For example: When using NSWindowStyleMaskFullSizeContentView (hidden title bar) and ScrollView as root,
-    // NSScrollView.automaticallyAdjustsContentInsets (default YES) adds contentInset.top to push content below the toolbar.
-    // However, React Native doesn't know about this native contentInset adjustments,causing some caltulation issues  
-    self.automaticallyAdjustsContentInsets = NO;
 #endif // macOS]
-
-// We intentionally force `UIScrollView`s `semanticContentAttribute` to `LTR` here
-// because this attribute affects a position of vertical scrollbar; we don't want this
-// scrollbar flip because we also flip it with whole `UIScrollView` flip.
-self.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
-
 
     __weak __typeof(self) weakSelf = self;
     _delegateSplitter = [[RCTGenericDelegateSplitter alloc] initWithDelegateUpdateBlock:^(id delegate) {


### PR DESCRIPTION
Fix content inset adjustments for macOS ScrollView.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
