### PR TITLE
docs: fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For a full and detailed list of the system requirements and how to set up your d
 
 ## Getting Started
 
-See the [Getting Started Guide](https://microsoft.github.io/react-native-windows/docs/rnm-getting-started) on our React Native for Windows + macOS website to build your first React Native for macOS app.
+See the [Getting Started Guide](https://microsoft.github.io/react-native-macos/docs/getting-started) on our React Native for macOS website to build your first React Native for macOS app.
 
 ### Logging Issues
 


### PR DESCRIPTION
Updated the link for the Getting Started Guide for React Native for macOS.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The four fields below are mandatory. -->

<!-- This fork of react-native provides React Native for macOS for the community.  It also contains some changes that are required for usage internal to Microsoft.  We are working on reducing the diff between Facebook's public version of react-native and our microsoft/react-native-macos fork.  Long term, we want this fork to only contain macOS concerns and have the other iOS and Android concerns contributed upstream.

If you are making a new change then one of the following should be done:
- Consider if it is possible to achieve the desired behavior without making a change to microsoft/react-native-macos.  Often a change can be made in a layer above in facebook/react-native instead.
- Create a corresponding PR against [facebook/react-native](https://github.com/facebook/react-native)
**Note:** Ideally you would wait for Facebook feedback before submitting to Microsoft, since we want to ensure that this fork doesn't deviate from upstream.
-->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I noticed a link in the docs that was lead-piping users straight into a dead end. I've updated it to point to the actual content, saving future developers roughly **2.5 seconds of confusion** and one frustrated sigh each. 