### PR TITLE
fix(fabric): textInput text color not adapting to appearance changes

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -9,7 +9,6 @@
 
 #import <react/featureflags/ReactNativeFeatureFlags.h>
 #import <react/renderer/components/iostextinput/TextInputComponentDescriptor.h>
-#import <react/renderer/graphics/Color.h> // [macOS]
 #import <react/renderer/textlayoutmanager/RCTAttributedTextUtils.h>
 #import <react/renderer/textlayoutmanager/TextLayoutManager.h>
 
@@ -176,20 +175,6 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   const auto &props = static_cast<const TextInputProps &>(*_props);
   NSMutableDictionary<NSAttributedStringKey, id> *attrs =
       RCTNSTextAttributesFromTextAttributes(props.getEffectiveTextAttributes(RCTFontSizeMultiplier()));
-
-#if TARGET_OS_OSX
-  // The C++ color pipeline resolves dynamic colors (like labelColor) to static
-  // values at creation time, so re-calling RCTNSTextAttributesFromTextAttributes
-  // after an appearance change returns the same stale color. When the foreground
-  // color is the default (semantic labelColor, not a user-specified color),
-  // replace it with a fresh dynamic NSColor.labelColor so the text adapts to the
-  // current appearance. Explicit colors (e.g. "white", "red") are left as-is.
-  const auto &effectiveAttrs = props.getEffectiveTextAttributes(RCTFontSizeMultiplier());
-  facebook::react::SharedColor defaultColor = facebook::react::defaultForegroundTextColor();
-  if (!effectiveAttrs.foregroundColor || *effectiveAttrs.foregroundColor == *defaultColor) {
-    attrs[NSForegroundColorAttributeName] = [NSColor labelColor];
-  }
-#endif
 
   _backedTextInputView.defaultTextAttributes = attrs;
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -9,6 +9,7 @@
 
 #import <react/featureflags/ReactNativeFeatureFlags.h>
 #import <react/renderer/components/iostextinput/TextInputComponentDescriptor.h>
+#import <react/renderer/graphics/Color.h> // [macOS]
 #import <react/renderer/textlayoutmanager/RCTAttributedTextUtils.h>
 #import <react/renderer/textlayoutmanager/TextLayoutManager.h>
 
@@ -169,6 +170,44 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   [self _restoreTextSelection];
 }
 
+// [macOS
+- (void)_updateDefaultTextAttributes
+{
+  const auto &props = static_cast<const TextInputProps &>(*_props);
+  NSMutableDictionary<NSAttributedStringKey, id> *attrs =
+      RCTNSTextAttributesFromTextAttributes(props.getEffectiveTextAttributes(RCTFontSizeMultiplier()));
+
+#if TARGET_OS_OSX
+  // The C++ color pipeline resolves dynamic colors (like labelColor) to static
+  // values at creation time, so re-calling RCTNSTextAttributesFromTextAttributes
+  // after an appearance change returns the same stale color. When the foreground
+  // color is the default (semantic labelColor, not a user-specified color),
+  // replace it with a fresh dynamic NSColor.labelColor so the text adapts to the
+  // current appearance. Explicit colors (e.g. "white", "red") are left as-is.
+  const auto &effectiveAttrs = props.getEffectiveTextAttributes(RCTFontSizeMultiplier());
+  facebook::react::SharedColor defaultColor = facebook::react::defaultForegroundTextColor();
+  if (!effectiveAttrs.foregroundColor || *effectiveAttrs.foregroundColor == *defaultColor) {
+    attrs[NSForegroundColorAttributeName] = [NSColor labelColor];
+  }
+#endif
+
+  _backedTextInputView.defaultTextAttributes = attrs;
+
+  // Also update the existing attributed text so the visible text re-renders
+  // with the new color (defaultTextAttributes only affects newly typed text).
+  // Wrap in _comingFromJS to prevent textInputDidChange from pushing a state
+  // update back to the shadow tree, which would overwrite our fresh colors
+  // with the stale cached attributed string.
+  NSString *currentText = _backedTextInputView.attributedText.string;
+  if (currentText.length > 0) {
+    NSAttributedString *updated = [[NSAttributedString alloc] initWithString:currentText attributes:attrs];
+    _comingFromJS = YES;
+    _backedTextInputView.attributedText = updated;
+    _comingFromJS = NO;
+  }
+}
+// macOS]
+
 #if !TARGET_OS_OSX // [macOS]
 // TODO: replace with registerForTraitChanges once iOS 17.0 is the lowest supported version
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
@@ -178,12 +217,20 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   if (facebook::react::ReactNativeFeatureFlags::enableFontScaleChangesUpdatingLayout() &&
       UITraitCollection.currentTraitCollection.preferredContentSizeCategory !=
           previousTraitCollection.preferredContentSizeCategory) {
-    const auto &newTextInputProps = static_cast<const TextInputProps &>(*_props);
-    _backedTextInputView.defaultTextAttributes =
-        RCTNSTextAttributesFromTextAttributes(newTextInputProps.getEffectiveTextAttributes(RCTFontSizeMultiplier()));
+    [self _updateDefaultTextAttributes];
   }
