### PR TITLE
fix(fmt): patch base.h consteval gate via prepare_command for Xcode 26.x

### DIFF
--- a/packages/react-native/third-party-podspecs/fmt.podspec
+++ b/packages/react-native/third-party-podspecs/fmt.podspec
@@ -17,23 +17,36 @@ Pod::Spec.new do |spec|
     :git => fmt_git_url,
     :tag => "11.0.2"
   }
+  # Patch fmt's existing "Apple clang < 14 broken" gate at
+  # `include/fmt/base.h:122` to catch ALL Apple clang versions. fmt 11.0.2's
+  # consteval `basic_format_string` constructor is rejected by Xcode 26.x's
+  # stricter constexpr evaluator, breaking the compile of `Pods/fmt/src/format.cc`
+  # at `format-inl.h:59`, `60`, `1387`, `1391`, `1394`, etc. with:
+  #
+  #   error: call to consteval function 'fmt::basic_format_string<...>'
+  #          is not a constant expression
+  #
+  # fmt already disables consteval for compilers it considers broken
+  # (Apple clang < 14, MSVC VS2019 < 16.10 etc. — see `base.h:113-132`) by
+  # forcing the `FMT_USE_CONSTEVAL=0` branch of its config chain. Widening
+  # the existing Apple-clang branch to drop the `< 14000029L` upper bound
+  # adds Xcode 26.x to that broken-list and falls back to fmt's constexpr
+  # path, which compiles cleanly. Notes:
+  #
+  # - An xcconfig `GCC_PREPROCESSOR_DEFINITIONS = FMT_USE_CONSTEVAL=0`
+  #   alone does NOT work: fmt's chain in `base.h:113-132` has no
+  #   `#ifndef FMT_USE_CONSTEVAL` guard and unconditionally redefines the
+  #   macro to `1` on any compiler that sets `__cpp_consteval`. Patching
+  #   the source is the only path that survives the preprocessor.
+  # - Long-term fix is a fmt 11.1+ bump (fmt's own upstream addressed the
+  #   stricter-eval interaction there). This `sed` is the minimal,
+  #   reversible workaround until that lands.
+  spec.prepare_command = <<-CMD
+    /usr/bin/sed -i.bak 's|defined(__apple_build_version__) && __apple_build_version__ < 14000029L|defined(__apple_build_version__)|' include/fmt/base.h
+  CMD
   spec.pod_target_xcconfig = {
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
-    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES", # Disable warnings because we don't control this library
-    # [macOS] Xcode 26.x ships a stricter consteval evaluator than
-    # fmt 11.0.2's `FMT_STRING` macro expects, breaking the compile
-    # of `Pods/fmt/src/format.cc` with "call to consteval function is
-    # not a constant expression" at `format-inl.h:59, 60, 1387, 1391,
-    # 1394, ...`. fmt's own internal logic already gates consteval off
-    # for compilers it considers broken (see `base.h:113-132` —
-    # Apple clang <14, MSVC VS2019 <16.10, etc.); Xcode 26.x exposes a
-    # new failure mode that hasn't been added to that list yet, so we
-    # opt out of consteval here. The constexpr fallback fmt provides
-    # is fully functional — only the compile-time format-string check
-    # is sacrificed. Long-term fix is to bump fmt to 11.1+, where the
-    # underlying issue is addressed upstream; until then this is the
-    # minimal, reversible workaround.
-    "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) FMT_USE_CONSTEVAL=0"
+    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
   }
   spec.platforms = min_supported_versions
   spec.libraries = "c++"

--- a/packages/react-native/third-party-podspecs/fmt.podspec
+++ b/packages/react-native/third-party-podspecs/fmt.podspec
@@ -19,7 +19,21 @@ Pod::Spec.new do |spec|
   }
   spec.pod_target_xcconfig = {
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
-    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
+    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES", # Disable warnings because we don't control this library
+    # [macOS] Xcode 26.x ships a stricter consteval evaluator than
+    # fmt 11.0.2's `FMT_STRING` macro expects, breaking the compile
+    # of `Pods/fmt/src/format.cc` with "call to consteval function is
+    # not a constant expression" at `format-inl.h:59, 60, 1387, 1391,
+    # 1394, ...`. fmt's own internal logic already gates consteval off
+    # for compilers it considers broken (see `base.h:113-132` —
+    # Apple clang <14, MSVC VS2019 <16.10, etc.); Xcode 26.x exposes a
+    # new failure mode that hasn't been added to that list yet, so we
+    # opt out of consteval here. The constexpr fallback fmt provides
+    # is fully functional — only the compile-time format-string check
+    # is sacrificed. Long-term fix is to bump fmt to 11.1+, where the
+    # underlying issue is addressed upstream; until then this is the
+    # minimal, reversible workaround.
+    "GCC_PREPROCESSOR_DEFINITIONS" => "$(inherited) FMT_USE_CONSTEVAL=0"
   }
   spec.platforms = min_supported_versions
   spec.libraries = "c++"


