### PR TITLE
fix(0.81, ci): ensure PR gate job fails instead of skipping when upstream jobs fail

### DIFF
--- a/.github/workflows/microsoft-pr.yml
+++ b/.github/workflows/microsoft-pr.yml
@@ -153,6 +153,7 @@ jobs:
 
   PR:
     name: "PR"
+    if: always()
     permissions: {}
     runs-on: ubuntu-latest
     needs:
@@ -165,5 +166,10 @@ jobs:
       - test-react-native-macos-init
       # - react-native-test-app-integration
     steps:
+      - name: Check for failures or cancellations
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "One or more required jobs failed or were cancelled."
+          exit 1
       - name: All required jobs passed
-        run: echo "All required jobs completed."
+        run: echo "All required jobs completed successfully."


### PR DESCRIPTION
## Summary

- The `PR` gate job is the required status check for merging
- Without `if: always()`, when any dependency job fails, the gate job gets **skipped** — and GitHub treats `SKIPPED` as passing for required checks, allowing PRs with failing CI to merge
- Adds `if: always()` so the gate job always runs, plus an explicit check that fails when any dependency failed or was cancelled

## Test plan

- [ ] Verify that when all jobs pass, the `PR` gate job still passes
- [ ] Verify that when any job fails, the `PR` gate job now **fails** instead of being skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)