### PR TITLE
fix(macos): expose React-RCTUIKit module to RCTSwiftUI Swift consumers

### DIFF
--- a/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUI.podspec
+++ b/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUI.podspec
@@ -30,6 +30,14 @@ Pod::Spec.new do |s|
   s.module_name            = "RCTSwiftUI"
   s.header_dir             = "RCTSwiftUI"
 
+  # [macOS] Expose the React_RCTUIKit clang module to Swift so
+  # RCTSwiftUIContainerView.swift can `import React_RCTUIKit` and pick up
+  # the ObjC `@compatibility_alias RCTUIColor → NSColor` / `RCTPlatformView`
+  # without re-declaring them as Swift typealiases. The dep is harmless on
+  # iOS (the umbrella headers are mostly typedef-only there); kept
+  # unconditional to preserve parity with the rest of the apple pods.
+  s.dependency "React-RCTUIKit"
+
   # Swift-specific configuration
   s.pod_target_xcconfig    = {
     "SWIFT_VERSION" => "5.0",

--- a/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
+++ b/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
@@ -6,6 +6,17 @@
  */
 
 import SwiftUI
+// [macOS] Pull in the ObjC @compatibility_alias declarations for
+// `RCTPlatformView` (UIView/NSView) and `RCTUIColor` (UIColor/NSColor)
+// from RCTUIKit. Without this import the Swift file used to re-declare
+// these as local `public typealias`es, which shadowed the ObjC aliases
+// and forced every consumer of this module to choose between the Swift
+// and ObjC name. After the React-RCTUIKit pod dep is wired in
+// RCTSwiftUI.podspec, the import is the canonical source of truth.
+// `RCTPlatformHostingController` stays as a Swift typealias below — it
+// wraps NSHostingController / UIHostingController which are SwiftUI
+// generics and not in the ObjC compat layer.
+import React_RCTUIKit
 #if os(macOS) // [macOS
 import AppKit
 #else
@@ -13,12 +24,8 @@ import UIKit
 #endif // macOS]
 
 #if os(macOS) // [macOS
-public typealias RCTPlatformView = NSView
-public typealias RCTUIColor = NSColor
 public typealias RCTPlatformHostingController = NSHostingController
 #else
-public typealias RCTPlatformView = UIView
-public typealias RCTUIColor = UIColor
 public typealias RCTPlatformHostingController = UIHostingController
 #endif // macOS]
 


### PR DESCRIPTION
  ## Summary

Wires the `React-RCTUIKit` pod into `RCTSwiftUI` so `RCTSwiftUIContainerView.swift` can import the ObjC-side `@compatibility_alias` declarations (`RCTPlatformView`, `RCTUIColor`) directly, instead of carrying its own Swift `typealias`
shadow copies of those names.

Two files, two coupled changes — must ship together. Removing the Swift typealiases without first wiring the pod dep would leave the Swift file with no source for `RCTPlatformView` / `RCTUIColor` and break compilation.
  ### 1. `RCTSwiftUI.podspec` — add `React-RCTUIKit` dependency

```ruby
s.dependency "React-RCTUIKit"

This puts the React_RCTUIKit clang module on the Swift module search path when RCTSwiftUIContainerView.swift builds. Unconditional (not s.osx) for parity with the rest of the apple pods — the dep is harmless on iOS since the umbrella
headers are mostly typedef-only there.

2. RCTSwiftUIContainerView.swift — import the module, drop duplicate typealiases

Before:
import SwiftUI
#if os(macOS)
import AppKit
#else
import UIKit
#endif

#if os(macOS)
public typealias RCTPlatformView = NSView
public typealias RCTUIColor = NSColor
public typealias RCTPlatformHostingController = NSHostingController
#else
public typealias RCTPlatformView = UIView
public typealias RCTUIColor = UIColor
public typealias RCTPlatformHostingController = UIHostingController
#endif

After:
import SwiftUI
import React_RCTUIKit  // [macOS] pulls in @compatibility_alias RCTPlatformView / RCTUIColor
#if os(macOS)
import AppKit
#else
import UIKit
#endif

#if os(macOS)
public typealias RCTPlatformHostingController = NSHostingController
#else
public typealias RCTPlatformHostingController = UIHostingController
#endif

RCTPlatformView is now sourced from RCTUIView.h:28-33 (@compatibility_alias RCTPlatformView UIView/NSView); RCTUIColor from RCTUIKitCompat.h:25-29. RCTPlatformHostingController stays as a Swift typealias — it's NSHostingController /
UIHostingController from SwiftUI, parameterized by view type, not in the ObjC compat layer.

Closes the "RCTUIKit Swift module" item on the Road to 0.83 tracking issue (#2901) — Saad's note there: "RCTUIKit.h can't be imported from Swift (needed by RCTSwiftUIContainerView.swift). Already broken out into its own module on main,
needs rebase into 0.83-merge." The module-ification itself was already brought in by the 0.83-merge upstream pull; what was missing was the consumer-side wiring on RCTSwiftUI, which this PR adds.

Test Plan

- pod install in packages/rn-tester on 0.83-merge resolves the new dep edge cleanly: Podfile.lock now records RCTSwiftUI (1000.0.0): - React-RCTUIKit, and React-RCTUIKit already appears at line 2262 as a top-level pod. Spec checksum
bumped from 97b5f3… to c47667…. 86 dependencies / 85 installed, no resolution errors. (Validated locally.)
- SourceKit reports No such module 'React_RCTUIKit' until pod install runs (the workspace doesn't know about the dep before install). After install, the workspace materializes React_RCTUIKit and the import resolves. This is the standard
pre-install state on any clean checkout, not a regression.
- The Swift file's only consumers of the dropped typealiases are local references inside the same file — verified the file still type-checks at the language level (uses match the ObjC @compatibility_alias types exactly).

Related

- #2847 — the original RCTUIKit module-ification on main (now needed on 0.83-merge too — already merged in via the upstream pull, this PR completes the consumer wiring)
- #2901 — Road to 0.83 tracking issue (closes the RCTUIKit Swift module item)