### PR TITLE
ci: pass --access public to npm publish

### DIFF
--- a/.ado/jobs/npm-publish.yml
+++ b/.ado/jobs/npm-publish.yml
@@ -47,7 +47,7 @@ jobs:
         condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 
       - script: |
-          yarn workspaces foreach -vv --all --topological --no-private npm publish --tag $(publishTag) --tolerate-republish
+          yarn workspaces foreach -vv --all --topological --no-private npm publish --access public --tag $(publishTag) --tolerate-republish
         displayName: Publish packages
         condition: and(succeeded(), eq(variables['publish_react_native_macos'], '1'))
 


### PR DESCRIPTION
## Summary

- Pass `--access public` explicitly to `npm publish` in the ADO publish pipeline so scoped packages publish with public access.
- Previously the pipeline relied on `yarn config set npmPublishAccess public`, which doesn't reliably propagate through `yarn workspaces foreach ... npm publish`.

## Test plan

- [ ] Trigger ADO publish pipeline on a `-stable` branch and confirm packages publish successfully with public access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)