### PR TITLE
fix: prevent dev loading view clipping

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -176,7 +176,7 @@ RCT_EXPORT_MODULE()
 
     if (!self->_window) {
       self->_window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 375, 20)
-                                                styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskFullSizeContentView
+                                                styleMask:NSWindowStyleMaskBorderless
                                                   backing:NSBackingStoreBuffered
                                                     defer:YES];
       [self->_window setIdentifier:sRCTDevLoadingViewWindowIdentifier];

--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -170,6 +170,10 @@ RCT_EXPORT_MODULE()
     if (!self->_container) {
       self->_container = [[RCTUIView alloc] init]; // [macOS]
       self->_container.translatesAutoresizingMaskIntoConstraints = NO;
+      self->_container.wantsLayer = YES;
+      self->_container.layer.cornerRadius = 4;
+      self->_container.layer.cornerCurve = kCACornerCurveContinuous;
+      self->_container.layer.masksToBounds = YES;
       [self->_container addSubview:self->_label];
     }
     self->_container.backgroundColor = backgroundColor;
@@ -179,6 +183,8 @@ RCT_EXPORT_MODULE()
                                                 styleMask:NSWindowStyleMaskBorderless
                                                   backing:NSBackingStoreBuffered
                                                     defer:YES];
+      self->_window.backgroundColor = [NSColor clearColor];
+      self->_window.opaque = NO;
       [self->_window setIdentifier:sRCTDevLoadingViewWindowIdentifier];
       [self->_window.contentView addSubview:self->_container];
     }
@@ -197,10 +203,14 @@ RCT_EXPORT_MODULE()
       [self->_label.trailingAnchor constraintLessThanOrEqualToAnchor:self->_container.trailingAnchor constant:-10],
     ]];
 
-    if (![[RCTKeyWindow() sheets] doesContain:self->_window]) {
-      [RCTKeyWindow() beginSheet:self->_window completionHandler:^(NSModalResponse returnCode) {
-        [self->_window orderOut:self];
-      }];
+    NSWindow *parentWindow = RCTKeyWindow();
+    if (![[parentWindow childWindows] doesContain:self->_window]) {
+      NSRect parentFrame = parentWindow.frame;
+      NSRect loadingFrame = self->_window.frame;
+      [self->_window setFrameOrigin:NSMakePoint(
+                                        NSMidX(parentFrame) - NSWidth(loadingFrame) / 2,
+                                        NSMidY(parentFrame) - NSHeight(loadingFrame) / 2)];
+      [parentWindow addChildWindow:self->_window ordered:NSWindowAbove];
     }
 #endif // macOS]
   });
@@ -242,9 +252,10 @@ RCT_EXPORT_METHOD(hide)
           self->_hiding = false;
         }];
 #else // [macOS]
-    for (NSWindow *window in [RCTKeyWindow() sheets]) {
+    for (NSWindow *window in NSApp.windows) {
       if ([[window identifier] isEqualToString:sRCTDevLoadingViewWindowIdentifier]) {
-        [RCTKeyWindow() endSheet:window];
+        [window.parentWindow removeChildWindow:window];
+        [window orderOut:self];
       }
     }
     self->_window = nil;

--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -7,8 +7,6 @@
 
 #import <React/RCTDevLoadingView.h>
 
-#import <QuartzCore/QuartzCore.h>
-
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
 #import <React/RCTAppearance.h>
 #import <React/RCTBridge.h>
@@ -170,19 +168,18 @@ RCT_EXPORT_MODULE()
     if (!self->_container) {
       self->_container = [[RCTUIView alloc] init]; // [macOS]
       self->_container.translatesAutoresizingMaskIntoConstraints = NO;
-      self->_container.wantsLayer = YES;
-      self->_container.layer.cornerRadius = 4;
-      self->_container.layer.cornerCurve = kCACornerCurveContinuous;
-      self->_container.layer.masksToBounds = YES;
       [self->_container addSubview:self->_label];
     }
     self->_container.backgroundColor = backgroundColor;
 
     if (!self->_window) {
       self->_window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 375, 20)
-                                                styleMask:NSWindowStyleMaskBorderless
+                                                styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView
                                                   backing:NSBackingStoreBuffered
                                                     defer:YES];
+      self->_window.titleVisibility = NSWindowTitleHidden;
+      self->_window.titlebarAppearsTransparent = YES;
+      self->_window.movable = NO;
       self->_window.backgroundColor = [NSColor clearColor];
       self->_window.opaque = NO;
       [self->_window setIdentifier:sRCTDevLoadingViewWindowIdentifier];

--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -7,6 +7,8 @@
 
 #import <React/RCTDevLoadingView.h>
 
+#import <QuartzCore/QuartzCore.h>
+
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
 #import <React/RCTAppearance.h>
 #import <React/RCTBridge.h>
@@ -168,22 +170,22 @@ RCT_EXPORT_MODULE()
     if (!self->_container) {
       self->_container = [[RCTUIView alloc] init]; // [macOS]
       self->_container.translatesAutoresizingMaskIntoConstraints = NO;
+      self->_container.wantsLayer = YES;
+      self->_container.layer.masksToBounds = YES;
       [self->_container addSubview:self->_label];
     }
     self->_container.backgroundColor = backgroundColor;
 
     if (!self->_window) {
       self->_window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 375, 20)
-                                                styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView
+                                                styleMask:NSWindowStyleMaskBorderless
                                                   backing:NSBackingStoreBuffered
                                                     defer:YES];
-      self->_window.titleVisibility = NSWindowTitleHidden;
-      self->_window.titlebarAppearsTransparent = YES;
-      self->_window.movable = NO;
       self->_window.backgroundColor = [NSColor clearColor];
       self->_window.opaque = NO;
       [self->_window setIdentifier:sRCTDevLoadingViewWindowIdentifier];
       [self->_window.contentView addSubview:self->_container];
+      self->_container.layer.cornerRadius = NSHeight(self->_window.contentView.bounds) / 2;
     }
 
     // Container constraints

--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -186,6 +186,7 @@ RCT_EXPORT_MODULE()
       [self->_window setIdentifier:sRCTDevLoadingViewWindowIdentifier];
       [self->_window.contentView addSubview:self->_container];
       self->_container.layer.cornerRadius = NSHeight(self->_window.contentView.bounds) / 2;
+      self->_container.layer.cornerCurve = kCACornerCurveContinuous;
     }
 
     // Container constraints


### PR DESCRIPTION
## Summary

Present the macOS `RCTDevLoadingView` banner as a centered child window instead of a modal sheet. AppKit masks short borderless sheets into a pointed pill shape; a child window remains attached to and follows the parent without inheriting the sheet frame mask.

The banner now applies its own subtle continuous corner radius and matching child windows are detached and hidden during cleanup.

## Changelog

[MACOS] [FIXED] - Prevent the development loading view from being clipped

## Test Plan

<img width="826" height="226" alt="image" src="https://github.com/user-attachments/assets/3be70235-7c06-4621-8083-456316ab4af9" />