### PR TITLE
ci(0.81): pass --access public to npm publish

### DIFF
--- a/.ado/jobs/npm-publish.yml
+++ b/.ado/jobs/npm-publish.yml
@@ -80,12 +80,12 @@ jobs:
               yarn config set npmPublishRegistry "https://registry.npmjs.org"
               yarn config set npmAuthToken $(npmAuthToken)
               echo "Publishing with yarn npm publish"
-              yarn ./packages/virtualized-lists npm publish --tolerate-republish --tag $(publishTag)
-              yarn ./packages/react-native npm publish      --tolerate-republish --tag $(publishTag)
+              yarn ./packages/virtualized-lists npm publish --access public --tolerate-republish --tag $(publishTag)
+              yarn ./packages/react-native npm publish      --access public --tolerate-republish --tag $(publishTag)
             else
               echo "Publishing with npm publish"
-              npm publish ./packages/virtualized-lists --tag $(publishTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
-              npm publish ./packages/react-native      --tag $(publishTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
+              npm publish ./packages/virtualized-lists --access public --tag $(publishTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
+              npm publish ./packages/react-native      --access public --tag $(publishTag) --registry https://registry.npmjs.org/ --//registry.npmjs.org/:_authToken=$(npmAuthToken)
             fi
           fi
         displayName: Publish packages


### PR DESCRIPTION
## Summary
- add `--access public` to scoped package publish commands in `.ado/jobs/npm-publish.yml`
- apply the flag to both yarn and npm publish paths

## Why
Azure publish failed while publishing `@react-native-macos/virtualized-lists` with:
- `YN0035 Not found`
- `PUT https://registry.npmjs.org/@react-native-macos%2fvirtualized-lists`

For scoped packages, publish needs explicit public access. This change aligns the pipeline command with npm scoped package publish requirements.

## Test Plan
- Re-run the Azure publish pipeline on this PR/branch and verify `Publish packages` succeeds for both:
  - `@react-native-macos/virtualized-lists`
  - `react-native-macos`
