### PR TITLE
fix(podspec): comment out duplicate scrollview subspec in React-FabricComponents

### DIFF
--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -101,14 +101,25 @@ Pod::Spec.new do |s|
       sss.header_dir           = "react/renderer/components/safeareaview"
     end
 
-    ss.subspec "scrollview" do |sss|
-      sss.source_files         = podspec_sources(["react/renderer/components/scrollview/*.{m,mm,cpp,h}",
-                                  "react/renderer/components/scrollview/platform/cxx/**/*.{m,mm,cpp,h}"],
-                                  ["react/renderer/components/scrollview/*.h",
-                                  "react/renderer/components/scrollview/platform/cxx/**/*.h"])
-      sss.exclude_files        = "react/renderer/components/scrollview/tests"
-      sss.header_dir           = "react/renderer/components/scrollview"
-    end
+    # [macOS The "scrollview" subspec below duplicates source_files already declared in
+    # React-Fabric.podspec's "scrollview" subspec (which uses a recursive
+    # `react/renderer/components/scrollview/**/*` glob). The overlap causes
+    # ScrollViewShadowNode.cpp and friends to be compiled into both the
+    # React-Fabric and React-FabricComponents Pods targets, breaking consumers
+    # that link both libraries via `-all_load` (duplicate symbols). Comment it
+    # out here so scrollview is only built into React-Fabric -- where
+    # React-Fabric's mounting/internal/CullingContext.cpp already needs
+    # ScrollViewShadowNode anyway.
+    #
+    # ss.subspec "scrollview" do |sss|
+    #   sss.source_files         = podspec_sources(["react/renderer/components/scrollview/*.{m,mm,cpp,h}",
+    #                               "react/renderer/components/scrollview/platform/cxx/**/*.{m,mm,cpp,h}"],
+    #                               ["react/renderer/components/scrollview/*.h",
+    #                               "react/renderer/components/scrollview/platform/cxx/**/*.h"])
+    #   sss.exclude_files        = "react/renderer/components/scrollview/tests"
+    #   sss.header_dir           = "react/renderer/components/scrollview"
+    # end
+    # macOS]
 
     ss.subspec "text" do |sss|
       sss.source_files         = podspec_sources(["react/renderer/components/text/*.{m,mm,cpp,h}",


### PR DESCRIPTION
## Summary

The `scrollview` subspec is declared in BOTH `React-Fabric.podspec` and `React-FabricComponents.podspec`, with overlapping `source_files`:

- `React-Fabric.podspec` → `react/renderer/components/scrollview/**/*.{m,mm,cpp,h}` (recursive)
- `React-FabricComponents.podspec` → `react/renderer/components/scrollview/*.{m,mm,cpp,h}` + `scrollview/platform/cxx/**/*` (non-recursive + platform/cxx)

Both globs include the same top-level files (`ScrollViewShadowNode.cpp`, `BaseScrollViewProps.cpp`, `ScrollEvent.cpp`, etc.). After `pod install`, those source files end up in both the `React-Fabric` and `React-FabricComponents` Pods targets.

### What breaks

- **Consumers that link both libraries** (e.g. via `-all_load`) hit **duplicate symbol** errors at link time.
- **Consumers that deduplicate by hand** by dropping scrollview sources from one target break differently: `React-Fabric`'s `mounting/internal/CullingContext.cpp` references `ScrollViewShadowNode`, so if the dedup drops it from `React-Fabric`, link fails with `Undefined symbols: ScrollViewShadowNode`.

### Fix

Comment out (rather than delete, per the [macOS diffs-with-upstream guide](https://github.com/microsoft/react-native-macos/blob/main/docsite/docs/contributing/diffs-with-upstream.md)) the `scrollview` subspec in `React-FabricComponents.podspec`, wrapped in `# [macOS` / `# macOS]` diff tags with an inline explanation. The recursive glob in `React-Fabric.podspec`'s scrollview subspec already covers everything FabricComponents was listing.

### Test plan

- [x] `pod install` succeeded against this branch (`RCT_NEW_ARCH_ENABLED=0` in `packages/rn-tester/`).
- [x] Generated `Pods.xcodeproj`:
  - `React-Fabric-macOS` target's Sources phase contains `ScrollViewShadowNode.cpp`, `BaseScrollViewProps.cpp`, `ScrollEvent.cpp`, `ScrollViewEventEmitter.cpp`, `ScrollViewState.cpp` ✓
  - `React-FabricComponents-macOS` target's Sources phase does NOT contain those files ✓
- [ ] Build verification on `RNTester` (CI will do this)

Discovered while integrating `react-native-macos` v0.81.6 into a monorepo that links both `libReact-Fabric-macOS.a` and `libReact-FabricComponents-macOS.a` via `-all_load`.