+
+  if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) { // [macOS]
+    [self _updateDefaultTextAttributes]; // [macOS]
+  } // [macOS]
 }
-#endif // [macOS] 
+#else // [macOS
+- (void)viewDidChangeEffectiveAppearance
+{
+  [super viewDidChangeEffectiveAppearance];
+  [self _updateDefaultTextAttributes];
+}
+#endif // macOS]
 
 - (void)reactUpdateResponderOffsetForScrollView:(RCTScrollViewComponentView *)scrollView
 {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -202,12 +202,16 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   if (facebook::react::ReactNativeFeatureFlags::enableFontScaleChangesUpdatingLayout() &&
       UITraitCollection.currentTraitCollection.preferredContentSizeCategory !=
           previousTraitCollection.preferredContentSizeCategory) {
-    [self _updateDefaultTextAttributes];
+    const auto &newTextInputProps = static_cast<const TextInputProps &>(*_props);
+    _backedTextInputView.defaultTextAttributes =
+        RCTNSTextAttributesFromTextAttributes(newTextInputProps.getEffectiveTextAttributes(RCTFontSizeMultiplier()));
   }
 
-  if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) { // [macOS]
-    [self _updateDefaultTextAttributes]; // [macOS]
-  } // [macOS]
+  // [macOS
+  if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
+    [self _updateDefaultTextAttributes];
+  }
+  // macOS]
 }
 #else // [macOS
 - (void)viewDidChangeEffectiveAppearance

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -146,7 +146,13 @@ inline static RCTPlatformColor *RCTEffectiveForegroundColorFromTextAttributes(co
 {
   RCTPlatformColor *effectiveForegroundColor = RCTUIColorFromSharedColor(textAttributes.foregroundColor) ?: [RCTPlatformColor labelColor]; // [macOS]
 
-  if (!isnan(textAttributes.opacity)) {
+  // [macOS
+  // Skip colorWithAlphaComponent: when opacity is 1.0 — the multiplication is
+  // a no-op, but on macOS it has the side effect of converting dynamic system
+  // colors (like NSColor.labelColor) into static resolved colors, preventing
+  // them from adapting to appearance changes (light/dark mode).
+  if (!isnan(textAttributes.opacity) && textAttributes.opacity != 1.0f) {
+  // macOS]
     effectiveForegroundColor = [effectiveForegroundColor
         colorWithAlphaComponent:CGColorGetAlpha(effectiveForegroundColor.CGColor) * textAttributes.opacity];
   }
@@ -158,7 +164,7 @@ inline static RCTPlatformColor *RCTEffectiveBackgroundColorFromTextAttributes(co
 {
   RCTPlatformColor *effectiveBackgroundColor = RCTUIColorFromSharedColor(textAttributes.backgroundColor); // [macOS]
 
-  if (effectiveBackgroundColor && !isnan(textAttributes.opacity)) {
+  if (effectiveBackgroundColor && !isnan(textAttributes.opacity) && textAttributes.opacity != 1.0f) { // [macOS]
     effectiveBackgroundColor = [effectiveBackgroundColor
         colorWithAlphaComponent:CGColorGetAlpha(effectiveBackgroundColor.CGColor) * textAttributes.opacity];
   }

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -194,16 +194,6 @@ NSMutableDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttri
   if (textAttributes.foregroundColor || !isnan(textAttributes.opacity)) {
     attributes[NSForegroundColorAttributeName] = effectiveForegroundColor;
   }
-#if TARGET_OS_OSX // [macOS
-  // On macOS, NSAttributedString defaults to black when no foreground color
-  // attribute is present, unlike iOS where the text view provides its own
-  // default. Always set the foreground color so that text is visible in both
-  // light and dark mode. RCTEffectiveForegroundColorFromTextAttributes falls
-  // back to the platform's dynamic labelColor when no color is specified.
-  else {
-    attributes[NSForegroundColorAttributeName] = effectiveForegroundColor;
-  }
-#endif // macOS]
 
   if (textAttributes.backgroundColor || !isnan(textAttributes.opacity)) {
     attributes[NSBackgroundColorAttributeName] = RCTEffectiveBackgroundColorFromTextAttributes(textAttributes);

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -183,6 +183,16 @@ NSMutableDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttri
   if (textAttributes.foregroundColor || !isnan(textAttributes.opacity)) {
     attributes[NSForegroundColorAttributeName] = effectiveForegroundColor;
   }
+#if TARGET_OS_OSX // [macOS
+  // On macOS, NSAttributedString defaults to black when no foreground color
+  // attribute is present, unlike iOS where the text view provides its own
+  // default. Always set the foreground color so that text is visible in both
+  // light and dark mode. RCTEffectiveForegroundColorFromTextAttributes falls
+  // back to the platform's dynamic labelColor when no color is specified.
+  else {
+    attributes[NSForegroundColorAttributeName] = effectiveForegroundColor;
+  }
+#endif // macOS]
 
   if (textAttributes.backgroundColor || !isnan(textAttributes.opacity)) {
     attributes[NSBackgroundColorAttributeName] = RCTEffectiveBackgroundColorFromTextAttributes(textAttributes);

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -146,13 +146,14 @@ inline static RCTPlatformColor *RCTEffectiveForegroundColorFromTextAttributes(co
 {
   RCTPlatformColor *effectiveForegroundColor = RCTUIColorFromSharedColor(textAttributes.foregroundColor) ?: [RCTPlatformColor labelColor]; // [macOS]
 
-  // [macOS
-  // Skip colorWithAlphaComponent: when opacity is 1.0 — the multiplication is
-  // a no-op, but on macOS it has the side effect of converting dynamic system
-  // colors (like NSColor.labelColor) into static resolved colors, preventing
-  // them from adapting to appearance changes (light/dark mode).
+#if TARGET_OS_OSX // [macOS
+  // On macOS, colorWithAlphaComponent: converts dynamic system colors (like
+  // NSColor.labelColor) to static resolved colors, preventing them from
+  // adapting to appearance changes. Skip when opacity is 1.0 (a no-op).
   if (!isnan(textAttributes.opacity) && textAttributes.opacity != 1.0f) {
-  // macOS]
+#else // macOS]
+  if (!isnan(textAttributes.opacity)) {
+#endif
     effectiveForegroundColor = [effectiveForegroundColor
         colorWithAlphaComponent:CGColorGetAlpha(effectiveForegroundColor.CGColor) * textAttributes.opacity];
   }
@@ -164,7 +165,11 @@ inline static RCTPlatformColor *RCTEffectiveBackgroundColorFromTextAttributes(co
 {
   RCTPlatformColor *effectiveBackgroundColor = RCTUIColorFromSharedColor(textAttributes.backgroundColor); // [macOS]
 
-  if (effectiveBackgroundColor && !isnan(textAttributes.opacity) && textAttributes.opacity != 1.0f) { // [macOS]
+#if TARGET_OS_OSX // [macOS
+  if (effectiveBackgroundColor && !isnan(textAttributes.opacity) && textAttributes.opacity != 1.0f) {
+#else // macOS]
+  if (effectiveBackgroundColor && !isnan(textAttributes.opacity)) {
+#endif
     effectiveBackgroundColor = [effectiveBackgroundColor
         colorWithAlphaComponent:CGColorGetAlpha(effectiveBackgroundColor.CGColor) * textAttributes.opacity];
   }


### PR DESCRIPTION
## Summary

- Fixes TextInput text color not updating when the system appearance changes (light ↔ dark mode) on the new architecture (Fabric)
- Ensures the default text color (`labelColor`) is always set on macOS, since `NSAttributedString` defaults to black unlike iOS
- Adds `viewDidChangeEffectiveAppearance` (macOS) and `hasDifferentColorAppearanceComparedToTraitCollection:` (iOS) handlers to refresh text attributes on appearance change

## Root Cause

Three interrelated issues on macOS Fabric:

1. **Missing foreground color**: `RCTNSTextAttributesFromTextAttributes` skipped setting `NSForegroundColorAttributeName` when no explicit `color` prop or `opacity` was set. On macOS, `NSAttributedString` defaults to black (unlike iOS where `UITextField` provides its own dynamic default), making text invisible in dark mode.

2. **No appearance change handler**: `RCTTextInputComponentView` had no `viewDidChangeEffectiveAppearance` override on macOS, so `defaultTextAttributes` were never refreshed when switching light/dark mode.

3. **Frozen dynamic colors**: The C++ color pipeline resolves dynamic colors (like `labelColor`) to static values at creation time. Simply re-calling `RCTNSTextAttributesFromTextAttributes` after an appearance change returns the same stale color. The fix detects when the foreground color is the default semantic `labelColor` (vs. a user-specified color) and replaces it with a fresh `[NSColor labelColor]`, then re-applies the attributed text while suppressing React state reconciliation.

## Test plan

- [ ] Launch RNTester macOS in dark mode → TextInput with no `color` prop shows visible text
- [ ] Toggle to light mode → text color adapts (dark text on light background)
- [ ] Toggle back to dark mode → text color adapts (light text on dark background)
- [ ] TextInput with explicit `color` prop (e.g. `"red"`, `"white"`) preserves its color across appearance changes
- [ ] Both single-line and multiline TextInput work correctly
- [ ] Newly typed text after appearance change uses the correct color

🤖 Generated with [Claude Code](https://claude.com/claude-code)