### PR TITLE
chore(0.81): new patch release

### DIFF
--- a/.nx/version-plans/version-plan-1782515304485.md
+++ b/.nx/version-plans/version-plan-1782515304485.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+0.81 patch release retry after failed 0.81.8 publish

--- a/packages/react-native/Libraries/Core/ReactNativeVersion.js
+++ b/packages/react-native/Libraries/Core/ReactNativeVersion.js
@@ -17,6 +17,6 @@ export const version: $ReadOnly<{
 }> = {
   major: 0,
   minor: 81,
-  patch: 8,
+  patch: 7,
   prerelease: null,
 };

--- a/packages/react-native/React/Base/RCTVersion.m
+++ b/packages/react-native/React/Base/RCTVersion.m
@@ -23,7 +23,7 @@ NSDictionary* RCTGetReactNativeVersion(void)
     __rnVersion = @{
                   RCTVersionMajor: @(0),
                   RCTVersionMinor: @(81),
-                  RCTVersionPatch: @(8),
+                  RCTVersionPatch: @(7),
                   RCTVersionPrerelease: [NSNull null],
                   };
   });

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.81.8
+VERSION_NAME=0.81.7
 react.internal.publishingGroup=com.facebook.react
 
 android.useAndroidX=true

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.kt
@@ -14,7 +14,7 @@ public object ReactNativeVersion {
   public val VERSION: Map<String, Any?> = mapOf(
     "major" to 0,
     "minor" to 81,
-    "patch" to 8,
+    "patch" to 7,
     "prerelease" to null
   )
 }

--- a/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -14,14 +14,14 @@
 
 #define REACT_NATIVE_VERSION_MAJOR 0
 #define REACT_NATIVE_VERSION_MINOR 81
-#define REACT_NATIVE_VERSION_PATCH 8
+#define REACT_NATIVE_VERSION_PATCH 7
 
 namespace facebook::react {
 
 constexpr struct {
   int32_t Major = 0;
   int32_t Minor = 81;
-  int32_t Patch = 8;
+  int32_t Patch = 7;
   std::string_view Prerelease = "";
 } ReactNativeVersion;
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-macos",
-  "version": "0.81.8",
+  "version": "0.81.7",
   "description": "React Native for macOS",
   "license": "MIT",
   "repository": {
@@ -187,7 +187,7 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^29.7.0",
-    "@react-native-macos/virtualized-lists": "0.81.8",
+    "@react-native-macos/virtualized-lists": "0.81.7",
     "@react-native/assets-registry": "0.81.6",
     "@react-native/codegen": "0.81.6",
     "@react-native/community-cli-plugin": "0.81.6",

--- a/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
+++ b/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
@@ -361,7 +361,7 @@ exports[`execute test-app "ReactAppDependencyProvider.podspec" should match snap
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-version = \\"0.81.8\\"
+version = \\"0.81.7\\"
 source = { :git => 'https://github.com/facebook/react-native.git' }
 if version == '1000.0.0'
   # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
@@ -399,7 +399,7 @@ exports[`execute test-app "ReactCodegen.podspec" should match snapshot 1`] = `
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-version = \\"0.81.8\\"
+version = \\"0.81.7\\"
 source = { :git => 'https://github.com/facebook/react-native.git' }
 if version == '1000.0.0'
   # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
@@ -840,7 +840,7 @@ exports[`execute test-app-legacy "ReactAppDependencyProvider.podspec" should mat
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-version = \\"0.81.8\\"
+version = \\"0.81.7\\"
 source = { :git => 'https://github.com/facebook/react-native.git' }
 if version == '1000.0.0'
   # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
@@ -878,7 +878,7 @@ exports[`execute test-app-legacy "ReactCodegen.podspec" should match snapshot 1`
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-version = \\"0.81.8\\"
+version = \\"0.81.7\\"
 source = { :git => 'https://github.com/facebook/react-native.git' }
 if version == '1000.0.0'
   # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-macos/virtualized-lists",
-  "version": "0.81.8",
+  "version": "0.81.7",
   "description": "Virtualized lists for React Native macOS.",
   "license": "MIT",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3283,7 +3283,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@react-native-macos/virtualized-lists@npm:0.81.8, @react-native-macos/virtualized-lists@workspace:packages/virtualized-lists":
+"@react-native-macos/virtualized-lists@npm:0.81.7, @react-native-macos/virtualized-lists@workspace:packages/virtualized-lists":
   version: 0.0.0-use.local
   resolution: "@react-native-macos/virtualized-lists@workspace:packages/virtualized-lists"
   dependencies:
@@ -12309,7 +12309,7 @@ __metadata:
   resolution: "react-native-macos@workspace:packages/react-native"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.7.0"
-    "@react-native-macos/virtualized-lists": "npm:0.81.8"
+    "@react-native-macos/virtualized-lists": "npm:0.81.7"
     "@react-native/assets-registry": "npm:0.81.6"
     "@react-native/codegen": "npm:0.81.6"
     "@react-native/community-cli-plugin": "npm:0.81.6"


### PR DESCRIPTION
## Summary
- revert the generated `chore(release): publish 0.81.8` bump commit so repo versions return to the last published baseline (`0.81.7`)
- keep a single Nx patch version plan to retry releasing `0.81.8`

## Why
`0.81.8` was tagged in git but did not fully publish to npm. Retrying from `0.81.7` + a patch version plan is the same working pattern used in the previous release-retry PR.

## Changes since v0.81.7
- chore(0.81): bump fmt to 12.1.0 to fix Xcode 26.4 (#2997)
- fix(0.81): Add value-initialization in RCTComponentData (#2999)
- ci(0.81): pass --access public to npm publish (#3000)

## Validation
- `yarn exec -- nx release --dry-run --verbose`
  - resolves current versions as `0.81.7`
  - plans bump to `0.81.8` for both `react-native-macos` and `@react-native-macos/virtualized-lists`

🤖 Generated with Copilot CLI
