### PR TITLE
fix(0.83, RCTUIKit): Extend support to SwiftUI

### DIFF
--- a/packages/react-native/React/RCTUIKit/RCTUIKitCompat.h
+++ b/packages/react-native/React/RCTUIKit/RCTUIKitCompat.h
@@ -233,12 +233,16 @@ typedef NS_ENUM(NSInteger, UIActivityIndicatorViewStyle) {
 @compatibility_alias RCTPlatformViewController UIViewController;
 @compatibility_alias RCTUIApplication UIApplication;
 @compatibility_alias RCTPlatformSwitch UISwitch;
+@compatibility_alias RCTPlatformHostingController UIHostingController;
+@compatibility_alias RCTPlatformViewRepresentable UIViewRepresentable;
 #else
 @compatibility_alias RCTPlatformApplication NSApplication;
 @compatibility_alias RCTPlatformWindow NSWindow;
 @compatibility_alias RCTPlatformViewController NSViewController;
 @compatibility_alias RCTUIApplication NSApplication;
 @compatibility_alias RCTPlatformSwitch NSSwitch;
+@compatibility_alias RCTPlatformHostingController NSHostingController;
+@compatibility_alias RCTPlatformViewRepresentable NSViewRepresentable;
 #endif
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUI.podspec
+++ b/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUI.podspec
@@ -29,6 +29,7 @@ Pod::Spec.new do |s|
   s.public_header_files    = "*.h"
   s.module_name            = "RCTSwiftUI"
   s.header_dir             = "RCTSwiftUI"
+  s.dependency "React-RCTUIKit" # [macOS]
 
   # Swift-specific configuration
   s.pod_target_xcconfig    = {

--- a/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
+++ b/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
@@ -6,21 +6,7 @@
  */
 
 import SwiftUI
-#if os(macOS) // [macOS
-import AppKit
-#else
-import UIKit
-#endif // macOS]
-
-#if os(macOS) // [macOS
-public typealias RCTPlatformView = NSView
-public typealias RCTUIColor = NSColor
-public typealias RCTPlatformHostingController = NSHostingController
-#else
-public typealias RCTPlatformView = UIView
-public typealias RCTUIColor = UIColor
-public typealias RCTPlatformHostingController = UIHostingController
-#endif // macOS]
+import React_RCTUIKit
 
 @MainActor @objc public class RCTSwiftUIContainerView: NSObject {
   private var containerViewModel = ContainerViewModel()
@@ -61,7 +47,7 @@ public typealias RCTPlatformHostingController = UIHostingController
     containerViewModel.grayscale = CGFloat(grayscale.floatValue)
   }
 
-  @objc public func updateDropShadow(standardDeviation: NSNumber, x: NSNumber, y: NSNumber, color: RCTUIColor) { // [macOS]
+  @objc public func updateDropShadow(standardDeviation: NSNumber, x: NSNumber, y: NSNumber, color: RCTPlatformColor) { // [macOS]
     containerViewModel.shadowRadius = CGFloat(standardDeviation.floatValue)
     containerViewModel.shadowX = CGFloat(x.floatValue)
     containerViewModel.shadowY = CGFloat(y.floatValue)
@@ -128,7 +114,7 @@ struct SwiftUIContainerView: View {
 
   var body: some View {
     if let contentView = viewModel.contentView {
-      PlatformViewWrapper(view: contentView) // [macOS]
+      RCTPlatformViewWrapper(view: contentView) // [macOS]
         .blur(radius: viewModel.blurRadius)
         .grayscale(viewModel.grayscale)
         .shadow(color: viewModel.shadowColor, radius: viewModel.shadowRadius, x: viewModel.shadowX, y: viewModel.shadowY)
@@ -139,26 +125,13 @@ struct SwiftUIContainerView: View {
   }
 }
 
-#if os(macOS) // [macOS
-struct PlatformViewWrapper: NSViewRepresentable {
-  let view: NSView
+struct RCTPlatformViewWrapper: RCTPlatformViewRepresentable { // [macOS]
+  let view: RCTPlatformView
 
-  func makeNSView(context: Context) -> NSView {
+  func makeRCTPlatformView(context: Context) -> RCTPlatformView { // [macOS]
     return view
   }
 
-  func updateNSView(_ nsView: NSView, context: Context) {
+  func updateRCTPlatformView(_ view: RCTPlatformView, context: Context) { // [macOS]
   }
 }
-#else
-struct PlatformViewWrapper: UIViewRepresentable {
-  let view: UIView
-
-  func makeUIView(context: Context) -> UIView {
-    return view
-  }
-
-  func updateUIView(_ uiView: UIView, context: Context) {
-  }
-}
-#endif // macOS]

--- a/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIContainerViewWrapper.h
+++ b/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIContainerViewWrapper.h
@@ -6,38 +6,21 @@
  */
 
 #import <Foundation/Foundation.h>
-#if TARGET_OS_OSX // [macOS
-#import <AppKit/AppKit.h>
-#else // macOS]
-#import <UIKit/UIKit.h>
-#endif // [macOS]
+#import <React/RCTUIKit.h> // [macOS]
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RCTSwiftUIContainerViewWrapper : NSObject
 
-#if !TARGET_OS_OSX // [macOS]
-- (UIView *_Nullable)contentView;
-#else // [macOS
-- (NSView *_Nullable)contentView;
-#endif // macOS]
+- (RCTPlatformView *_Nullable)contentView;
 - (void)updateBlurRadius:(NSNumber *)radius;
 - (void)updateGrayscale:(NSNumber *)grayscale;
-#if !TARGET_OS_OSX // [macOS]
-- (void)updateDropShadow:(NSNumber *)standardDeviation x:(NSNumber *)x y:(NSNumber *)y color:(UIColor *)color;
-#else // [macOS
-- (void)updateDropShadow:(NSNumber *)standardDeviation x:(NSNumber *)x y:(NSNumber *)y color:(NSColor *)color;
-#endif // macOS]
+- (void)updateDropShadow:(NSNumber *)standardDeviation x:(NSNumber *)x y:(NSNumber *)y color:(RCTPlatformColor *)color; // [macOS]
 - (void)updateSaturation:(NSNumber *)saturation;
 - (void)updateContrast:(NSNumber *)contrast;
 - (void)updateHueRotate:(NSNumber *)degrees;
-#if !TARGET_OS_OSX // [macOS]
-- (void)updateContentView:(UIView *)view;
-- (UIView *_Nullable)hostingView;
-#else // [macOS
-- (void)updateContentView:(NSView *)view;
-- (NSView *_Nullable)hostingView;
-#endif // macOS]
+- (void)updateContentView:(RCTPlatformView *)view; // [macOS]
+- (RCTPlatformView *_Nullable)hostingView; // [macOS]
 - (void)resetStyles;
 - (void)updateLayoutWithBounds:(CGRect)bounds;
 

--- a/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIContainerViewWrapper.m
+++ b/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIContainerViewWrapper.m
@@ -9,14 +9,6 @@
 
 @import RCTSwiftUI;
 
-#if TARGET_OS_OSX // [macOS
-typedef NSView RCTPlatformView;
-typedef NSColor RCTUIColor;
-#else // macOS]
-typedef UIView RCTPlatformView;
-typedef UIColor RCTUIColor;
-#endif // [macOS]
-
 @interface RCTSwiftUIContainerViewWrapper ()
 @property (nonatomic, strong) RCTSwiftUIContainerView *swiftContainerView;
 @end
@@ -76,7 +68,7 @@ typedef UIColor RCTUIColor;
   [self.swiftContainerView updateHueRotate:degrees];
 }
 
-- (void)updateDropShadow:(NSNumber *)standardDeviation x:(NSNumber *)x y:(NSNumber *)y color:(RCTUIColor *)color // [macOS]
+- (void)updateDropShadow:(NSNumber *)standardDeviation x:(NSNumber *)x y:(NSNumber *)y color:(RCTPlatformColor *)color // [macOS]
 {
   [self.swiftContainerView updateDropShadowWithStandardDeviation:standardDeviation x:x y:y color:color];
 }

--- a/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIWrapper.podspec
+++ b/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIWrapper.podspec
@@ -30,6 +30,7 @@ Pod::Spec.new do |s|
   s.module_name            = "RCTSwiftUIWrapper"
   s.header_dir             = "RCTSwiftUIWrapper"
   s.dependency "RCTSwiftUI"
+  s.dependency "React-RCTUIKit" # [macOS]
   
   s.pod_target_xcconfig    = {
     "SWIFT_VERSION" => "5.0",


### PR DESCRIPTION
## Summary:

Followup to https://github.com/microsoft/react-native-macos/pull/2958 , whose repo is still locked so we can't edit it.

Extend RCTUIKit support to SwiftUI

## Test Plan:

CI should pass
