### PR TITLE
fix(codegen): fix react-native modules/components duplication

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
@@ -329,7 +329,7 @@ function parseiOSAnnotations(
 ) /*: {[string]: $FlowFixMe} */ {
   const mLibraryMap = {} /*:: as {[string]: $FlowFixMe} */;
   const cLibraryMap = {} /*:: as {[string]: $FlowFixMe} */;
-  const map = {};
+  const map = {} /*:: as {[string]: $FlowFixMe} */; // [macOS]
 
   for (const library of libraries) {
     const iosConfig = library?.config?.ios;
@@ -363,6 +363,40 @@ function parseiOSAnnotations(
       }
     }
   }
+  // [macOS
+  // Allow react-native-macos to override react-native modules/components
+  const isAllowedOverride = (libraryNames /*: Set<string> */) => {
+    const names = Array.from(libraryNames);
+    return (
+      names.length === 2 &&
+      names.includes('react-native') &&
+      names.includes('react-native-macos')
+    );
+  };
+
+  // Merge entries with react-native-macos taking precedence over react-native
+  for (const [moduleName, libraryNames] of Object.entries(mLibraryMap)) {
+    if (isAllowedOverride(libraryNames)) {
+      // Remove the module from react-native, keep only react-native-macos
+      if (map['react-native']?.modules?.[moduleName]) {
+        delete map['react-native'].modules[moduleName];
+      }
+      // Update the library map to only contain react-native-macos
+      mLibraryMap[moduleName] = new Set(['react-native-macos']);
+    }
+  }
+
+  for (const [componentName, libraryNames] of Object.entries(cLibraryMap)) {
+    if (isAllowedOverride(libraryNames)) {
+      // Remove the component from react-native, keep only react-native-macos
+      if (map['react-native']?.components?.[componentName]) {
+        delete map['react-native'].components[componentName];
+      }
+      // Update the library map to only contain react-native-macos
+      cLibraryMap[componentName] = new Set(['react-native-macos']);
+    }
+  }
+  // macOS]
 
   const moduleConflicts = Object.entries(mLibraryMap)
     .filter(([_, libraryNames]) => libraryNames.size > 1)


### PR DESCRIPTION
## Summary:

In `react-native-macos` 0.81, running `pod install` will error out due to react-native modules/components duplication when using react-native and react-native-macos in the same repository.

<img width="1888" height="618" alt="image" src="https://github.com/user-attachments/assets/72bbebd2-ba28-461d-bf8b-2ca679e7f7c1" />

## Test Plan:

Pod install should succeed and the app should build normally. 
