### PR TITLE
fix(0.81, podspec): comment out duplicate scrollview subspec in React-FabricComponents

### DIFF
--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -99,14 +99,25 @@ Pod::Spec.new do |s|
       sss.header_dir           = "react/renderer/components/safeareaview"
     end
 
-    ss.subspec "scrollview" do |sss|
-      sss.source_files         = podspec_sources(["react/renderer/components/scrollview/*.{m,mm,cpp,h}",
-                                  "react/renderer/components/scrollview/platform/cxx/**/*.{m,mm,cpp,h}"],
-                                  ["react/renderer/components/scrollview/*.h",
-                                  "react/renderer/components/scrollview/platform/cxx/**/*.h"])
-      sss.exclude_files        = "react/renderer/components/scrollview/tests"
-      sss.header_dir           = "react/renderer/components/scrollview"
-    end
+    # [macOS The "scrollview" subspec below duplicates source_files already declared in
+    # React-Fabric.podspec's "scrollview" subspec (which uses a recursive
+    # `react/renderer/components/scrollview/**/*` glob). The overlap causes
+    # ScrollViewShadowNode.cpp and friends to be compiled into both the
+    # React-Fabric and React-FabricComponents Pods targets, breaking consumers
+    # that link both libraries via `-all_load` (duplicate symbols). Comment it
+    # out here so scrollview is only built into React-Fabric -- where
+    # React-Fabric's mounting/internal/CullingContext.cpp already needs
+    # ScrollViewShadowNode anyway.
+    #
+    # ss.subspec "scrollview" do |sss|
+    #   sss.source_files         = podspec_sources(["react/renderer/components/scrollview/*.{m,mm,cpp,h}",
+    #                               "react/renderer/components/scrollview/platform/cxx/**/*.{m,mm,cpp,h}"],
+    #                               ["react/renderer/components/scrollview/*.h",
+    #                               "react/renderer/components/scrollview/platform/cxx/**/*.h"])
+    #   sss.exclude_files        = "react/renderer/components/scrollview/tests"
+    #   sss.header_dir           = "react/renderer/components/scrollview"
+    # end
+    # macOS]
 
     ss.subspec "text" do |sss|
       sss.source_files         = podspec_sources(["react/renderer/components/text/*.{m,mm,cpp,h}",


### PR DESCRIPTION
## Summary
Backport of the changes from branch `fix/remove-duplicate-scrollview-subspec` to `0.81-stable`.

Original PR: #2969

## Test Plan
Same as the original PR — verified locally via `pod install` in `packages/rn-tester/` that:
- `React-Fabric-macOS` target's Sources phase contains `ScrollViewShadowNode.cpp` (and the other scrollview sources).
- `React-FabricComponents-macOS` target's Sources phase does NOT contain those files.
- No duplicate symbols when both libraries are linked.
