### PR TITLE
fix(macos): include React-RCTUIKit.podspec in package files array

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -110,6 +110,7 @@
     "local-cli",
     "React-Core.podspec",
     "React-Core-prebuilt.podspec",
+    "React-RCTUIKit.podspec",
     "react-native.config.js",
     "React.podspec",
     "React",


### PR DESCRIPTION
## Summary

`packages/react-native/package.json` lists three macOS-fork podspecs in the `files` array — `React-Core.podspec`, `React-Core-prebuilt.podspec`, `React.podspec` — but **omits `React-RCTUIKit.podspec`**, which was introduced by #2847
(RCTUIKit module-ification, merged March 2026). As a result the file lives in the source tree but is excluded from the npm publish.

Any downstream consumer of a published \`react-native-macos@0.83\` hits this immediately:

\`\`\`
[!] No podspec found for \`React-RCTUIKit\` in \`../node_modules/react-native-macos/\`
\`\`\`

\`pod install\` fails before reaching any actual install step.

Discovered while running [react-native-test-app](https://github.com/microsoft/react-native-test-app)'s \`example-macos\` against the fork's \`0.83-merge\` via a local Verdaccio registry — the file shows up in the source tree
(\`packages/react-native/React-RCTUIKit.podspec\`) but never lands in \`node_modules/react-native-macos/\` after install.

Fix is a one-line addition to the \`files\` array, right next to the other root-level podspecs. Closes the consumer-install gap for any downstream user (RNTA, Epistles, anyone else) once 0.83 ships to npm.

## Test Plan

- **Before:** \`npm pack\` on \`packages/react-native\` produces a tarball without \`React-RCTUIKit.podspec\`. RNTA's \`example-macos\` \`pod install\` fails with "No podspec found for React-RCTUIKit".
- **After:** \`npm pack\` includes the file; \`pod install\` resolves the React-RCTUIKit pod from \`../node_modules/react-native-macos/React-RCTUIKit.podspec\` and continues. Validated locally with RNTA's \`example-macos\` building
cleanly through to a \`ReactTestApp.app\` artifact.

## Related

- #2847 — introduced \`React-RCTUIKit.podspec\` (and the corresponding \`React-RCTUIKit\` pod dep in \`React-Core.podspec\`), but didn't update the \`files\` array.
- #2958 — wires \`React-RCTUIKit\` into \`RCTSwiftUI.podspec\`; depends on this podspec being available to consumers.
- #2901 — Road to 0.83 tracking issue (unblocks downstream consumers in general).