### PR TITLE
fix(0.83, rctuikit): make SwiftUI platform aliases visible to Swift

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -75,13 +75,14 @@ let reactOSCompat = RNTarget(
 
 let rctSwiftUI = RNTarget(
   name: .rctSwiftUI,
-  path: "ReactApple/RCTSwiftUI"
+  path: "ReactApple/RCTSwiftUI",
+  dependencies: [.reactRCTUIKit] // [macOS]
 )
 
 let rctSwiftUIWrapper = RNTarget(
   name: .rctSwiftUIWrapper,
   path: "ReactApple/RCTSwiftUIWrapper",
-  dependencies: [.rctSwiftUI]
+  dependencies: [.rctSwiftUI, .reactRCTUIKit] // [macOS]
 )
 
 // React-rendererconsistency.podspec

--- a/packages/react-native/React/RCTUIKit/RCTUIKitCompat.h
+++ b/packages/react-native/React/RCTUIKit/RCTUIKitCompat.h
@@ -233,16 +233,12 @@ typedef NS_ENUM(NSInteger, UIActivityIndicatorViewStyle) {
 @compatibility_alias RCTPlatformViewController UIViewController;
 @compatibility_alias RCTUIApplication UIApplication;
 @compatibility_alias RCTPlatformSwitch UISwitch;
-@compatibility_alias RCTPlatformHostingController UIHostingController;
-@compatibility_alias RCTPlatformViewRepresentable UIViewRepresentable;
 #else
 @compatibility_alias RCTPlatformApplication NSApplication;
 @compatibility_alias RCTPlatformWindow NSWindow;
 @compatibility_alias RCTPlatformViewController NSViewController;
 @compatibility_alias RCTUIApplication NSApplication;
 @compatibility_alias RCTPlatformSwitch NSSwitch;
-@compatibility_alias RCTPlatformHostingController NSHostingController;
-@compatibility_alias RCTPlatformViewRepresentable NSViewRepresentable;
 #endif
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
+++ b/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
@@ -8,6 +8,49 @@
 import SwiftUI
 import React_RCTUIKit
 
+// [macOS
+// These SwiftUI platform types would ideally live with the other RCTPlatform* aliases in
+// React-RCTUIKit, but that module is Objective-C and SwiftPM can't mix Obj-C and Swift in one
+// target, so they live here in the consuming module for now.
+#if os(macOS)
+typealias RCTPlatformHostingController = NSHostingController
+#else
+typealias RCTPlatformHostingController = UIHostingController
+#endif
+
+#if os(macOS)
+protocol RCTPlatformViewRepresentable: NSViewRepresentable where NSViewType == RCTPlatformView {
+  func makeRCTPlatformView(context: Context) -> RCTPlatformView
+  func updateRCTPlatformView(_ view: RCTPlatformView, context: Context)
+}
+
+extension RCTPlatformViewRepresentable {
+  func makeNSView(context: Context) -> RCTPlatformView {
+    makeRCTPlatformView(context: context)
+  }
+
+  func updateNSView(_ nsView: RCTPlatformView, context: Context) {
+    updateRCTPlatformView(nsView, context: context)
+  }
+}
+#else
+protocol RCTPlatformViewRepresentable: UIViewRepresentable where UIViewType == RCTPlatformView {
+  func makeRCTPlatformView(context: Context) -> RCTPlatformView
+  func updateRCTPlatformView(_ view: RCTPlatformView, context: Context)
+}
+
+extension RCTPlatformViewRepresentable {
+  func makeUIView(context: Context) -> RCTPlatformView {
+    makeRCTPlatformView(context: context)
+  }
+
+  func updateUIView(_ uiView: RCTPlatformView, context: Context) {
+    updateRCTPlatformView(uiView, context: context)
+  }
+}
+#endif
+// macOS]
+
 @MainActor @objc public class RCTSwiftUIContainerView: NSObject {
   private var containerViewModel = ContainerViewModel()
   private var hostingController: RCTPlatformHostingController<SwiftUIContainerView>? // [macOS]


### PR DESCRIPTION
## Summary

Follow-up fix to #3006, which merged before we had CI testing (oops). Turns out `@compatibility_alias` is not compatible with Swift, so we can't use it. Furthermore, `RCTUIKit` can't have Swift sources as SPM doesn't support mixed language modules yet. So for now, let's move the Swift-only usecase out to RCTSwiftUI, the caller. 

## Test Plan

Validated locally with Xcode 26.4.1:

- Clean `RCTSwiftUI-macOS` Pods target build → **BUILD SUCCEEDED**.
- Full `RNTester-macOS` app build → **BUILD SUCCEEDED**.
- SwiftPM prebuild (`node scripts/ios-prebuild.js -s` then `-b -p macos`) now compiles `React_RCTUIKit`, `RCTSwiftUI` and `RCTSwiftUIWrapper` with **no "no such module"** error (the previous failure point).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>