### PR TITLE
fix(0.81, macos): three Fabric focus regressions (blur, sendAccessibilityEvent, VirtualView)

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1762,7 +1762,13 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // [macOS]
 
 - (void)blur
 {
-  [[self window] resignFirstResponder];
+  // `NSWindow` does not implement `resignFirstResponder`; only NSResponder
+  // subclasses inherit it. Calling the selector on the window is a silent
+  // no-op, leaving programmatic `ref.blur()` from JS without effect. The
+  // correct AppKit equivalent is `makeFirstResponder:nil`, which clears
+  // the current first responder. Mirrors the working pattern at
+  // RCTTextInputComponentView.mm:995-997.
+  [[self window] makeFirstResponder:nil];
 }
 
 - (BOOL)needsPanelToBecomeKey

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1762,13 +1762,9 @@ static NSString *RCTRecursiveAccessibilityLabel(RCTUIView *view) // [macOS]
 
 - (void)blur
 {
-  // `NSWindow` does not implement `resignFirstResponder`; only NSResponder
-  // subclasses inherit it. Calling the selector on the window is a silent
-  // no-op, leaving programmatic `ref.blur()` from JS without effect. The
-  // correct AppKit equivalent is `makeFirstResponder:nil`, which clears
-  // the current first responder. Mirrors the working pattern at
-  // RCTTextInputComponentView.mm:995-997.
-  [[self window] makeFirstResponder:nil];
+  if ([[self window] firstResponder] == self) {
+    [[self window] makeFirstResponder:nil];
+  }
 }
 
 - (BOOL)needsPanelToBecomeKey

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualView/RCTVirtualViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualView/RCTVirtualViewComponentView.mm
@@ -174,32 +174,12 @@ static BOOL sIsAccessibilityUsed = NO;
 
 - (BOOL)acceptsFirstResponder
 {
-  // Mirror of the iOS `focusItemsInRect:` hook for keyboard / Tab
-  // navigation. AppKit queries `acceptsFirstResponder` while walking
-  // the responder chain to compute the next Tab target. If this view
-  // is hidden via the `hideOffscreenVirtualViewsOnIOS` optimization,
-  // we unhide here so a subsequent Tab landing actually finds a real
-  // view to focus.
-  //
-  // Caveat: a fully `hidden=YES` view is excluded from AppKit's
-  // responder chain at the parent level, so `acceptsFirstResponder`
-  // will not be queried until the view becomes visible. This override
-  // therefore only catches the "visible but flagged offscreen" case
-  // where `_unhideIfNeeded` is a fast no-op anyway. The complete fix
-  // for Tab-into-fully-hidden views requires switching the hiding
-  // strategy from `self.hidden = YES` to something that keeps the
-  // view in the responder chain (e.g. zero-alpha / out-of-bounds
-  // frame) — out of scope here; tracked as a follow-up.
   [self _unhideIfNeeded];
   return [super acceptsFirstResponder];
 }
 
 - (id)accessibilityHitTest:(NSPoint)point
 {
-  // VoiceOver cursor / pointer-hover-with-VoiceOver path. Same
-  // rationale as `accessibilityChildren` above: a hit-test that
-  // would land on a flagged-offscreen virtual view should unhide
-  // it so the AX tree has a real element to return.
   [self _unhideIfNeeded];
   return [super accessibilityHitTest:point];
 }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualView/RCTVirtualViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualView/RCTVirtualViewComponentView.mm
@@ -171,6 +171,38 @@ static BOOL sIsAccessibilityUsed = NO;
   [self _unhideIfNeeded];
   return [super accessibilityChildren];
 }
