### PR TITLE
fix(cli): fix undeclared `chalk` dependency

### DIFF
--- a/packages/react-native/local-cli/runMacOS/runMacOS.js
+++ b/packages/react-native/local-cli/runMacOS/runMacOS.js
@@ -41,8 +41,8 @@ const path = require('node:path');
 const colors = (() => {
   const {WriteStream} = require('node:tty');
   if (WriteStream.prototype.hasColors() &&
-    !process.env['NODE_TEST_CONTEXT'] &&
-    process.env['NODE_ENV'] !== 'test'
+    !process.env.NODE_TEST_CONTEXT &&
+    process.env.NODE_ENV !== 'test'
   ) {
     return {
       bold: (s) => '\u001B[1m' + s + '\u001B[22m',


### PR DESCRIPTION
## Summary:

macOS bundling fails because it tries to import `chalk` but does not declare it.

```
/~/packages/app/example/node_modules/react-native-macos/react-native.config.js: node:internal/modules/cjs/loader:1421
  const err = new Error(message);
              ^

Error: Cannot find module 'chalk'
Require stack:
- /~/node_modules/.store/react-native-macos-virtual-89732d1908/package/local-cli/runMacOS/runMacOS.js
- /~/node_modules/.store/react-native-macos-virtual-89732d1908/package/react-native.config.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1421:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1059:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1064:22)
    at Module._load (node:internal/modules/cjs/loader:1227:37)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:245:24)
    at Module.require (node:internal/modules/cjs/loader:1504:12)
    at require (node:internal/modules/helpers:152:16)
    at Object.<anonymous> (/~/node_modules/.store/react-native-macos-virtual-89732d1908/package/local-cli/runMacOS/runMacOS.js:38:15)
    at Module._compile (node:internal/modules/cjs/loader:1761:14) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/~/node_modules/.store/react-native-macos-virtual-89732d1908/package/local-cli/runMacOS/runMacOS.js',
    '/~/node_modules/.store/react-native-macos-virtual-89732d1908/package/react-native.config.js'
  ]
}
```

Instead of adding `chalk` as a dependency (and introducing a diff), we inline the functions we use.

## Test Plan:

n/a