### PR TITLE
fix(macos): guard iOS-only methods in RCTViewComponentView.mm so the file compiles on macOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -807,7 +807,7 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
 
   BOOL isPointInside = [self pointInside:point withEvent:event];
 
-  UIView *currentContainerView = self.currentContainerView;
+  RCTPlatformView *currentContainerView = self.currentContainerView; // [macOS]
 
   BOOL clipsToBounds = false;
 
@@ -1045,8 +1045,18 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
 // `blur` applied, we need to wrap it in a SwiftUI view to render the effect.
 // In this case, `effectiveContentView` will be the content view inside the
 // SwiftUI wrapper.
-- (UIView *)effectiveContentView
+//
+// macOS: SwiftUI-filter wrapping isn't yet ported (the wrapper assumes
+// UIKit's `UIView` / `RCTSwiftUIContainerViewWrapper` UIKit surface), so
+// the macOS path short-circuits to `return self`. When the SwiftUI port
+// lands for AppKit, gate the body on `enableSwiftUIBasedFilters()` &&
+// !TARGET_OS_OSX. Return type is `RCTPlatformView*` so the macOS caller
+// at currentContainerView compiles. [macOS]
+- (RCTPlatformView *)effectiveContentView // [macOS]
 {
+#if TARGET_OS_OSX // [macOS
+  return self;
+#else // macOS]
   if (!ReactNativeFeatureFlags::enableSwiftUIBasedFilters()) {
     return self;
   }
@@ -1089,6 +1099,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   }
 
   return effectiveContentView;
+#endif // [macOS]
 }
 
 // This UIView is the UIView that holds all subviews. It is sometimes not self