+
+- (BOOL)acceptsFirstResponder
+{
+  // Mirror of the iOS `focusItemsInRect:` hook for keyboard / Tab
+  // navigation. AppKit queries `acceptsFirstResponder` while walking
+  // the responder chain to compute the next Tab target. If this view
+  // is hidden via the `hideOffscreenVirtualViewsOnIOS` optimization,
+  // we unhide here so a subsequent Tab landing actually finds a real
+  // view to focus.
+  //
+  // Caveat: a fully `hidden=YES` view is excluded from AppKit's
+  // responder chain at the parent level, so `acceptsFirstResponder`
+  // will not be queried until the view becomes visible. This override
+  // therefore only catches the "visible but flagged offscreen" case
+  // where `_unhideIfNeeded` is a fast no-op anyway. The complete fix
+  // for Tab-into-fully-hidden views requires switching the hiding
+  // strategy from `self.hidden = YES` to something that keeps the
+  // view in the responder chain (e.g. zero-alpha / out-of-bounds
+  // frame) — out of scope here; tracked as a follow-up.
+  [self _unhideIfNeeded];
+  return [super acceptsFirstResponder];
+}
+
+- (id)accessibilityHitTest:(NSPoint)point
+{
+  // VoiceOver cursor / pointer-hover-with-VoiceOver path. Same
+  // rationale as `accessibilityChildren` above: a hit-test that
+  // would land on a flagged-offscreen virtual view should unhide
+  // it so the AX tree has a real element to return.
+  [self _unhideIfNeeded];
+  return [super accessibilityHitTest:point];
+}
 #endif // macOS]
 
 - (void)prepareForRecycle

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -347,13 +347,6 @@ static void RCTPerformMountInstructions(
 #if !TARGET_OS_OSX // [macOS]
     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, componentView);
 #else // [macOS
-    // Move first-responder to the component view and post the
-    // AppKit-equivalent accessibility notification so VoiceOver picks
-    // up the focus change. Without this branch the Fabric path for
-    // `AccessibilityInfo.setAccessibilityFocus(reactTag)` silently
-    // no-ops on macOS — the old-arch path in
-    // RCTAccessibilityManager.mm:setAccessibilityFocus: does the
-    // equivalent work, which we mirror here.
     if (componentView != nil) {
       [[componentView window] makeFirstResponder:componentView];
       NSAccessibilityPostNotification(componentView, NSAccessibilityFocusedUIElementChangedNotification);

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -346,7 +346,19 @@ static void RCTPerformMountInstructions(
     RCTUIView<RCTComponentViewProtocol> *componentView = [_componentViewRegistry findComponentViewWithTag:reactTag]; // [macOS]
 #if !TARGET_OS_OSX // [macOS]
     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, componentView);
-#endif // [macOS]
+#else // [macOS
+    // Move first-responder to the component view and post the
+    // AppKit-equivalent accessibility notification so VoiceOver picks
+    // up the focus change. Without this branch the Fabric path for
+    // `AccessibilityInfo.setAccessibilityFocus(reactTag)` silently
+    // no-ops on macOS — the old-arch path in
+    // RCTAccessibilityManager.mm:setAccessibilityFocus: does the
+    // equivalent work, which we mirror here.
+    if (componentView != nil) {
+      [[componentView window] makeFirstResponder:componentView];
+      NSAccessibilityPostNotification(componentView, NSAccessibilityFocusedUIElementChangedNotification);
+    }
+#endif // macOS]
   }
 }
 


### PR DESCRIPTION
## Summary

Backport of #3015 to `0.81-stable`.

Three macOS-only Fabric focus / first-responder regressions:
1. **`RCTViewComponentView.blur()`** — was a no-op (`resignFirstResponder` on `NSWindow` doesn't clear the focused subview). Now clears via `makeFirstResponder:nil`, guarded on `self`.
2. **Fabric `setAccessibilityFocus`** — the macOS branch was empty; added `makeFirstResponder:` + `NSAccessibilityFocusedUIElementChangedNotification`.
3. **`RCTVirtualViewComponentView`** — added `acceptsFirstResponder` / `accessibilityHitTest:` hooks so keyboard/VoiceOver navigation unhides flagged-offscreen views.

All changes are macOS-gated; iOS/visionOS behavior is unchanged.

## Test Plan

Same as #3015 — builds clean (RNTester-macOS, BUILD SUCCEEDED); every change is inside a `#if TARGET_OS_OSX` / `#else` branch.

## Credit

Original work by @tvinhas in #2959 (commit cherry-picked to retain authorship). Supersedes #2959.

Co-authored-by: Thiago Vinhas <thiago@vinhas.net>
