### PR TITLE
fix: don't require @react-native-community/cli at config-load time

### DIFF
--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -87,8 +87,17 @@ try {
   }
 }
 
+let macosCommands;
+try {
 // $FlowFixMe[untyped-import]
-const macosCommands = require('./local-cli/runMacOS/runMacOS');
+  macosCommands = require('./local-cli/runMacOS/runMacOS');
+} catch {
+  if (verbose) {
+    console.warn(
+      '@react-native-community/cli not found, the react-native.config.js may be unusable.',
+    );
+  }
+}
 const {
   bundleCommand,
   startCommand,
@@ -161,7 +170,9 @@ if (android != null) {
 }
 
 // [macOS
-config.commands.push(...macosCommands);
+if (macosCommands != null) {
+  config.commands.push(...macosCommands);
+}
 if (apple) {
   config.platforms.macos = {
     linkConfig: () => {

--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -88,13 +88,15 @@ try {
 }
 
 let macosCommands;
+// Loading `runMacOS` requires `@react-native-community/cli`which is an
+// optional peer dependency and is not installed when using Expo CLI.
 try {
 // $FlowFixMe[untyped-import]
   macosCommands = require('./local-cli/runMacOS/runMacOS');
-} catch {
+} catch (e) {
   if (verbose) {
     console.warn(
-      '@react-native-community/cli not found, the react-native.config.js may be unusable.',
+      `Failed to load runMacOS commands, the react-native.config.js may be unusable: ${e instanceof Error ? e.message : String(e)}`,
     );
   }
 }

--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -91,7 +91,7 @@ let macosCommands;
 // Loading `runMacOS` requires `@react-native-community/cli`which is an
 // optional peer dependency and is not installed when using Expo CLI.
 try {
-// $FlowFixMe[untyped-import]
+  // $FlowFixMe[untyped-import]
   macosCommands = require('./local-cli/runMacOS/runMacOS');
 } catch (e) {
   if (verbose) {


### PR DESCRIPTION
## Summary:

In theory, `@react-native-community/cli` should be an optional dependency, but currently the `runMacOS` commands import requires `@react-native-community/cli` directly, causing Expo CLI users to also have to install `@react-native-community/cli`

This PR guards the `require` the same way as the platform packages, and only attaches the commands when the import succeeds. The runtime behavior for projects that do install the CLI is unchanged.

## Test Plan:

- In a project that does not depend on `@react-native-community/cli` (e.g. an Expo app using `expo-modules-autolinking`), run `pod install` and confirm `use_native_modules!` no longer throws when loading `react-native.config.js`.
- In a project that depends on `@react-native-community/cli`, confirm `npx react-native run-macos` and the other macOS commands still register and work as before.
- With `DEBUG=*` set, confirm the new warning (`./local-cli/runMacOS/runMacOS not found, the react-native.config.js may be unusable.`) is emitted only when the require fails, matching the existing warnings for the other platform packages.
