### PR TITLE
fix(macos): align TouchableBounce & AccessibilityInfo with upstream

### DIFF
--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -98,8 +98,9 @@ const AccessibilityInfo = {
    * See https://reactnative.dev/docs/accessibilityinfo#isBoldTextEnabled
    */
   isBoldTextEnabled(): Promise<boolean> {
-    // [macOS rework logic to return Promise.resolve(false) on macOS
-    if (Platform.OS === 'ios') {
+    if (Platform.OS === 'android') {
+      return Promise.resolve(false);
+    } else {
       return new Promise((resolve, reject) => {
         if (NativeAccessibilityManagerApple != null) {
           NativeAccessibilityManagerApple.getCurrentBoldTextState(
@@ -110,10 +111,7 @@ const AccessibilityInfo = {
           reject(new Error('NativeAccessibilityManagerIOS is not available'));
         }
       });
-    } else {
-      return Promise.resolve(false);
     }
-    // macOS]
   },
 
   /**
@@ -333,8 +331,9 @@ const AccessibilityInfo = {
    * See https://reactnative.dev/docs/accessibilityinfo#isReduceTransparencyEnabled
    */
   isReduceTransparencyEnabled(): Promise<boolean> {
-    // [macOS rework logic to return Promise.resolve(false) on macOS
-    if (Platform.OS === 'ios') {
+    if (Platform.OS === 'android') {
+      return Promise.resolve(false);
+    } else {
       return new Promise((resolve, reject) => {
         if (NativeAccessibilityManagerApple != null) {
           NativeAccessibilityManagerApple.getCurrentReduceTransparencyState(
@@ -345,10 +344,7 @@ const AccessibilityInfo = {
           reject(new Error('NativeAccessibilityManagerIOS is not available'));
         }
       });
-    } else {
-      return Promise.resolve(false);
     }
-    // macOS]
   },
 
   /**

--- a/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
@@ -202,7 +202,11 @@ class TouchableBounce extends React.Component<
             this.props.enableFocusRing === true) &&
           !this.props.disabled
         }
-        focusable={this.props.focusable !== false && !this.props.disabled}
+        focusable={
+          this.props.focusable !== false &&
+          this.props.onPress !== undefined &&
+          !this.props.disabled
+        }
         tooltip={this.props.tooltip}
         onMouseEnter={this.props.onMouseEnter}
         onMouseLeave={this.props.onMouseLeave}


### PR DESCRIPTION
## Summary

Supersedes #2964. Two small JS fixes from the 0.83 merge audit.

**`TouchableBounce.js`** — add the `onPress !== undefined` guard to the macOS `focusable` check (matches upstream 0.83). A `TouchableBounce` with no `onPress` is no longer Tab/VoiceOver focusable.

**`AccessibilityInfo.js`** — drop the macOS carve-outs in `isBoldTextEnabled` and `isReduceTransparencyEnabled` so both use upstream's android-first guard and fall through to native on macOS, like their siblings (`isReduceMotionEnabled`, `isInvertColorsEnabled`):
- `isReduceTransparencyEnabled` now returns the real macOS "Reduce Transparency" setting instead of a hardcoded `false` — the native side already tracks and live-updates it.
- `isBoldTextEnabled` still returns `false` on macOS (no native value), now with zero fork divergence.

Both methods now match upstream exactly, aside from the fork-wide `NativeAccessibilityManagerApple` rename.

## Test plan

- macOS: `isReduceTransparencyEnabled` reflects the System Settings toggle; `isBoldTextEnabled` stays `false`.
- `TouchableBounce` without `onPress` is not focusable.
- iOS / Android unchanged; no type changes.

Related: #2901.