### PR TITLE
ci(0.81): pass --access public to npm publish

### DIFF
--- a/.ado/jobs/npm-publish.yml
+++ b/.ado/jobs/npm-publish.yml
@@ -80,12 +80,12 @@ jobs:
               yarn config set npmPublishRegistry "https://registry.npmjs.org"
               yarn config set npmAuthToken $(npmAuthToken)
               echo "Publishing with yarn npm publish"
-              yarn ./packages/virtualized-lists npm publish --tolerate-republish --tag $(publishTag)
-              yarn ./packages/react-native npm publish      --tolerate-republish --tag $(publishTag)
+              yarn ./packages/virtualized-lists npm publish --access public --tolerate-republish --tag $(publishTag)
+              yarn ./packages/react-native npm publish      --access public --tolerate-republish --tag $(publishTag)
             else
               echo "Publishing with npm publish"
-              npm publish ./packages/virtualized-lists --tag $(publishTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
-              npm publish ./packages/react-native      --tag $(publishTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
+              npm publish ./packages/virtualized-lists --access public --tag $(publishTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
+              npm publish ./packages/react-native      --access public --tag $(publishTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
             fi
           fi
         displayName: Publish packages


### PR DESCRIPTION
## Summary

- Pass `--access public` explicitly to both the `yarn npm publish` and `npm publish` paths in the ADO publish pipeline so scoped packages publish with public access.

## Test plan

- [ ] Trigger ADO publish pipeline on `0.81-stable` and confirm packages publish successfully with public access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)