### PR TITLE
ci: use Node 22 for Azure Pipelines

### DIFF
--- a/.ado/jobs/npm-publish.yml
+++ b/.ado/jobs/npm-publish.yml
@@ -24,6 +24,11 @@ jobs:
       fetchFilter: blob:none
       persistCredentials: true
 
+    - task: UseNode@1
+      inputs:
+        version: '22.22.0'
+      displayName: 'Use Node.js 22.22.0'
+
     - template: /.ado/templates/configure-git.yml@self
 
     - script: |


### PR DESCRIPTION
## Summary:

Azure Pipelines was still using Node 18, which is lower than the minimum needed and wasn't compatible with react-native-codegen

