### PR TITLE
fix(macos): three Fabric focus regressions (blur, sendAccessibilityEvent, VirtualView)

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1757,7 +1757,13 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // [macOS]
 
 - (void)blur
 {
-  [[self window] resignFirstResponder];
+  // `NSWindow` does not implement `resignFirstResponder`; only NSResponder
+  // subclasses inherit it. Calling the selector on the window is a silent
+  // no-op, leaving programmatic `ref.blur()` from JS without effect. The
+  // correct AppKit equivalent is `makeFirstResponder:nil`, which clears
+  // the current first responder. Mirrors the working pattern at
+  // RCTTextInputComponentView.mm:995-997.
+  [[self window] makeFirstResponder:nil];
 }
 
 - (BOOL)needsPanelToBecomeKey

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1757,13 +1757,9 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // [macOS]
 
 - (void)blur
 {
-  // `NSWindow` does not implement `resignFirstResponder`; only NSResponder
-  // subclasses inherit it. Calling the selector on the window is a silent
-  // no-op, leaving programmatic `ref.blur()` from JS without effect. The
-  // correct AppKit equivalent is `makeFirstResponder:nil`, which clears
-  // the current first responder. Mirrors the working pattern at
-  // RCTTextInputComponentView.mm:995-997.
-  [[self window] makeFirstResponder:nil];
+  if ([[self window] firstResponder] == self) {
+    [[self window] makeFirstResponder:nil];
+  }
 }
 
 - (BOOL)needsPanelToBecomeKey

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualView/RCTVirtualViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualView/RCTVirtualViewComponentView.mm
@@ -174,32 +174,12 @@ static BOOL sIsAccessibilityUsed = NO;
 
 - (BOOL)acceptsFirstResponder
 {
-  // Mirror of the iOS `focusItemsInRect:` hook for keyboard / Tab
-  // navigation. AppKit queries `acceptsFirstResponder` while walking
-  // the responder chain to compute the next Tab target. If this view
-  // is hidden via the `hideOffscreenVirtualViewsOnIOS` optimization,
-  // we unhide here so a subsequent Tab landing actually finds a real
-  // view to focus.
-  //
-  // Caveat: a fully `hidden=YES` view is excluded from AppKit's
-  // responder chain at the parent level, so `acceptsFirstResponder`
-  // will not be queried until the view becomes visible. This override
-  // therefore only catches the "visible but flagged offscreen" case
-  // where `_unhideIfNeeded` is a fast no-op anyway. The complete fix
-  // for Tab-into-fully-hidden views requires switching the hiding
-  // strategy from `self.hidden = YES` to something that keeps the
-  // view in the responder chain (e.g. zero-alpha / out-of-bounds
-  // frame) — out of scope here; tracked as a follow-up.
   [self _unhideIfNeeded];
   return [super acceptsFirstResponder];
 }
 
 - (id)accessibilityHitTest:(NSPoint)point
 {
-  // VoiceOver cursor / pointer-hover-with-VoiceOver path. Same
-  // rationale as `accessibilityChildren` above: a hit-test that
-  // would land on a flagged-offscreen virtual view should unhide
-  // it so the AX tree has a real element to return.
   [self _unhideIfNeeded];
   return [super accessibilityHitTest:point];
 }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualView/RCTVirtualViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualView/RCTVirtualViewComponentView.mm
@@ -171,6 +171,38 @@ static BOOL sIsAccessibilityUsed = NO;
   [self _unhideIfNeeded];
   return [super accessibilityChildren];
 }
+
+- (BOOL)acceptsFirstResponder
+{
+  // Mirror of the iOS `focusItemsInRect:` hook for keyboard / Tab
+  // navigation. AppKit queries `acceptsFirstResponder` while walking
+  // the responder chain to compute the next Tab target. If this view
+  // is hidden via the `hideOffscreenVirtualViewsOnIOS` optimization,
+  // we unhide here so a subsequent Tab landing actually finds a real
+  // view to focus.
+  //
+  // Caveat: a fully `hidden=YES` view is excluded from AppKit's
+  // responder chain at the parent level, so `acceptsFirstResponder`
+  // will not be queried until the view becomes visible. This override
+  // therefore only catches the "visible but flagged offscreen" case
+  // where `_unhideIfNeeded` is a fast no-op anyway. The complete fix
+  // for Tab-into-fully-hidden views requires switching the hiding
+  // strategy from `self.hidden = YES` to something that keeps the
+  // view in the responder chain (e.g. zero-alpha / out-of-bounds
+  // frame) — out of scope here; tracked as a follow-up.
+  [self _unhideIfNeeded];
+  return [super acceptsFirstResponder];
+}
+
+- (id)accessibilityHitTest:(NSPoint)point
+{
+  // VoiceOver cursor / pointer-hover-with-VoiceOver path. Same
+  // rationale as `accessibilityChildren` above: a hit-test that
+  // would land on a flagged-offscreen virtual view should unhide
+  // it so the AX tree has a real element to return.
+  [self _unhideIfNeeded];
+  return [super accessibilityHitTest:point];
+}
 #endif // macOS]
 
 - (void)prepareForRecycle

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -347,13 +347,6 @@ static void RCTPerformMountInstructions(
 #if !TARGET_OS_OSX // [macOS]
     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, componentView);
 #else // [macOS