@@ -1096,7 +1107,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
 // the view and is not affected by clipping.
 - (RCTUIView *)currentContainerView // [macOS]
 {
-  UIView *effectiveContentView = self.effectiveContentView;
+  RCTPlatformView *effectiveContentView = self.effectiveContentView; // [macOS]
 
   if (_useCustomContainerView) {
     if (!_containerView) {
@@ -1357,7 +1368,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
       if (primitive.type == FilterType::DropShadow) {
         if (_swiftUIWrapper != nullptr && std::holds_alternative<DropShadowParams>(primitive.parameters)) {
           const auto &dropShadowParams = std::get<DropShadowParams>(primitive.parameters);
-          UIColor *shadowColor = RCTUIColorFromSharedColor(dropShadowParams.color);
+          RCTUIColor *shadowColor = RCTUIColorFromSharedColor(dropShadowParams.color); // [macOS]
           [_swiftUIWrapper updateDropShadow:@(dropShadowParams.standardDeviation)
                                           x:@(dropShadowParams.offsetX)
                                           y:@(dropShadowParams.offsetY)
@@ -2409,6 +2420,17 @@ enum MouseEventType {
   return NO;
 }
 
+#if !TARGET_OS_OSX // [macOS]
+// The block below is iOS-specific: SwiftUI-filter wrapping
+// (`transferVisualPropertiesFromView:`), `UIResponder` overrides
+// (`canBecomeFirstResponder`, `focus`, `blur`, `becomeFirstResponder`,
+// `resignFirstResponder`) and the `handleCommand:` shim that forwards into
+// them. The macOS branch above (between `#if TARGET_OS_OSX` at line 1846
+// and `#endif // macOS]` at line 2381) provides AppKit-flavored equivalents
+// for `focus`, `blur`, and the responder methods; SwiftUI-filter wrapping is
+// not yet ported to macOS (see `effectiveContentView` above, which short-
+// circuits on macOS). Without this guard the iOS code below is a duplicate
+// declaration on the macOS compile and uses unknown type `UIView`. [macOS]
 - (void)transferVisualPropertiesFromView:(UIView *)sourceView toView:(UIView *)destinationView
 {
   // shadow
@@ -2512,6 +2534,7 @@ enum MouseEventType {
 
   return YES;
 }
+#endif // [macOS]
 
 @end
 


### PR DESCRIPTION
## Summary

`RCTViewComponentView.mm` did not compile on macOS in `0.83-merge`. The upstream 0.83 merge brought in new iOS-only methods that aren't wrapped in `#if !TARGET_OS_OSX` guards, leaving them visible to the macOS compile where they trip
duplicate-declaration errors against the existing AppKit-flavored methods in the macOS branch + use `UIView` / `UIColor` types unknown to AppKit.

Concrete errors blocking `xcodebuild -scheme RNTester-macOS`:

RCTViewComponentView.mm:810:3: error: unknown type name 'UIView'; did you mean 'NSView'?
RCTViewComponentView.mm:1048:4: error: expected a type        (- (UIView )effectiveContentView)
RCTViewComponentView.mm:1371:11: error: unknown type name 'UIColor'; did you mean 'CIColor'?
RCTViewComponentView.mm:2412:43: error: expected a type        (transferVisualPropertiesFromView:(UIView))
RCTViewComponentView.mm:2465:1: error: duplicate declaration of method 'handleCommand:args:'
RCTViewComponentView.mm:2478:1: error: duplicate declaration of method 'focus'
RCTViewComponentView.mm:2483:1: error: duplicate declaration of method 'blur'
RCTViewComponentView.mm:2490:1: error: duplicate declaration of method 'becomeFirstResponder'
RCTViewComponentView.mm:2503:1: error: duplicate declaration of method 'resignFirstResponder'

The macOS branch at lines `1846-2381` already provides AppKit-flavored versions of `focus`, `blur`, `becomeFirstResponder`, `resignFirstResponder`, `handleCommand:` — the duplicates after that block are iOS-canonical implementations
brought in by the upstream merge.

This PR is **surgical**: every change is either (a) wrapping iOS code in `#if !TARGET_OS_OSX` so it disappears from the macOS compile, or (b) swapping `UIView*` / `UIColor*` types for the existing fork-wide `RCTPlatformView*` /
`RCTUIColor*` compatibility aliases that resolve to the right AppKit class on macOS. **No iOS behavior changes** — every iOS code path executes identically before and after.

### Changes (5 surgical edits)

1. **Line 810 — `hitTest:` local var.** `UIView *currentContainerView` → `RCTPlatformView *currentContainerView`. The getter (`currentContainerView` declared at 1107) already returns `RCTUIView*` which is `NSView*` on macOS and `UIView*`
 on iOS; the local just needed to match.

2. **Lines 1048-1102 — `effectiveContentView` method.** Return type `UIView*` → `RCTPlatformView*`. Wrapped the SwiftUI-filter body in `#if TARGET_OS_OSX ... return self; #else ... <existing body> ... #endif`. The SwiftUI-filter wrapping
 uses `RCTSwiftUIContainerViewWrapper` which currently assumes UIKit's `UIView` surface — not yet ported to macOS. macOS falls back to the trivial `return self` path (callers continue to work because the type is `RCTPlatformView*`).

3. **Line 1109 — `currentContainerView` caller.** `UIView *effectiveContentView = self.effectiveContentView;` → `RCTPlatformView *effectiveContentView = ...`. Matches the updated return type from change #2.

4. **Line 1371 — SwiftUI dropShadow color.** `UIColor *shadowColor = RCTUIColorFromSharedColor(...)` → `RCTUIColor *shadowColor = ...`. `RCTUIColor` is the existing `@compatibility_alias` defined at
`React/RCTUIKit/RCTUIKitCompat.h:25-29` (UIColor on iOS, NSColor on macOS). `RCTUIColorFromSharedColor` already returns NSColor on macOS, and `RCTSwiftUIContainerViewWrapper.h` exposes the `updateDropShadow:...color:` selector with both
UIColor (iOS) and NSColor (macOS) overloads — the typed alias picks the right one per platform.

5. **Lines 2412-2515 — wrap iOS-only methods in `#if !TARGET_OS_OSX`.** Covers `transferVisualPropertiesFromView:toView:` (UIView-typed args), `canBecomeFirstResponder` (UIResponder semantics — macOS uses `acceptsFirstResponder`
instead), and the duplicates of `handleCommand:args:` / `focus` / `blur` / `becomeFirstResponder` / `resignFirstResponder` that conflict with the AppKit-flavored versions in the macOS branch above.

### Relationship to other in-flight PRs

- **Depends on #2961** (fmt FMT_USE_CONSTEVAL=0) — without it, `pod install`+`xcodebuild` fails at `Pods/fmt/src/format.cc` before ever reaching this file on Xcode 26.x.
- **Coexists with #2959** (three Fabric focus regressions) — that PR touches the macOS branch of this same file (lines 1886-1924) for focus behavior; this PR touches different line ranges for compile correctness. No merge conflict.

Together, **#2961 + this PR + #2959** are the minimum set required for `xcodebuild -scheme RNTester-macOS build` to succeed on `0.83-merge` for Xcode 26.x. Without this PR, the file is rejected at the type-check stage and the whole
`React-RCTFabric-macOS` target fails to compile.

Closes the macOS-compile half of the **"Verify focus changes"** + **"RNTester validation"** items on the Road to 0.83 tracking issue (#2901). With #2960 (pbxproj restore) + this PR + #2961, `xcodebuild ... -scheme RNTester-macOS build`
now completes with `** BUILD SUCCEEDED **`.

## Test Plan

- **Before:** `xcodebuild -workspace packages/rn-tester/RNTesterPods.xcworkspace -scheme RNTester-macOS -configuration Debug -destination 'generic/platform=macOS' ARCHS=arm64 ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO build` fails at
`CompileC .../React-RCTFabric-macOS.build/.../RCTViewComponentView.o` with the 9+ errors quoted above. Reproducible on a clean `0.83-merge` checkout running Xcode 26.x.
- **After:** same `xcodebuild` produces `** BUILD SUCCEEDED **` and a runnable `Build/Products/Debug/RNTester-macOS.app`. Validated locally with Xcode 26.5 / arm64 / Debug after applying both #2961 and this PR.
- **iOS regression check:** every edit either swaps `UIView`/`UIColor` for `RCTPlatformView`/`RCTUIColor` (compat aliases that resolve identically to the original types on iOS) or moves iOS code inside `#if !TARGET_OS_OSX`. No iOS code
path is removed; iOS `RNTester` build is unaffected.
- 311 warnings remain after this PR — all pre-existing on `0.83-merge` (deprecation notices on AppKit APIs, "build phase runs every build" hints, etc.), unrelated to this change.

## Related

- #2901 — Road to 0.83 tracking issue (closes the macOS-compile blocker for "Verify focus changes" / "RNTester validation")
- #2961 — fmt FMT_USE_CONSTEVAL=0 (prerequisite for reaching this file's compile on Xcode 26.x)
- #2959 — Three Fabric focus regressions (touches same file, different lines, no conflict)
- #2960 — Restore project.pbxproj (prerequisite for any `pod install` on `0.83-merge`)