### PR TITLE
chore(0.81): new patch release

### DIFF
--- a/.nx/version-plans/version-plan-1776378471122.md
+++ b/.nx/version-plans/version-plan-1776378471122.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+New patch release


### PR DESCRIPTION
## Summary
- add an Nx version plan for a new 0.81 patch release
- prepare the stable branch for `nx release` to bump `react-native-macos` and `@react-native-macos/virtualized-lists` from `0.81.6` to `0.81.7`

## Why
- follow the documented patch release flow in `docsite/docs/releases/patch-release.md` and `docsite/docs/contributing/versioning.md`
- use PR CI to validate the release dry-run before the actual publish flow runs

## Validation
- `yarn nx release --dry-run --verbose --skip-publish`

## Notes
- the npm publish 404 for `@react-native-macos/virtualized-lists@0.81.6` does not appear to be a repo version mismatch; that version is already present on npm, which points more strongly to npm access/auth for publishing the scoped package