-    // Move first-responder to the component view and post the
-    // AppKit-equivalent accessibility notification so VoiceOver picks
-    // up the focus change. Without this branch the Fabric path for
-    // `AccessibilityInfo.setAccessibilityFocus(reactTag)` silently
-    // no-ops on macOS — the old-arch path in
-    // RCTAccessibilityManager.mm:setAccessibilityFocus: does the
-    // equivalent work, which we mirror here.
     if (componentView != nil) {
       [[componentView window] makeFirstResponder:componentView];
       NSAccessibilityPostNotification(componentView, NSAccessibilityFocusedUIElementChangedNotification);

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -346,7 +346,19 @@ static void RCTPerformMountInstructions(
     RCTUIView<RCTComponentViewProtocol> *componentView = [_componentViewRegistry findComponentViewWithTag:reactTag]; // [macOS]
 #if !TARGET_OS_OSX // [macOS]
     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, componentView);
-#endif // [macOS]
+#else // [macOS
+    // Move first-responder to the component view and post the
+    // AppKit-equivalent accessibility notification so VoiceOver picks
+    // up the focus change. Without this branch the Fabric path for
+    // `AccessibilityInfo.setAccessibilityFocus(reactTag)` silently
+    // no-ops on macOS — the old-arch path in
+    // RCTAccessibilityManager.mm:setAccessibilityFocus: does the
+    // equivalent work, which we mirror here.
+    if (componentView != nil) {
+      [[componentView window] makeFirstResponder:componentView];
+      NSAccessibilityPostNotification(componentView, NSAccessibilityFocusedUIElementChangedNotification);
+    }
+#endif // macOS]
   }
 }
 


### PR DESCRIPTION
## Summary

Supersedes #2959 (the original PR's source fork is disabled, so that branch can no longer be updated). This carries the same three macOS Fabric focus/first-responder fixes forward, with @tvinhas's original commit cherry-picked to preserve authorship credit, plus one small refinement.

The three regressions were surfaced while validating the "Verify focus changes" item on #2901.

### 1. `RCTViewComponentView.blur()` was a no-op
`resignFirstResponder` on `NSWindow` doesn't clear the focused subview, so `ref.blur()` from JS did nothing. Now clears the first responder via `makeFirstResponder:nil`, **guarded on `self`** so it only clears focus when this view actually holds it — matching iOS `[self resignFirstResponder]` semantics and avoiding stealing focus from an unrelated view.

### 2. Fabric `setAccessibilityFocus` was a silent no-op on macOS
`synchronouslyDispatchAccessbilityEventOnUIThread:` had a `#if !TARGET_OS_OSX` guard with no `#else`, so `AccessibilityInfo.setAccessibilityFocus(reactTag)` did nothing on the Fabric path. Added the macOS branch (`makeFirstResponder:` + `NSAccessibilityFocusedUIElementChangedNotification`), mirroring the old-arch path in `RCTAccessibilityManager.mm`.

### 3. `RCTVirtualViewComponentView` keyboard-nav hooks
Added `acceptsFirstResponder` and `accessibilityHitTest:` to the macOS branch so keyboard/Tab and VoiceOver navigation unhide flagged-offscreen views under the `hideOffscreenVirtualViews` optimization. Partial by design (a fully `hidden=YES` view is dropped from the responder chain — full fix needs a hide-strategy redesign, tracked as follow-up).

## Difference from #2959
- Added the `if ([[self window] firstResponder] == self)` guard on `blur()` for iOS-parity / to avoid focus-stealing.
- Trimmed the verbose inline comments.

## Test plan
- Builds clean: RNTester-macOS (`xcodebuild -scheme RNTester-macOS -destination 'generic/platform=macOS'`) — **BUILD SUCCEEDED**.
- All three changes are macOS-gated (`#if TARGET_OS_OSX` / `#else`) and preserve existing iOS/visionOS behavior.

## Credit
Original work by @tvinhas in #2959 (commit cherry-picked to retain authorship).

Co-authored-by: Thiago Vinhas <thiago@vinhas.net>
