### PR TITLE
fix(ci): normalize backport comment line endings

### DIFF
--- a/.github/workflows/microsoft-backport.yml
+++ b/.github/workflows/microsoft-backport.yml
@@ -44,8 +44,8 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          # Extract everything after "/backport " and split into branch names
-          BRANCHES=$(echo "$COMMENT_BODY" | head -1 | sed 's|^/backport ||' | xargs)
+          # GitHub comment bodies can use CRLF, so strip the trailing carriage return.
+          BRANCHES=$(printf '%s\n' "$COMMENT_BODY" | head -n 1 | tr -d '\r' | sed 's|^/backport ||' | xargs)
           if [ -z "$BRANCHES" ]; then
             echo "::error::No target branches specified"
             exit 1

--- a/.github/workflows/microsoft-backport.yml
+++ b/.github/workflows/microsoft-backport.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          # GitHub comment bodies can use CRLF, so strip the trailing carriage return.
+          # Extract everything after "/backport " and split into branch names
           BRANCHES=$(printf '%s\n' "$COMMENT_BODY" | head -n 1 | tr -d '\r' | sed 's|^/backport ||' | xargs)
           if [ -z "$BRANCHES" ]; then
             echo "::error::No target branches specified"


### PR DESCRIPTION
## Summary

- normalize CRLF line endings when parsing `/backport` comments
- prevent carriage returns from becoming part of target branch names

## Test Plan

- verified `/backport 0.81-stable\r\n` parses as `0.81-stable`
- parsed the updated workflow as YAML