### PR TITLE
chore(0.81): fix visionOS compiler errors

### DIFF
--- a/.nx/version-plans/version-plan-1783964890426.md
+++ b/.nx/version-plans/version-plan-1783964890426.md
@@ -1,0 +1,5 @@
+---
+__default__: patch
+---
+
+Fix visionOS compiler errors

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -322,8 +322,8 @@ static RCTUIColor *defaultPlaceholderColor(void) // [macOS]
     self.inputAssistantItem.leadingBarButtonGroups = _initialValueLeadingBarButtonGroups;
     self.inputAssistantItem.trailingBarButtonGroups = _initialValueTrailingBarButtonGroups;
   }
-  _disableKeyboardShortcuts = disableKeyboardShortcuts;
 #endif
+  _disableKeyboardShortcuts = disableKeyboardShortcuts;
 }
 
 #pragma mark - Overrides

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -306,6 +306,7 @@ static RCTUIColor *defaultPlaceholderColor(void) // [macOS]
 
 - (void)setDisableKeyboardShortcuts:(BOOL)disableKeyboardShortcuts
 {
+  _disableKeyboardShortcuts = disableKeyboardShortcuts;
 #if TARGET_OS_IOS
   // Initialize the initial values only once
   if (_initialValueLeadingBarButtonGroups == nil) {
@@ -323,7 +324,6 @@ static RCTUIColor *defaultPlaceholderColor(void) // [macOS]
     self.inputAssistantItem.trailingBarButtonGroups = _initialValueTrailingBarButtonGroups;
   }
 #endif
-  _disableKeyboardShortcuts = disableKeyboardShortcuts;
 }
 
 #pragma mark - Overrides

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -423,6 +423,7 @@
 
 - (void)setDisableKeyboardShortcuts:(BOOL)disableKeyboardShortcuts
 {
+  _disableKeyboardShortcuts = disableKeyboardShortcuts;
 #if TARGET_OS_IOS
   // Initialize the initial values only once
   if (_initialValueLeadingBarButtonGroups == nil) {
@@ -440,7 +441,6 @@
     self.inputAssistantItem.trailingBarButtonGroups = _initialValueTrailingBarButtonGroups;
   }
 #endif
-  _disableKeyboardShortcuts = disableKeyboardShortcuts;
 }
 
 #pragma mark - Placeholder

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -439,8 +439,8 @@
     self.inputAssistantItem.leadingBarButtonGroups = _initialValueLeadingBarButtonGroups;
     self.inputAssistantItem.trailingBarButtonGroups = _initialValueTrailingBarButtonGroups;
   }
-  _disableKeyboardShortcuts = disableKeyboardShortcuts;
 #endif
+  _disableKeyboardShortcuts = disableKeyboardShortcuts;
 }
 
 #pragma mark - Placeholder

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -84,7 +84,7 @@ RCT_EXPORT_MODULE()
 
   _currentInterfaceDimensions = [self _exportedDimensions];
 
-#if !TARGET_OS_OSX // [macOS]
+#if TARGET_OS_IOS // [macOS] [visionOS]
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(interfaceOrientationDidChange)
                                                name:UIApplicationDidBecomeActiveNotification


### PR DESCRIPTION
## Summary
Backport of the changes from PR #3018 to `0.81-stable`.

Includes a patch version plan generated with the documented NX release workflow.

## Test Plan
Same as the original PR.

- `yarn nx release plan:check`