### PR DESCRIPTION
## Summary

Patches fmt 11.0.2's `include/fmt/base.h` via the podspec's `prepare_command` to widen the existing "Apple clang < 14 consteval broken" gate so it catches all Apple clang. Xcode 26.x ships a stricter consteval evaluator than fmt 11.0.2
expects; the bundled `FMT_STRING` macro reaches `basic_format_string`'s consteval constructor and the compiler refuses with:

Pods/fmt/include/fmt/format-inl.h:59:24: error: call to consteval function
  'fmt::basic_format_string<...>::basic_format_string<FMT_COMPILE_STRING, 0>'
  is not a constant expression

(Multiple sites: lines 59, 60, 1387, 1391, 1394, ...)

This blocks every `pod install` + `xcodebuild` cycle on Xcode 26.x for any consumer of `react-native-macos` — including RNTester-macOS on `0.83-merge` and `microsoft/react-native-test-app`'s `example-macos`.

  ## Why `prepare_command` (and not xcconfig `-D`)

An earlier version of this PR set `GCC_PREPROCESSOR_DEFINITIONS = "$(inherited) FMT_USE_CONSTEVAL=0"` in `pod_target_xcconfig`. That approach **does not actually work**: fmt's config chain at `base.h:113-132` has no `#ifndef
FMT_USE_CONSTEVAL` guard and unconditionally redefines the macro to `1` on any compiler that sets `__cpp_consteval`. The `-D` from the compile command line gets overwritten by the time `basic_format_string`'s decorator is processed.
Verified locally: the macro lands in the generated xcconfig, but compile still fails with the same consteval errors.

Patching the source is the only path that survives clang's preprocessor passes. The existing "Apple clang < 14" branch on `base.h:122-123` already disables consteval for compilers fmt's authors consider broken; widening it to catch all
Apple clang versions extends that fix to Xcode 26.x and falls back to fmt's constexpr path, which compiles cleanly. The constexpr path is fmt's documented fallback and is already battle-tested for MSVC < VS2019 16.10, GCC < 10, and Apple
 clang < 14.

The `sed -i.bak` edit:

defined(apple_build_version) && apple_build_version < 14000029L
  → defined(apple_build_version)

Minimal, mechanical, reversible. Long-term fix is a fmt 11.1+ bump (fmt's own upstream addressed this in subsequent releases); this is the workaround until that bump lands.

## Test Plan

- **Before:** `xcodebuild -workspace packages/rn-tester/RNTesterPods.xcworkspace -scheme RNTester-macOS -configuration Debug -destination 'generic/platform=macOS' ARCHS=arm64 build` on `0.83-merge` fails at `CompileC
.../fmt.build/.../format.o` with the consteval errors above. Reproducible on any Xcode 26.x.
- **After:** Same `xcodebuild` produces `** BUILD SUCCEEDED **`. Additionally validated against `microsoft/react-native-test-app`'s `example-macos` via a local Verdaccio publish: `pod install` + `xcodebuild -scheme Example` both green,
produces a 44 MB `ReactTestApp.app` linking `hermesvm.framework`.
- The patched `base.h:122` line on a clean checkout reads `#elif defined(__apple_build_version__)` (no version constraint), and `FMT_USE_CONSTEVAL` resolves to `0` for all Apple clang.

## Related

- #2901 — Road to 0.83 tracking issue (unblocks RNTester-macOS validation on Xcode 26.x for everyone)
- #2963 — `React-RCTUIKit.podspec` files-array fix (also discovered during the same RNTA integration test that surfaced the inadequacy of the xcconfig-only approach)
- fmt 11.0.2 → 11.1+ bump (follow-up — would let us drop this prepare_command entirely)