### PR TITLE
fix(macos): don't reset prop-derived state during Fabric view recycle

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -762,11 +762,6 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   _removeClippedSubviews = NO;
   _reactSubviews = [NSMutableArray new];
   _accessibilityElements = [NSMutableArray new];
-#if TARGET_OS_OSX // [macOS
-    _allowsVibrancy = NO;
-    self.acceptsFirstMouse = NO;
-    self.mouseDownCanMoveWindow = YES;
-#endif // macOS]
 }
 
 - (void)setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:(NSSet<NSString *> *_Nullable)props


### PR DESCRIPTION
## Summary

`RCTViewComponentView.prepareForRecycle` resets `allowsVibrancy`, `acceptsFirstMouse`, and `mouseDownCanMoveWindow` to their defaults on macOS. But `_props` is preserved across recycle and `updateProps:` diffs against it, so resetting the native state without also resetting `_props` desyncs the two: when a recycled view is reused by a node holding the same non-default value, the diff sees no change, skips re-applying, and the native state stays stuck at the default.

Removing the resets makes macOS rely on the preserved-`_props` diff, matching the iOS path (which resets no prop-derived state here).

## Test plan

Recycle `View`s carrying a non-default `mouseDownCanMoveWindow` / `acceptsFirstMouse` / `allowsVibrancy` (e.g. in a scrolling list) and confirm reused rows keep the correct native behavior instead of reverting to defaults.