### PR TITLE
chore(0.81): new patch release

### DIFF
--- a/.nx/version-plans/version-plan-1776975418700.md
+++ b/.nx/version-plans/version-plan-1776975418700.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+New patch release


### PR DESCRIPTION
## Summary
- Add an Nx version plan for a new 0.81 patch release
- Prepare the stable branch for `nx release` to bump `react-native-macos` and `@react-native-macos/virtualized-lists` from `0.81.7` to `0.81.8`

## Changes since v0.81.7
- feat(0.81, ci): prebuild React xcframework for macOS (#2921)
- chore(0.81, deps): Bump various packages to mitigate CVEs (#2931)
- fix(0.81, ci): use mapped upstream version for Hermes version marker (#2934)

## Validation
- `yarn nx release --dry-run --verbose --skip-publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)