### PR TITLE
fix(0.81): resolve cli-platform-apple from cli-platform-ios path for pnpm

### DIFF
--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -71,8 +71,12 @@ try {
 // [macOS
 let apple;
 try {
+  const iosPath = require.resolve('@react-native-community/cli-platform-ios', {
+    paths: [process.cwd()],
+  });
   apple = findCommunityPlatformPackage(
     '@react-native-community/cli-platform-apple',
+    iosPath,
   );
 } catch {
   if (verbose) {


### PR DESCRIPTION
## Summary
- Backport of #2945 to `0.81-stable`
- Re-applies the fix from #2820 that was inadvertently reverted in #2917
- In pnpm setups, `@react-native-community/cli-platform-apple` is a transitive dependency of `cli-platform-ios` and not directly resolvable from the project root — resolve `cli-platform-ios` first and use its path as the starting directory

Fixes #2944

## Test plan
- Verified in a pnpm monorepo that `cli-platform-apple` resolves correctly and the `macos` platform is registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)