### PR TITLE
fix(codegen): use REACT_NATIVE constant for npmPackageName

### DIFF
--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -185,7 +185,8 @@ if (apple) {
     },
     projectConfig: apple.getProjectConfig({platformName: 'macos'}),
     dependencyConfig: apple.getProjectConfig({platformName: 'macos'}),
-    npmPackageName: 'react-native-macos',
+    npmPackageName: require('./scripts/codegen/generate-artifacts-executor/constants')
+      .REACT_NATIVE,
   };
 }
 // macOS]


### PR DESCRIPTION
## Summary
Replaces the hardcoded `'react-native-macos'` string at `packages/react-native/react-native.config.js:188` with the `REACT_NATIVE` constant from `scripts/codegen/generate-artifacts-executor/constants.js`. The constant already reads
`packageJson.name` so the resolved value is unchanged on this fork, but the indirection means future package-name moves (workspace renames, internal rebrand, etc.) don't require remembering this one site.

Closes the **"Codegen package name constant"** item on the Road to 0.83 tracking issue (#2901).

## Test Plan

- `pod install` in `packages/rn-tester` runs the codegen step end-to-end and resolves `npmPackageName` without errors (validated locally on 0.83-merge).
- No behavior change for the current package name `react-native-macos`.