### PR TITLE
fix(ci): run checks on merge branches

### DIFF
--- a/.github/workflows/microsoft-pr.yml
+++ b/.github/workflows/microsoft-pr.yml
@@ -3,7 +3,7 @@ name: PR
 on:
   pull_request:
     types: [opened, synchronize, edited]
-    branches: [ "main", "*-stable", "release/*" ]
+    branches: [ "main", "*-stable", "release/*", "*-merge" ]
 
 concurrency:
   # Ensure single build of a pull request. `main` should not be affected.


### PR DESCRIPTION
## Summary:

We've started to use intermediate `*-merge` branches, so let's have CI run on them too. They won't block merging if they fail since these are working branches. 