### PR TITLE
fix(macos): align TouchableBounce focusable + AccessibilityInfo guards with upstream 0.83

### DIFF
--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -98,8 +98,9 @@ const AccessibilityInfo = {
    * See https://reactnative.dev/docs/accessibilityinfo#isBoldTextEnabled
    */
   isBoldTextEnabled(): Promise<boolean> {
-    // [macOS rework logic to return Promise.resolve(false) on macOS
-    if (Platform.OS === 'ios') {
+    if (Platform.OS === 'android' || Platform.OS === 'macos' /* [macOS] */) {
+      return Promise.resolve(false);
+    } else {
       return new Promise((resolve, reject) => {
         if (NativeAccessibilityManagerApple != null) {
           NativeAccessibilityManagerApple.getCurrentBoldTextState(
@@ -110,10 +111,7 @@ const AccessibilityInfo = {
           reject(new Error('NativeAccessibilityManagerIOS is not available'));
         }
       });
-    } else {
-      return Promise.resolve(false);
     }
-    // macOS]
   },
 
   /**
@@ -333,8 +331,9 @@ const AccessibilityInfo = {
    * See https://reactnative.dev/docs/accessibilityinfo#isReduceTransparencyEnabled
    */
   isReduceTransparencyEnabled(): Promise<boolean> {
-    // [macOS rework logic to return Promise.resolve(false) on macOS
-    if (Platform.OS === 'ios') {
+    if (Platform.OS === 'android' || Platform.OS === 'macos' /* [macOS] */) {
+      return Promise.resolve(false);
+    } else {
       return new Promise((resolve, reject) => {
         if (NativeAccessibilityManagerApple != null) {
           NativeAccessibilityManagerApple.getCurrentReduceTransparencyState(
@@ -345,10 +344,7 @@ const AccessibilityInfo = {
           reject(new Error('NativeAccessibilityManagerIOS is not available'));
         }
       });
-    } else {
-      return Promise.resolve(false);
     }
-    // macOS]
   },
 
   /**

--- a/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
@@ -202,7 +202,11 @@ class TouchableBounce extends React.Component<
             this.props.enableFocusRing === true) &&
           !this.props.disabled
         }
-        focusable={this.props.focusable !== false && !this.props.disabled}
+        focusable={
+          this.props.focusable !== false &&
+          this.props.onPress !== undefined && // [macOS] mirror upstream's 0.83 focusable guard
+          !this.props.disabled
+        }
         tooltip={this.props.tooltip}
         onMouseEnter={this.props.onMouseEnter}
         onMouseLeave={this.props.onMouseLeave}


### PR DESCRIPTION
## Summary

Two small JS-layer cleanups surfaced by a three-way-merge audit of fork-patched `Libraries/Components/**` files after the 0.83 upstream merge. Both fixes address divergence between the fork's `[macOS]` patches and upstream's restructured
 0.83 logic.

### 1. `TouchableBounce.js` — missing `onPress` guard in macOS `focusable` check

Upstream 0.83 changed the `focusable` prop on the inner `<Animated.View>` of `TouchableBounce.render()` from:

```js
focusable={this.props.focusable !== false && !this.props.disabled}

to:

focusable={
  this.props.focusable !== false &&
  this.props.onPress !== undefined &&
  !this.props.disabled
}

The fork's [macOS] block — which replaces the upstream <Animated.View> prop set with a macOS-specific set including acceptsFirstMouse, enableFocusRing, tooltip, mouse/drag handlers, etc. — kept the pre-0.83 focusable shape, missing the
new onPress !== undefined guard. Effect on macOS: a TouchableBounce without an onPress prop is still Tab-focusable / VoiceOver-reachable, even though it has no interaction. Decorative wrappers wrongly grab keyboard focus.

Fix: add the same onPress !== undefined guard to the macOS focusable check.

2. AccessibilityInfo.js — align macOS noop carve-outs with upstream's 0.83 android-first guard structure

Upstream 0.83 restructured two methods — isBoldTextEnabled (line 100) and isReduceTransparencyEnabled (line 335) — from:

if (Platform.OS === 'ios') { /* iOS native call */ } else { return Promise.resolve(false); }

to:

if (Platform.OS === 'android') { return Promise.resolve(false); } else { /* iOS native call */ }

(android-first guard). The fork's [macOS] blocks preserved the OLD if (ios) shape, which on macOS happens to land in the else branch and currently produces correct (noop) behavior. But this is structurally fragile:

- A future Apple platform reporting a non-'ios'/non-'macos' Platform.OS would silently fall into the macOS else branch (currently fine since it's a noop, but a foot-gun if someone changes the else body).
- The fork's diff against upstream is larger than necessary — every future merge will have to wrestle with this shape mismatch.

Fix: align with upstream's android-first guard, adding macos explicitly to the noop branch as an || Platform.OS === 'macos' /* [macOS] */ inline clause. Single-line diff against upstream; easy for future merges.

Together, these close the audit item for "Audit upstream breaking changes" on the Road to 0.83 tracking issue (#2901). The audit covered 9 fork-patched JS files; 7 were clean (ViewNativeComponent, ReactNativeStyleAttributes, ScrollView,
ScrollViewStickyHeader, TextInput, ImageInjection, ImageTypes) and 2 had the issues fixed here.

Test Plan

- TouchableBounce focusable: code review — the macOS guard mirrors upstream's exactly, in the same precedence inside the [macOS]/macOS] block.
- AccessibilityInfo.isBoldTextEnabled / isReduceTransparencyEnabled on macOS: both still return Promise.resolve(false) (verified by reading the new guard — Platform.OS === 'macos' matches the early-return).
- iOS unchanged: same native call, same error message, same Promise shape.
- Flow types: no signature changes; type-check is unaffected.

Related

- #2901 — Road to 0.83 tracking issue (closes the "Audit upstream breaking changes" item alongside the earlier audit comment noting P1-P4 already absorbed by the merge).
- Audit also flagged a third candidate (TextInput.js:90,92 RCTSingelineTextInputNativeComponent typo'd require path), but verification showed both the file AND the require are consistently misspelled the same way — quirky, not broken.
Out of scope.