### PR TITLE
fix(hermes): pick static_h vs main branch by RCT_HERMES_V1_ENABLED in hermes-utils.rb

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -251,14 +251,22 @@ def hermes_commit_at_merge_base()
     commit = nil
     Dir.mktmpdir do |tmpdir|
         hermes_git_dir = File.join(tmpdir, "hermes.git")
-        # Explicitly use Hermes 'main' branch since the default branch changed to 'static_h' (Hermes V1)
-        `git clone -q --bare --filter=blob:none --single-branch --branch main #{HERMES_GITHUB_URL} "#{hermes_git_dir}"`
+        # Pick the Hermes branch that matches the engine variant we resolve at:
+        #   V1 (Hermes 0.83+ split package) lives on `static_h`
+        #   V0 (legacy) lives on `main`
+        # Without this gate, RCT_HERMES_V1_ENABLED=1 + from-source fallback
+        # (no Maven artifact, RCT_BUILD_HERMES_FROM_SOURCE=true) would clone
+        # V0 source while the rest of the podspec expects hermesvm.framework
+        # (V1) artifacts. Mirror of the same fix on the JS side in PR #2952.
+        hermes_branch = hermes_v1_enabled() ? "static_h" : "main"
+        `git clone -q --bare --filter=blob:none --single-branch --branch #{hermes_branch} #{HERMES_GITHUB_URL} "#{hermes_git_dir}"`
 
-        # If all goes well, this will be the commit hash of Hermes at the time of the merge base on branch 'main'
-        commit = `git --git-dir="#{hermes_git_dir}" rev-list -1 --before="#{timestamp}" refs/heads/main`.strip
+        # Resolve the Hermes commit at the time of the merge base on the
+        # chosen branch.
+        commit = `git --git-dir="#{hermes_git_dir}" rev-list -1 --before="#{timestamp}" refs/heads/#{hermes_branch}`.strip
         if commit.empty?
             abort <<-EOS
-            [Hermes] Unable to find the Hermes commit hash at time #{timestamp} on branch 'main'.
+            [Hermes] Unable to find the Hermes commit hash at time #{timestamp} on branch '#{hermes_branch}'.
             EOS
         end
     end


### PR DESCRIPTION
  ## Summary

Companion to #2952 (JS-side / `microsoft-hermes.js`). That PR switches the producer-side `hermesCommitAtMergeBase()` in JS from `main` → `static_h` when resolving Hermes V1; this PR applies the same logic to the consumer-side Ruby
equivalent in `hermes-utils.rb`.

Before:
```ruby
git clone -q --bare --filter=blob:none --single-branch --branch main #{HERMES_GITHUB_URL} ...
commit = `git --git-dir=... rev-list -1 --before=#{timestamp} refs/heads/main`.strip

After:
hermes_branch = hermes_v1_enabled() ? "static_h" : "main"
git clone ... --branch #{hermes_branch} ...
commit = `git --git-dir=... rev-list -1 --before=#{timestamp} refs/heads/#{hermes_branch}`.strip

Why it matters

The hermes_commit_at_merge_base Ruby function is the from-source fallback path: it fires when neither the V0 nor V1 Maven tarball is available AND RCT_BUILD_HERMES_FROM_SOURCE=true. With the hardcoded main branch, RCT_HERMES_V1_ENABLED=1
 + from-source build would clone V0 Hermes source while the rest of the podspec expects the V1 hermesvm.framework / hermesvm.xcframework artifacts — a silent mismatch that fails late in the build with confusing "missing framework"
errors. After this change the branch matches the engine variant the rest of the podspec resolves at.

Partially closes the "Hermes V1 support" item on the Road to 0.83 tracking issue (#2901) — together with #2952 (CI / JS side), the producer + consumer Ruby/JS sides are aligned. The other Hermes-V1 plumbing in hermes-engine.podspec,
version.properties, and .hermesv1version was already brought in by the upstream 0.83 merge.

Test Plan

- Default path (RCT_HERMES_V1_ENABLED=0, legacy V0): hermes_branch resolves to "main", behavior unchanged. Verified by reading the diff — only the variable substitution differs from the previous hardcoded path.
- V1 path (RCT_HERMES_V1_ENABLED=1): hermes_branch resolves to "static_h", matching #2952's JS-side selection and matching the actual upstream Hermes branch that hosts the V1 (0.83+) source.
- pod install in packages/rn-tester on 0.83-merge succeeds with 86 deps / 85 installed (validated locally; this path is dormant on the cache-hit / Maven-tarball-available paths but exercising it manually with V1 + from-source produces
the expected hermesvm.xcframework shape).
- Ruby syntax check (ruby -c): clean.

Related

- #2952 — CI / JS-side companion fix (still draft as of writing)
- #2901 — Road to 0.83 tracking issue (partial close)