### PR TITLE
fix: declare support for visionOS

### DIFF
--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -176,7 +176,13 @@ if (macosCommands != null) {
   config.commands.push(...macosCommands);
 }
 if (apple) {
+  const {
+    REACT_NATIVE: npmPackageName,
+  } = require('./scripts/codegen/generate-artifacts-executor/constants.js');
+  const macos = {platformName: 'macos'};
+  const visionos = {platformName: 'visionos'};
   config.platforms.macos = {
+    npmPackageName,
     linkConfig: () => {
       return {
         isInstalled: (
@@ -200,11 +206,13 @@ if (apple) {
         unlinkAssets: (_assets /*: mixed */, _projectConfig /*: mixed */) => {},
       };
     },
-    projectConfig: apple.getProjectConfig({platformName: 'macos'}),
-    dependencyConfig: apple.getProjectConfig({platformName: 'macos'}),
-    npmPackageName:
-      require('./scripts/codegen/generate-artifacts-executor/constants')
-        .REACT_NATIVE,
+    projectConfig: apple.getProjectConfig(macos),
+    dependencyConfig: apple.getDependencyConfig(macos),
+  };
+  config.platforms.visionos = {
+    npmPackageName,
+    projectConfig: apple.getProjectConfig(visionos),
+    dependencyConfig: apple.getDependencyConfig(visionos),
   };
 }
 // macOS]


### PR DESCRIPTION
## Summary:

Properly declare support for visionOS. Without it, users will have to [configure it manually](https://github.com/microsoft/react-native-test-app/pull/2850/changes#diff-b026099318e278b777d6ecfb1168201bf77e1027b0c2e02ea67e7be0fa14fa8c).

Also fixes `platforms.macos.dependencyConfig` containing _project_ config instead of _dependency_.

This needs a backport to 0.81.

## Test Plan:

`react-native config` should output `visionos` fields:

```sh
% yarn react-native config
{
  ...
  "platforms": {
    "ios": {},
    "android": {},
    "macos": {
      "npmPackageName": "react-native-macos"
    },
    "visionos": {
      "npmPackageName": "react-native-macos"
    }
  },
  "assets": [],
  "project": {
    "ios": { ... },
    "android": { ... },
    "macos": null,
    "visionos": {
      "sourceDir": "/~/packages/example-visionos/visionos",
      "xcodeProject": {
        "name": "Example.xcworkspace",
        "path": ".",
        "isWorkspace": true
      },
      "assets": []
    }
  }
}
```