### PR TITLE
fix: set codegenConfig key to macos

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -202,7 +202,7 @@
       {
         "name": "FBReactNativeSpec",
         "type": "all",
-        "ios": {
+        "macos": {
           "modules": {
             "AccessibilityManager": {
               "unstableRequiresMainQueueSetup": true


### PR DESCRIPTION
## Summary:

Per suggestion from @tido64 , set this key to `macos` so codegen doesn't complain about duplicate ios modules. Not sure if this fix holds if we want to use react-native-macos for iOS or visionOS, but time will tell.

## Test Plan:

CI should pass