### PR TITLE
chore: add support for macos platform key in autolinking config

### DIFF
--- a/packages/react-native/scripts/cocoapods/autolinking.rb
+++ b/packages/react-native/scripts/cocoapods/autolinking.rb
@@ -38,12 +38,13 @@ def list_native_modules!(config_command)
   config = JSON.parse(json)
 
   packages = config["dependencies"]
-  ios_project_root = Pathname.new(config["project"]["ios"]["sourceDir"])
+  project_config = config["project"]["macos"] || config["project"]["ios"] # [macOS]
+  ios_project_root = Pathname.new(project_config["sourceDir"]) # [macOS]
   react_native_path = Pathname.new(config["reactNativePath"])
   found_pods = []
 
   packages.each do |package_name, package|
-    next unless package_config = package["platforms"]["ios"]
+    next unless package_config = package["platforms"]["macos"] || package["platforms"]["ios"] # [macOS]
 
     name = package["name"]
     podspec_path = package_config["podspecPath"]


### PR DESCRIPTION
## Summary:

The CocoaPods autolinking script hard-codes the `ios` platform key when reading the `react-native config` JSON, which assumes the upstream config provider always emits its project root and per-package config under `ios`. For proper out-of-tree platform support, autolinking should honor `--platform macos` and read `package["platforms"]["macos"]`, otherwise `config["project"]["ios"]` is `nil` and `pod install` crashes.


## Test Plan:

- `pod install` in a `react-native-macos` test app driven by Expo's CLI (`expo-modules-autolinking` with `--platform macos`) completes without the `nil:NilClass` error on `config["project"]["ios"]`.
- `pod install` in a `react-native-macos` test app driven by `@react-native-community/cli` (which emits `ios` keys) still resolves the same set of pods as before.
- Autolinked modules that only declare `platforms.ios` in their `react-native.config.js` still appear in `Found N modules for target ...`.
