### PR TITLE
chore(ci): Bump Xcode to 26.2

### DIFF
--- a/.github/actions/microsoft-setup-toolchain/action.yml
+++ b/.github/actions/microsoft-setup-toolchain/action.yml
@@ -18,7 +18,7 @@ inputs:
     default: "22"
   xcode-developer-dir:
     description: Set the path for the active Xcode developer directory
-    default: "/Applications/Xcode.app"
+    default: "/Applications/Xcode_26.2.app"
   cmake-version:
     description: CMake version to install. Set to 'system' to skip installation and use the runner's pre-installed cmake.
     default: "3.31.9"

--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -4,7 +4,7 @@ inputs:
   xcode-version:
     description: 'The xcode version to use'
     required: false
-    default: '16.2.0'
+    default: '26.2'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Summary:

CI is failing because of fmt's version, bumping Xcode to 26.2 should fix it 

## Test Plan:

CI should be green
