### PR TITLE
fix(0.81): add publishConfig.executableFiles for yarn pack compatibility

### DIFF
--- a/.github/workflows/microsoft-test-react-native-macos-init.yml
+++ b/.github/workflows/microsoft-test-react-native-macos-init.yml
@@ -62,9 +62,6 @@ jobs:
         run: |
           set -eox pipefail
           npm install ${{ runner.temp }}/react-native-macos.tgz
-          # yarn pack strips execute bits; publishConfig.executableFiles restores them
-          # at publish time, but we also chmod here for local CI packs.
-          find node_modules/react-native-macos/scripts -name '*.sh' -exec chmod +x {} +
 
       - name: Apply macOS template
         working-directory: ${{ runner.temp }}/testcli

--- a/.github/workflows/microsoft-test-react-native-macos-init.yml
+++ b/.github/workflows/microsoft-test-react-native-macos-init.yml
@@ -62,8 +62,8 @@ jobs:
         run: |
           set -eox pipefail
           npm install ${{ runner.temp }}/react-native-macos.tgz
-          # yarn pack strips execute bits from shell scripts.
-          # publishConfig.executableFiles could fix this but doesn't support globs.
+          # yarn pack strips execute bits; publishConfig.executableFiles restores them
+          # at publish time, but we also chmod here for local CI packs.
           find node_modules/react-native-macos/scripts -name '*.sh' -exec chmod +x {} +
 
       - name: Apply macOS template

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -27,6 +27,27 @@
     "react-native": "cli.js",
     "react-native-macos": "cli.js"
   },
+  "publishConfig": {
+    "executableFiles": [
+      "scripts/find-node-for-xcode.sh",
+      "scripts/ios-configure-glog.sh",
+      "scripts/node-binary.sh",
+      "scripts/packager.sh",
+      "scripts/react-native-xcode.sh",
+      "scripts/react_native_pods_utils/script_phases.sh",
+      "scripts/update-ruby.sh",
+      "scripts/xcode/ccache-clang.sh",
+      "scripts/xcode/ccache-clang++.sh",
+      "scripts/xcode/with-environment.sh",
+      "sdks/hermes-engine/utils/build-apple-framework.sh",
+      "sdks/hermes-engine/utils/build-hermes-xcode.sh",
+      "sdks/hermes-engine/utils/build-hermesc-xcode.sh",
+      "sdks/hermes-engine/utils/build-ios-framework.sh",
+      "sdks/hermes-engine/utils/build-mac-framework.sh",
+      "sdks/hermes-engine/utils/copy-hermes-xcode.sh",
+      "sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh"
+    ]
+  },
   "main": "./index.js",
   "types": "types",
   "exports": {


### PR DESCRIPTION
## Summary
- Adds `publishConfig.executableFiles` to `packages/react-native/package.json` listing all shell scripts included in the tarball, so `yarn pack` / `npm publish` preserves their execute permissions.
- Updates the chmod workaround comment in the CI workflow to reflect that `publishConfig.executableFiles` is now configured.

## Test plan
- [ ] Verify `yarn pack` in `packages/react-native` produces a tarball with executable `.sh` files
- [ ] Verify the `microsoft-test-react-native-macos-init` CI job still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)