### PR TITLE
fix: fix `@react-native-community/cli-platform-apple` not being resolved correctly

### DIFF
--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -71,10 +71,9 @@ try {
 // [macOS
 let apple;
 try {
-  const iosPath = require.resolve(
-    '@react-native-community/cli-platform-ios',
-    {paths: [process.cwd()]},
-  );
+  const iosPath = require.resolve('@react-native-community/cli-platform-ios', {
+    paths: [process.cwd()],
+  });
   // $FlowFixMe[untyped-import]
   apple = findCommunityPlatformPackage(
     '@react-native-community/cli-platform-apple',


### PR DESCRIPTION
## Summary:

`@react-native-community/cli-platform-apple` is not correctly resolved in pnpm setups:

```
% DEBUG=react-native yarn build:macos
/~/packages/app/example/node_modules/react-native-macos/react-native.config.js: @react-native-community/cli-platform-apple not found, the react-native.config.js may be unusable.
info Bundling macos...
error Invalid platform "macos" selected.
info Available platforms are: "android", "ios", "windows". If you are trying to bundle for an out-of-tree platform, it may not be installed.
```

## Test Plan:

n/a