### PR TITLE
chore: minimize the virtualized-lists fork

### DIFF
--- a/.changeset/great-zebras-tease.md
+++ b/.changeset/great-zebras-tease.md
@@ -1,0 +1,6 @@
+---
+"@react-native-macos/virtualized-lists": minor
+"react-native-macos": minor
+---
+
+Remove the generic VirtualizedList and SectionList selection API, and keep macOS keyboard selection owned by FlatList. Option+Down selects the final data row, Enter activates the selected row, and native vertical inversion preserves child views.

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -1747,7 +1747,8 @@ class ScrollView extends React.Component<ScrollViewProps, ScrollViewState> {
     // this is the case.
     const preserveChildren =
       this.props.maintainVisibleContentPosition != null ||
-      (Platform.OS === 'android' && this.props.snapToAlignment != null);
+      (Platform.OS === 'android' && this.props.snapToAlignment != null) ||
+      (Platform.OS === 'macos' && this.props.inverted === true); // [macOS]
 
     const contentContainer = (
       <NativeScrollContentView

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-test.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-test.js
@@ -12,6 +12,7 @@
 
 const {create, unmount, update} = require('../../../../jest/renderer');
 const Text = require('../../../Text/Text').default;
+const Platform = require('../../../Utilities/Platform').default;
 const ReactNativeTestTools = require('../../../Utilities/ReactNativeTestTools');
 const View = require('../../View/View').default;
 const ScrollView = require('../ScrollView').default;
@@ -37,6 +38,46 @@ describe('ScrollView', () => {
         jest.dontMock('../ScrollView');
       },
     );
+  });
+
+  it('preserves children for native inversion on macOS', async () => {
+    const platformOSDescriptor = Object.getOwnPropertyDescriptor(
+      Platform,
+      'OS',
+    );
+    if (platformOSDescriptor == null) {
+      throw new Error('Platform.OS descriptor was not found');
+    }
+    // $FlowFixMe[incompatible-type] Exercise the macOS-only render branch.
+    Object.defineProperty(Platform, 'OS', {
+      ...platformOSDescriptor,
+      // $FlowFixMe[incompatible-type] Platform is a platform-specific union.
+      value: 'macos',
+    });
+    try {
+      const invertedComponent = await create(
+        <ScrollView inverted={true}>
+          <View />
+        </ScrollView>,
+      );
+      const regularComponent = await create(
+        <ScrollView inverted={false}>
+          <View />
+        </ScrollView>,
+      );
+
+      expect(
+        invertedComponent.root.findByType('RCTScrollContentView').props
+          .collapsableChildren,
+      ).toBe(false);
+      expect(
+        regularComponent.root.findByType('RCTScrollContentView').props
+          .collapsableChildren,
+      ).toBe(true);
+    } finally {
+      // $FlowFixMe[incompatible-type] Restore the test platform.
+      Object.defineProperty(Platform, 'OS', platformOSDescriptor);
+    }
   });
 
   it('mocks native methods and instance methods', async () => {

--- a/packages/react-native/Libraries/Lists/FlatList.d.ts
+++ b/packages/react-native/Libraries/Lists/FlatList.d.ts
@@ -9,7 +9,7 @@
 
 import type * as React from 'react';
 import type {
-  ListRenderItem,
+  ListRenderItemInfo,
   ViewToken,
   VirtualizedListProps,
   ViewabilityConfig,
@@ -19,7 +19,20 @@ import type {StyleProp} from '../StyleSheet/StyleSheet';
 import type {ViewStyle} from '../StyleSheet/StyleSheetTypes';
 import type {View} from '../Components/View/View';
 
-export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
+export interface FlatListRenderItemInfo<ItemT>
+  extends ListRenderItemInfo<ItemT> {
+  isSelected: boolean;
+}
+
+export type FlatListRenderItem<ItemT> = (
+  info: FlatListRenderItemInfo<ItemT>,
+) => React.ReactNode;
+
+export interface FlatListProps<ItemT>
+  extends Omit<
+    VirtualizedListProps<ItemT>,
+    'ListItemComponent' | 'renderItem'
+  > {
   /**
    * Optional custom style for multi-item rows generated when numColumns > 1
    */
@@ -88,6 +101,44 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
   initialScrollIndex?: number | null | undefined;
 
   /**
+   * Allows rows to be selected with the keyboard.
+   *
+   * @platform macos
+   */
+  enableSelectionOnKeyPress?: boolean | null | undefined;
+
+  /**
+   * The initially selected row.
+   *
+   * @platform macos
+   */
+  initialSelectedIndex?: number | null | undefined;
+
+  /**
+   * Called when the selected row changes.
+   *
+   * @platform macos
+   */
+  onSelectionChanged?:
+    | ((info: {
+        previousSelection: number;
+        newSelection: number;
+        item: ItemT | ReadonlyArray<ItemT> | null | undefined;
+      }) => void)
+    | null
+    | undefined;
+
+  /**
+   * Called when Enter is pressed on the selected row.
+   *
+   * @platform macos
+   */
+  onSelectionEntered?:
+    | ((item: ItemT | ReadonlyArray<ItemT> | null | undefined) => void)
+    | null
+    | undefined;
+
+  /**
    * Used to extract a unique key for a given item at the specified index. Key is used for caching
    * and as the react key to track item re-ordering. The default extractor checks `item.key`, then
    * falls back to using the index, like React does.
@@ -140,7 +191,13 @@ export interface FlatListProps<ItemT> extends VirtualizedListProps<ItemT> {
    * ```
    * Provides additional metadata like `index` if you need it.
    */
-  renderItem: ListRenderItem<ItemT> | null | undefined;
+  renderItem: FlatListRenderItem<ItemT> | null | undefined;
+
+  ListItemComponent?:
+    | React.ComponentType<FlatListRenderItemInfo<ItemT>>
+    | React.ReactElement
+    | null
+    | undefined;
 
   /**
    * See `ViewabilityHelper` for flow type and further documentation.
@@ -222,6 +279,13 @@ export abstract class FlatListComponent<
    * Displays the scroll indicators momentarily.
    */
   flashScrollIndicators: () => void;
+
+  /**
+   * Moves selection to the specified row.
+   *
+   * @platform macos
+   */
+  selectRowAtIndex: (index: number) => void;
 
   /**
    * Provides a handle to the underlying scroll responder.

--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -10,8 +10,8 @@
 
 import typeof ScrollViewNativeComponent from '../Components/ScrollView/ScrollViewNativeComponent';
 import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
+import type {HandledKeyEvent, KeyEvent} from '../Types/CoreEventTypes';
 import type {
-  ListRenderItem,
   ListRenderItemInfo,
   ListViewToken,
   ViewabilityConfigCallbackPair,
@@ -40,6 +40,17 @@ type RequiredFlatListProps<ItemT> = {
    */
   data: ?$ReadOnly<$ArrayLike<ItemT>>,
 };
+
+export type FlatListRenderItemInfo<ItemT> = {
+  ...ListRenderItemInfo<ItemT>,
+  isSelected: boolean,
+  ...
+};
+
+export type FlatListRenderItem<ItemT> = (
+  info: FlatListRenderItemInfo<ItemT>,
+) => React.Node;
+
 type OptionalFlatListProps<ItemT> = {
   /**
    * Takes an item from `data` and renders it into the list. Example usage:
@@ -67,7 +78,7 @@ type OptionalFlatListProps<ItemT> = {
    * `highlight` and `unhighlight` (which set the `highlighted: boolean` prop) are insufficient for
    * your use-case.
    */
-  renderItem?: ?ListRenderItem<ItemT>,
+  renderItem?: ?FlatListRenderItem<ItemT>,
 
   /**
    * Optional custom style for multi-item rows generated when numColumns > 1.
@@ -90,6 +101,23 @@ type OptionalFlatListProps<ItemT> = {
    * @platform macos
    */
   enableSelectionOnKeyPress?: ?boolean,
+  /**
+   * Called when the selected row changes.
+   *
+   * @platform macos
+   */
+  onSelectionChanged?: ?(info: {
+    previousSelection: number,
+    newSelection: number,
+    item: ?(ItemT | $ReadOnlyArray<ItemT>),
+    ...
+  }) => void,
+  /**
+   * Called when Enter is pressed on the selected row.
+   *
+   * @platform macos
+   */
+  onSelectionEntered?: ?(item: ?(ItemT | $ReadOnlyArray<ItemT>)) => void,
   // macOS]
   /**
    * A marker property for telling the list to re-render (since it implements `PureComponent`). If
@@ -143,7 +171,7 @@ type OptionalFlatListProps<ItemT> = {
   initialSelectedIndex?: ?number,
   // macOS]
   /**
-   * Reverses the direction of scroll. Uses native inversion on macOS and scale transforms of -1 elsewhere
+   * Reverses the direction of scroll. Uses native inversion on macOS and scale transforms of -1 elsewhere.
    */
   inverted?: ?boolean,
   /**
@@ -201,6 +229,16 @@ function isArrayLike(data: mixed): boolean {
   return typeof Object(data).length === 'number';
 }
 
+const SELECTION_KEY_DOWN_EVENTS: $ReadOnlyArray<HandledKeyEvent> = [
+  {key: 'ArrowUp'},
+  {key: 'ArrowUp', altKey: true},
+  {key: 'ArrowDown'},
+  {key: 'ArrowDown', altKey: true},
+  {key: 'Home'},
+  {key: 'End'},
+  {key: 'Enter'},
+];
+
 type FlatListBaseProps<ItemT> = {
   ...RequiredFlatListProps<ItemT>,
   ...OptionalFlatListProps<ItemT>,
@@ -218,6 +256,10 @@ export type FlatListProps<ItemT> = {
   >,
   ...FlatListBaseProps<ItemT>,
   ...
+};
+
+type FlatListState = {
+  selectedRowIndex: number,
 };
 
 /**
@@ -328,7 +370,10 @@ export type FlatListProps<ItemT> = {
  *
  * Also inherits [ScrollView Props](docs/scrollview.html#props), unless it is nested in another FlatList of same orientation.
  */
-class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
+class FlatList<ItemT = any> extends React.PureComponent<
+  FlatListProps<ItemT>,
+  FlatListState,
+> {
   /**
    * Scrolls to the end of the content. May be janky without `getItemLayout` prop.
    */
@@ -416,9 +461,7 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
    * @platform macos
    */
   selectRowAtIndex(index: number) {
-    if (this._listRef) {
-      this._listRef.selectRowAtIndex(index);
-    }
+    this._selectRowAtIndex(index);
   }
   // macOS]
 
@@ -458,6 +501,9 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
 
   constructor(props: FlatListProps<ItemT>) {
     super(props);
+    this.state = {
+      selectedRowIndex: props.initialSelectedIndex ?? -1,
+    };
     this._checkProps(this.props);
     if (this.props.viewabilityConfigCallbackPairs) {
       this._virtualizedListPairs =
@@ -512,6 +558,11 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
     );
 
     this._checkProps(this.props);
+
+    const itemCount = this._getItemCount(this.props.data);
+    if (this.state.selectedRowIndex >= itemCount) {
+      this.setState({selectedRowIndex: itemCount - 1});
+    }
   }
 
   _listRef: ?VirtualizedList;
@@ -519,6 +570,72 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
 
   _captureRef = (ref: ?VirtualizedList) => {
     this._listRef = ref;
+  };
+
+  _selectRowAtIndex = (index: number) => {
+    const itemCount = this._getItemCount(this.props.data);
+    invariant(
+      index >= 0 && index < itemCount,
+      `selectRowAtIndex out of range: requested index ${index} is out of 0 to ${
+        itemCount - 1
+      }`,
+    );
+
+    const previousSelection = this.state.selectedRowIndex;
+    this.setState({selectedRowIndex: index});
+    this._listRef?.ensureItemAtIndexIsVisible(index);
+
+    if (previousSelection !== index) {
+      this.props.onSelectionChanged?.({
+        previousSelection,
+        newSelection: index,
+        item: this._getItem((this.props.data: any), index),
+      });
+    }
+  };
+
+  _handleSelectionKeyDown = (event: KeyEvent) => {
+    this.props.onKeyDown?.(event);
+    if (event.defaultPrevented || event.isDefaultPrevented()) {
+      return;
+    }
+
+    const itemCount = this._getItemCount(this.props.data);
+    const selectedRowIndex = this.state.selectedRowIndex;
+
+    switch (event.nativeEvent.key) {
+      case 'ArrowUp':
+        if (itemCount > 0) {
+          this._selectRowAtIndex(
+            event.nativeEvent.altKey
+              ? 0
+              : Math.max(0, selectedRowIndex < 0 ? 0 : selectedRowIndex - 1),
+          );
+        }
+        break;
+      case 'ArrowDown':
+        if (itemCount > 0) {
+          this._selectRowAtIndex(
+            event.nativeEvent.altKey
+              ? itemCount - 1
+              : Math.min(itemCount - 1, selectedRowIndex + 1),
+          );
+        }
+        break;
+      case 'Enter':
+        if (selectedRowIndex >= 0 && selectedRowIndex < itemCount) {
+          this.props.onSelectionEntered?.(
+            this._getItem((this.props.data: any), selectedRowIndex),
+          );
+        }
+        break;
+      case 'Home':
+        this.scrollToOffset({animated: true, offset: 0});
+        break;
+      case 'End':
+        this.scrollToEnd({animated: true});
+        break;
+    }
   };
 
   // $FlowFixMe[missing-local-annot]
@@ -652,15 +769,17 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
 
   _renderer = (
     ListItemComponent: ?(React.ComponentType<any> | React.MixedElement),
-    renderItem: ?ListRenderItem<ItemT>,
+    renderItem: ?FlatListRenderItem<ItemT>,
     columnWrapperStyle: ?ViewStyleProp,
     numColumns: ?number,
     extraData: ?any,
+    enableSelectionOnKeyPress: boolean,
+    selectedRowIndex: number,
     // $FlowFixMe[missing-local-annot]
   ) => {
     const cols = numColumnsOrDefault(numColumns);
 
-    const render = (props: ListRenderItemInfo<ItemT>): React.Node => {
+    const render = (props: FlatListRenderItemInfo<ItemT>): React.Node => {
       if (ListItemComponent) {
         // $FlowFixMe[not-a-component] Component isn't valid
         // $FlowFixMe[incompatible-type] Component isn't valid
@@ -674,6 +793,8 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
     };
 
     const renderProp = (info: ListRenderItemInfo<ItemT>) => {
+      const isSelected =
+        enableSelectionOnKeyPress && selectedRowIndex === info.index;
       if (cols > 1) {
         const {item, index} = info;
         invariant(
@@ -687,7 +808,7 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
                 // $FlowFixMe[incompatible-type]
                 item: it,
                 index: index * cols + kk,
-                isSelected: info.isSelected, // [macOS]
+                isSelected,
                 separators: info.separators,
               });
               return element != null ? (
@@ -697,7 +818,7 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
           </View>
         );
       } else {
-        return render(info);
+        return render({...info, isSelected});
       }
     };
 
@@ -714,10 +835,21 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
       columnWrapperStyle,
       removeClippedSubviews: _removeClippedSubviews,
       strictMode = false,
+      enableSelectionOnKeyPress = false,
+      focusable,
+      initialSelectedIndex: _initialSelectedIndex,
+      keyDownEvents,
+      onKeyDown,
+      onSelectionChanged: _onSelectionChanged,
+      onSelectionEntered: _onSelectionEntered,
       ...restProps
     } = this.props;
 
     const renderer = strictMode ? this._memoizedRenderer : this._renderer;
+    const selectionEnabled = enableSelectionOnKeyPress === true;
+    const selectionKeyDownEvents = selectionEnabled
+      ? [...SELECTION_KEY_DOWN_EVENTS, ...(keyDownEvents ?? [])]
+      : keyDownEvents;
 
     return (
       // $FlowFixMe[incompatible-exact] - `restProps` (`Props`) is inexact.
@@ -728,6 +860,9 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
         keyExtractor={this._keyExtractor}
         ref={this._captureRef}
         viewabilityConfigCallbackPairs={this._virtualizedListPairs}
+        focusable={selectionEnabled ? (focusable ?? true) : focusable}
+        keyDownEvents={selectionKeyDownEvents}
+        onKeyDown={selectionEnabled ? this._handleSelectionKeyDown : onKeyDown}
         removeClippedSubviews={removeClippedSubviewsOrDefault(
           _removeClippedSubviews,
         )}
@@ -737,6 +872,8 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
           columnWrapperStyle,
           numColumns,
           this.props.extraData,
+          selectionEnabled,
+          this.state.selectedRowIndex,
         )}
       />
     );

--- a/packages/react-native/Libraries/Lists/__tests__/FlatList-test.js
+++ b/packages/react-native/Libraries/Lists/__tests__/FlatList-test.js
@@ -11,9 +11,23 @@
 'use strict';
 
 const {create} = require('../../../jest/renderer');
+const ScrollView = require('../../Components/ScrollView/ScrollView').default;
 const FlatList = require('../FlatList').default;
 const React = require('react');
 const {createRef} = require('react');
+const {act} = require('react-test-renderer');
+
+function createKeyEvent(key: string, altKey: boolean = false) {
+  let defaultPrevented = false;
+  return {
+    defaultPrevented,
+    isDefaultPrevented: () => defaultPrevented,
+    nativeEvent: {altKey, key},
+    preventDefault: () => {
+      defaultPrevented = true;
+    },
+  };
+}
 
 describe('FlatList', () => {
   it('renders simple list', async () => {
@@ -59,6 +73,147 @@ describe('FlatList', () => {
       />,
     );
     expect(component).toMatchSnapshot();
+  });
+
+  it('owns keyboard row selection state', async () => {
+    const listRef = createRef<React.ElementRef<typeof FlatList>>();
+    const onSelectionChanged = jest.fn();
+    const onSelectionEntered = jest.fn();
+    const component = await create(
+      <FlatList
+        data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
+        enableSelectionOnKeyPress={true}
+        initialSelectedIndex={0}
+        onSelectionChanged={onSelectionChanged}
+        onSelectionEntered={onSelectionEntered}
+        ref={listRef}
+        renderItem={({isSelected, item}) => (
+          <item isSelected={isSelected} value={item.key} />
+        )}
+      />,
+    );
+
+    expect(
+      component.root.findAllByType('item').map(item => item.props.isSelected),
+    ).toEqual([true, false, false]);
+
+    const scrollView = component.root.findByType(ScrollView);
+    expect(scrollView.props.keyDownEvents).toContainEqual({key: 'Enter'});
+
+    await act(async () => {
+      scrollView.props.onKeyDown(createKeyEvent('ArrowDown'));
+    });
+
+    expect(
+      component.root.findAllByType('item').map(item => item.props.isSelected),
+    ).toEqual([false, true, false]);
+    expect(onSelectionChanged).toHaveBeenCalledWith({
+      item: {key: 'i2'},
+      newSelection: 1,
+      previousSelection: 0,
+    });
+
+    await act(async () => {
+      scrollView.props.onKeyDown(createKeyEvent('ArrowDown', true));
+    });
+    expect(
+      component.root.findAllByType('item').map(item => item.props.isSelected),
+    ).toEqual([false, false, true]);
+    expect(onSelectionChanged).toHaveBeenLastCalledWith({
+      item: {key: 'i3'},
+      newSelection: 2,
+      previousSelection: 1,
+    });
+
+    scrollView.props.onKeyDown(createKeyEvent('Enter'));
+    expect(onSelectionEntered).toHaveBeenCalledWith({key: 'i3'});
+
+    await act(async () => {
+      listRef.current?.selectRowAtIndex(0);
+    });
+    expect(onSelectionChanged).toHaveBeenLastCalledWith({
+      item: {key: 'i1'},
+      newSelection: 0,
+      previousSelection: 2,
+    });
+  });
+
+  it('lets consumers prevent keyboard selection', async () => {
+    const onKeyDown = jest.fn(event => event.preventDefault());
+    const onSelectionChanged = jest.fn();
+    const component = await create(
+      <FlatList
+        data={[{key: 'i1'}, {key: 'i2'}]}
+        enableSelectionOnKeyPress={true}
+        initialSelectedIndex={0}
+        onKeyDown={onKeyDown}
+        onSelectionChanged={onSelectionChanged}
+        renderItem={({item}) => <item value={item.key} />}
+      />,
+    );
+
+    component.root
+      .findByType(ScrollView)
+      .props.onKeyDown(createKeyEvent('ArrowDown'));
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(onSelectionChanged).not.toHaveBeenCalled();
+  });
+
+  it('rejects selecting a row outside the data', async () => {
+    const listRef = createRef<React.ElementRef<typeof FlatList>>();
+    await create(
+      <FlatList
+        data={[{key: 'i1'}]}
+        ref={listRef}
+        renderItem={({item}) => <item value={item.key} />}
+      />,
+    );
+
+    expect(() => listRef.current?.selectRowAtIndex(1)).toThrow(
+      'selectRowAtIndex out of range',
+    );
+  });
+
+  it('keeps visible selections still and preserves scroll failure handling', async () => {
+    const listRef = createRef<React.ElementRef<typeof FlatList>>();
+    const onScrollToIndexFailed = jest.fn();
+    await create(
+      <FlatList
+        data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
+        getItemLayout={(_, index) => ({
+          index,
+          length: 10,
+          offset: index * 10,
+        })}
+        onScrollToIndexFailed={onScrollToIndexFailed}
+        ref={listRef}
+        renderItem={({item}) => <item value={item.key} />}
+      />,
+    );
+    const list = listRef.current;
+    if (list == null) {
+      throw new Error('FlatList ref was not set');
+    }
+    // $FlowFixMe[prop-missing] Verify selection scrolling on the owned list.
+    const virtualizedList = list._listRef;
+    if (virtualizedList == null) {
+      throw new Error('VirtualizedList ref was not set');
+    }
+    const scrollToOffset = jest.spyOn(virtualizedList, 'scrollToOffset');
+
+    await act(async () => {
+      virtualizedList._onLayout({
+        nativeEvent: {layout: {height: 100, width: 100}, zoomScale: 1},
+      });
+      virtualizedList._onContentSizeChange(100, 30);
+      list.selectRowAtIndex(1);
+    });
+
+    expect(scrollToOffset).not.toHaveBeenCalled();
+    expect(virtualizedList.props.onScrollToIndexFailed).toBe(
+      onScrollToIndexFailed,
+    );
   });
   it('renders empty list', async () => {
     const component = await create(

--- a/packages/react-native/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
+++ b/packages/react-native/Libraries/Lists/__tests__/__snapshots__/FlatList-test.js.snap
@@ -176,7 +176,6 @@ exports[`FlatList renders all the bells and whistles 1`] = `
       </View>
     </View>
     <View
-      collapsable={true}
       onLayout={[Function]}
     >
       <footer />

--- a/packages/react-native/Libraries/Lists/__tests__/__snapshots__/SectionList-test.js.snap
+++ b/packages/react-native/Libraries/Lists/__tests__/__snapshots__/SectionList-test.js.snap
@@ -386,7 +386,6 @@ exports[`SectionList renders all the bells and whistles 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       onLayout={[Function]}
     >
       <footer

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -34,7 +34,11 @@ export type {
 } from './Libraries/Components/DrawerAndroid/DrawerLayoutAndroid';
 export {default as DrawerLayoutAndroid} from './Libraries/Components/DrawerAndroid/DrawerLayoutAndroid';
 
-export type {FlatListProps} from './Libraries/Lists/FlatList';
+export type {
+  FlatListProps,
+  FlatListRenderItem,
+  FlatListRenderItemInfo,
+} from './Libraries/Lists/FlatList';
 export {default as FlatList} from './Libraries/Lists/FlatList';
 
 export type {
@@ -275,7 +279,6 @@ export {DynamicColorIOS} from './Libraries/StyleSheet/PlatformColorValueTypesIOS
 export type {DynamicColorMacOSTuple} from './Libraries/StyleSheet/PlatformColorValueTypesMacOS';
 export {DynamicColorMacOS} from './Libraries/StyleSheet/PlatformColorValueTypesMacOS';
 // macOS]
-
 
 export type {EasingFunction} from './Libraries/Animated/Easing';
 export {default as Easing} from './Libraries/Animated/Easing';

--- a/packages/rn-tester/js/components/RNTesterModuleList.js
+++ b/packages/rn-tester/js/components/RNTesterModuleList.js
@@ -97,7 +97,6 @@ const RNTesterModuleList: React.ComponentType<any> = memo(
               renderItem={renderListItem}
               keyboardShouldPersistTaps="handled"
               focusable={true} // [macOS]
-              enableSelectionOnKeyPress={true} // [macOS]
               automaticallyAdjustContentInsets={false}
               keyboardDismissMode="on-drag"
               renderSectionHeader={renderSectionHeader}

--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -12,7 +12,7 @@
 
 import type {Item} from '../../components/ListExampleShared';
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
-import type {FlatList, ListRenderItemInfo} from 'react-native';
+import type {FlatList, FlatListRenderItemInfo} from 'react-native';
 
 import {
   FooterComponent,
@@ -392,7 +392,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
       item,
       separators,
       isSelected, // [macOS]
-    }: ListRenderItemInfo<Item>) => {
+    }: FlatListRenderItemInfo<Item>) => {
       return (
         <ItemComponent
           testID={`item_${item.key}`}

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -24,7 +24,6 @@ import type {
   StyleProp,
   ViewStyle,
 } from 'react-native';
-import type {KeyEvent} from 'react-native/Libraries/Types/CoreEventTypes'; // [macOS]
 
 import clamp from '../Utilities/clamp';
 import infoLog from '../Utilities/infoLog';
@@ -87,7 +86,6 @@ type ViewabilityHelperCallbackTuple = {
 type State = {
   renderMask: CellRenderMask,
   cellsAroundViewport: {first: number, last: number},
-  selectedRowIndex: number, // [macOS]
   // Used to track items added at the start of the list for maintainVisibleContentPosition.
   firstVisibleItemKey: ?string,
   // When > 0 the scroll position available in JS is considered stale and should not be used.
@@ -304,10 +302,6 @@ class VirtualizedList extends StateSafePureComponent<
       this.scrollToOffset({offset: newOffset});
     }
   }
-
-  selectRowAtIndex(rowIndex: number) {
-    this._selectRowAtIndex(rowIndex);
-  }
   // macOS]
 
   recordInteraction() {
@@ -432,7 +426,6 @@ class VirtualizedList extends StateSafePureComponent<
     this.state = {
       cellsAroundViewport: initialRenderRegion,
       renderMask: VirtualizedList._createRenderMask(props, initialRenderRegion),
-      selectedRowIndex: this.props.initialSelectedIndex ?? -1, // [macOS]
       firstVisibleItemKey:
         this.props.getItemCount(this.props.data) > minIndexForVisible
           ? VirtualizedList._getItemKey(this.props, minIndexForVisible)
@@ -786,11 +779,6 @@ class VirtualizedList extends StateSafePureComponent<
     return {
       cellsAroundViewport: constrainedCells,
       renderMask: VirtualizedList._createRenderMask(newProps, constrainedCells),
-      // [macOS
-      selectedRowIndex: Math.max(
-        -1, // Used to indicate no row is selected
-        Math.min(prevState.selectedRowIndex, itemCount),
-      ), // macOS]
       firstVisibleItemKey: newFirstVisibleItemKey,
       pendingScrollUpdateCount:
         maintainVisibleContentPositionAdjustment != null
@@ -847,13 +835,6 @@ class VirtualizedList extends StateSafePureComponent<
           index={ii}
           inversionStyle={inversionStyle}
           item={item}
-          // [macOS
-          isSelected={
-            this.props.enableSelectionOnKeyPress &&
-            this.state.selectedRowIndex === ii
-              ? true
-              : false
-          } // macOS]
           key={key}
           prevCellKey={prevCellKey}
           onUpdateSeparators={this._onUpdateSeparators}
@@ -962,13 +943,13 @@ class VirtualizedList extends StateSafePureComponent<
     const {ListEmptyComponent, ListFooterComponent, ListHeaderComponent} =
       this.props;
     const {data, horizontal} = this.props;
-    // macOS natively supports inverted lists, thus not needing an inversion style
-    const inversionStyle =
-      this.props.inverted && Platform.OS !== 'macos' // [macOS]
-        ? horizontalOrDefault(this.props.horizontal)
-          ? styles.horizontallyInverted
+    const inversionStyle = this.props.inverted
+      ? horizontalOrDefault(this.props.horizontal)
+        ? styles.horizontallyInverted
+        : Platform.OS === 'macos' // [macOS]
+          ? null
           : styles.verticallyInverted
-        : null;
+      : null;
     const cells: Array<any | React.Node> = [];
     const stickyIndicesFromProps = new Set(this.props.stickyHeaderIndices);
     const stickyHeaderIndices = [];
@@ -1021,10 +1002,8 @@ class VirtualizedList extends StateSafePureComponent<
         <ListEmptyComponent />
       )): any);
       cells.push(
-        // $FlowFixMe[incompatible-type] React.Element internal inspection
         <VirtualizedListCellContextProvider
           cellKey={this._getCellKey() + '-empty'}
-          collapsable={Platform.OS !== 'macos'} // [macOS]
           key="$empty">
           {this._renderEmptyComponent(element, inversionStyle)}
         </VirtualizedListCellContextProvider>,
@@ -1074,7 +1053,6 @@ class VirtualizedList extends StateSafePureComponent<
             lastMetrics.offset + lastMetrics.length - firstMetrics.offset;
           cells.push(
             <View
-              collapsable={Platform.OS !== 'macos'} // [macOS]
               key={`$spacer-${section.first}`}
               // $FlowFixMe[incompatible-type]
               style={{[spacerKey]: spacerSize}}
@@ -1116,7 +1094,6 @@ class VirtualizedList extends StateSafePureComponent<
           cellKey={this._getFooterCellKey()}
           key="$footer">
           <View
-            collapsable={Platform.OS !== 'macos'} // [macOS]
             onLayout={this._onLayoutFooter}
             style={StyleSheet.compose(
               inversionStyle,
@@ -1317,25 +1294,6 @@ class VirtualizedList extends StateSafePureComponent<
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
    * LTI update could not be added via codemod */
   _defaultRenderScrollComponent = props => {
-    // [macOS
-    const preferredScrollerStyleDidChangeHandler =
-      this.props.onPreferredScrollerStyleDidChange;
-    const invertedDidChange = this.props.onInvertedDidChange;
-
-    let keyDownEvents = [
-      {key: 'ArrowUp'},
-      {key: 'ArrowDown'},
-      {key: 'Home'},
-      {key: 'End'},
-    ];
-
-    const keyboardNavigationProps = {
-      focusable: true,
-      keyDownEvents: keyDownEvents,
-      onKeyDown: this._handleKeyDown,
-    };
-    // macOS]
-
     const onRefresh = props.onRefresh;
     if (this._isNestedWithSameOrientation()) {
       // Prevent VirtualizedList._onContentSizeChange from being triggered by a bubbling onContentSizeChange event.
@@ -1353,14 +1311,7 @@ class VirtualizedList extends StateSafePureComponent<
         // $FlowFixMe[prop-missing] Invalid prop usage
         // $FlowFixMe[incompatible-use]
         <ScrollView
-          // [macOS
-          {...(props.enableSelectionOnKeyPress && keyboardNavigationProps)}
-          onInvertedDidChange={invertedDidChange}
-          onPreferredScrollerStyleDidChange={
-            preferredScrollerStyleDidChangeHandler
-          }
           {...props}
-          // macOS]
           refreshControl={
             props.refreshControl == null ? (
               <RefreshControl
@@ -1376,19 +1327,9 @@ class VirtualizedList extends StateSafePureComponent<
         />
       );
     } else {
-      return (
-        // $FlowFixMe[prop-missing] Invalid prop usage
-        // $FlowFixMe[incompatible-use]
-        <ScrollView
-          // [macOS
-          {...(props.enableSelectionOnKeyPress && keyboardNavigationProps)}
-          onInvertedDidChange={invertedDidChange}
-          onPreferredScrollerStyleDidChange={
-            preferredScrollerStyleDidChangeHandler
-          } // macOS]
-          {...props}
-        />
-      );
+      // $FlowFixMe[prop-missing] Invalid prop usage
+      // $FlowFixMe[incompatible-use]
+      return <ScrollView {...props} />;
     }
   };
 
@@ -1516,81 +1457,6 @@ class VirtualizedList extends StateSafePureComponent<
   _onLayoutHeader = (e: LayoutChangeEvent) => {
     this._headerLength = this._selectLength(e.nativeEvent.layout);
   };
-
-  // [macOS
-  _selectRowAtIndex = (rowIndex: number) => {
-    const prevIndex = this.state.selectedRowIndex;
-    const newIndex = rowIndex;
-    this.setState<'selectedRowIndex'>({selectedRowIndex: newIndex});
-
-    this.ensureItemAtIndexIsVisible(newIndex);
-    if (prevIndex !== newIndex) {
-      const item = this.props.getItem(this.props.data, newIndex);
-      if (this.props.onSelectionChanged) {
-        this.props.onSelectionChanged({
-          previousSelection: prevIndex,
-          newSelection: newIndex,
-          item: item,
-        });
-      }
-    }
-  };
-
-  _selectRowAboveIndex = (rowIndex: number) => {
-    const rowAbove = rowIndex > 0 ? rowIndex - 1 : rowIndex;
-    this._selectRowAtIndex(rowAbove);
-  };
-
-  _selectRowBelowIndex = (rowIndex: number) => {
-    const rowBelow =
-      rowIndex < this.state.cellsAroundViewport.last ? rowIndex + 1 : rowIndex;
-    this._selectRowAtIndex(rowBelow);
-  };
-
-  _handleKeyDown = (event: KeyEvent) => {
-    if (Platform.OS === 'macos') {
-      this.props.onKeyDown?.(event);
-      if (event.defaultPrevented) {
-        return;
-      }
-
-      const nativeEvent = event.nativeEvent;
-      const key = nativeEvent.key;
-
-      let selectedIndex = -1;
-      if (this.state.selectedRowIndex >= 0) {
-        selectedIndex = this.state.selectedRowIndex;
-      }
-
-      if (key === 'ArrowUp') {
-        if (nativeEvent.altKey) {
-          // Option+Up selects the first element
-          this._selectRowAtIndex(0);
-        } else {
-          this._selectRowAboveIndex(selectedIndex);
-        }
-      } else if (key === 'ArrowDown') {
-        if (nativeEvent.altKey) {
-          // Option+Down selects the last element
-          this._selectRowAtIndex(this.state.cellsAroundViewport.last);
-        } else {
-          this._selectRowBelowIndex(selectedIndex);
-        }
-      } else if (key === 'Enter') {
-        if (this.props.onSelectionEntered) {
-          const item = this.props.getItem(this.props.data, selectedIndex);
-          if (this.props.onSelectionEntered) {
-            this.props.onSelectionEntered(item);
-          }
-        }
-      } else if (key === 'Home') {
-        this.scrollToOffset({animated: true, offset: 0});
-      } else if (key === 'End') {
-        this.scrollToEnd({animated: true});
-      }
-    }
-  };
-  // macOS]
 
   // $FlowFixMe[missing-local-annot]
   _renderDebugOverlay() {

--- a/packages/virtualized-lists/Lists/VirtualizedListCellRenderer.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListCellRenderer.js
@@ -20,7 +20,7 @@ import {VirtualizedListCellContextProvider} from './VirtualizedListContext.js';
 import invariant from 'invariant';
 import * as React from 'react';
 import {isValidElement} from 'react';
-import {Platform, StyleSheet, View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
 
 export type Props<ItemT> = {
   CellRendererComponent?: ?React.ComponentType<CellRendererProps<ItemT>>,
@@ -33,7 +33,6 @@ export type Props<ItemT> = {
   horizontal: ?boolean,
   index: number,
   inversionStyle: StyleProp<ViewStyle>,
-  isSelected: ?boolean, // [macOS]
   item: ItemT,
   onCellLayout?: (
     event: LayoutChangeEvent,
@@ -142,7 +141,6 @@ export default class CellRenderer<ItemT> extends React.PureComponent<
     ListItemComponent: any,
     item: ItemT,
     index: number,
-    isSelected: ?boolean, // [macOS]
   ): React.Node {
     if (renderItem && ListItemComponent) {
       console.warn(
@@ -165,7 +163,6 @@ export default class CellRenderer<ItemT> extends React.PureComponent<
       return renderItem({
         item,
         index,
-        isSelected, // [macOS]
         separators: this._separators,
       });
     }
@@ -186,7 +183,6 @@ export default class CellRenderer<ItemT> extends React.PureComponent<
       item,
       index,
       inversionStyle,
-      isSelected, // [macOS]
       onCellLayout,
       renderItem,
     } = this.props;
@@ -195,7 +191,6 @@ export default class CellRenderer<ItemT> extends React.PureComponent<
       ListItemComponent,
       item,
       index,
-      isSelected, // [macOS]
     );
 
     // NOTE: that when this is a sticky header, `onLayout` will get automatically extracted and
@@ -216,7 +211,7 @@ export default class CellRenderer<ItemT> extends React.PureComponent<
       : horizontal
         ? [styles.row, inversionStyle]
         : inversionStyle;
-    let result: any = !CellRendererComponent ? ( // [macOS]
+    const result = !CellRendererComponent ? (
       <View
         style={cellStyle}
         onFocusCapture={this._onCellFocusCapture}
@@ -236,11 +231,6 @@ export default class CellRenderer<ItemT> extends React.PureComponent<
         {itemSeparator}
       </CellRendererComponent>
     );
-
-    if (Platform.OS === 'macos') {
-      // [macOS
-      result = React.cloneElement(result, {collapsable: false});
-    } // macOS]
 
     return (
       <VirtualizedListCellContextProvider cellKey={this.props.cellKey}>

--- a/packages/virtualized-lists/Lists/VirtualizedListProps.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListProps.js
@@ -35,7 +35,6 @@ export type Separators = {
 export type ListRenderItemInfo<ItemT> = {
   item: ItemT,
   index: number,
-  isSelected: ?boolean, // [macOS]
   separators: Separators,
   ...
 };
@@ -53,12 +52,6 @@ export type CellRendererProps<ItemT> = $ReadOnly<{
 export type ListRenderItem<ItemT> = (
   info: ListRenderItemInfo<ItemT>,
 ) => React.Node;
-
-// [macOS
-export type SelectedRowIndexPathType = {
-  sectionIndex: number,
-  rowIndex: number,
-}; // macOS]
 
 type RequiredVirtualizedListProps = {
   /**
@@ -290,56 +283,11 @@ type OptionalVirtualizedListProps = {
    */
   windowSize?: ?number,
 };
-// [macOS
-type VirtualizedListMacOSProps = {
-  /**
-   * Allows you to 'select' a row using arrow keys. The selected row will have the prop `isSelected`
-   * passed in as true to it's renderItem / ListItemComponent. You can also imperatively select a row
-   * using the `selectRowAtIndex` method. You can set the initially selected row using the
-   * `initialSelectedIndex` prop.
-   * Keyboard Behavior:
-   * - ArrowUp: Select row above current selected row
-   * - ArrowDown: Select row below current selected row
-   * - Option+ArrowUp: Select the first row
-   * - Opton+ArrowDown: Select the last 'realized' row
-   * - Home: Scroll to top of list
-   * - End: Scroll to end of list
-   *
-   * @platform macos
-   */
-  enableSelectionOnKeyPress?: ?boolean,
-  /**
-   * The initially selected row, if `enableSelectionOnKeyPress` is set.
-   */
-  initialSelectedIndex?: ?number,
-  /**
-   * If provided, will be invoked whenever the selection on the list changes. Make sure to set
-   * the property enableSelectionOnKeyPress to true to change selection via keyboard (macOS).
-   *
-   * @platform macos
-   */
-  onSelectionChanged?: ?(info: {
-    previousSelection: number,
-    newSelection: number,
-    item: ?Item,
-  }) => void,
-  /**
-   * If provided, called when 'Enter' key is pressed on an item.
-   *
-   * @platform macos
-   */
-  onSelectionEntered?: ?(item: ?Item) => void,
-
-  sectionIndex?: number,
-  rowIndex?: number,
-};
-// macOS]
 
 export type VirtualizedListProps = {
   ...ScrollViewProps,
   ...RequiredVirtualizedListProps,
   ...OptionalVirtualizedListProps,
-  ...VirtualizedListMacOSProps, // [macOS]
 };
 
 /**

--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -72,7 +72,6 @@ type OptionalVirtualizedSectionListProps<
   renderItem?: (info: {
     item: ItemT,
     index: number,
-    isSelected: ?boolean, // [macOS]
     section: SectionT,
     separators: {
       highlight: () => void,

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedList-test.js.snap
@@ -413,7 +413,6 @@ exports[`VirtualizedList forwards correct stickyHeaderIndices when partially in 
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 50,
@@ -908,7 +907,6 @@ exports[`VirtualizedList keeps sticky headers above viewport visualized 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 110,
@@ -925,7 +923,6 @@ exports[`VirtualizedList keeps sticky headers above viewport visualized 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 10,
@@ -1176,7 +1173,6 @@ exports[`VirtualizedList renders all the bells and whistles 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       onLayout={[Function]}
       style={
         Object {
@@ -1262,7 +1258,6 @@ exports[`VirtualizedList renders empty list with empty component 1`] = `
     </View>
     <empty />
     <View
-      collapsable={true}
       onLayout={[Function]}
     >
       <footer />
@@ -1552,7 +1547,6 @@ exports[`VirtualizedList renders sticky headers in viewport on batched render 1`
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 50,
@@ -1843,7 +1837,6 @@ exports[`adjusts render area with non-zero initialScrollIndex 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 50,
@@ -1924,7 +1917,6 @@ exports[`clamps render area when items removed for initialScrollIndex > 0 and sc
 >
   <View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 40,
@@ -2190,7 +2182,6 @@ exports[`discards intitial render if initialScrollIndex != 0 1`] = `
 >
   <View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 140,
@@ -2373,7 +2364,6 @@ exports[`does not adjust render area until content area layed out 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 150,
@@ -2469,7 +2459,6 @@ exports[`does not move render area when initialScrollIndex is > 0 and offset not
 >
   <View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 10,
@@ -2517,7 +2506,6 @@ exports[`does not move render area when initialScrollIndex is > 0 and offset not
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 140,
@@ -2582,7 +2570,6 @@ exports[`does not over-render when there is less than initialNumToRender cells 1
 >
   <View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 40,
@@ -2836,7 +2823,6 @@ exports[`expands first in viewport to render up to maxToRenderPerBatch on initia
 >
   <View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 40,
@@ -2860,7 +2846,6 @@ exports[`expands first in viewport to render up to maxToRenderPerBatch on initia
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 40,
@@ -3011,7 +2996,6 @@ exports[`expands render area by maxToRenderPerBatch on tick 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 130,
@@ -3288,7 +3272,6 @@ exports[`handles maintainVisibleContentPosition 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 150,
@@ -3426,7 +3409,6 @@ exports[`handles maintainVisibleContentPosition 2`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 90,
@@ -3474,7 +3456,6 @@ exports[`handles maintainVisibleContentPosition 2`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 150,
@@ -3612,7 +3593,6 @@ exports[`handles maintainVisibleContentPosition 3`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 80,
@@ -3668,7 +3648,6 @@ exports[`handles maintainVisibleContentPosition 3`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 150,
@@ -3808,7 +3787,6 @@ exports[`handles maintainVisibleContentPosition when anchor moves before minInde
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 150,
@@ -3937,7 +3915,6 @@ exports[`handles maintainVisibleContentPosition when anchor moves before minInde
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 150,
@@ -4001,7 +3978,6 @@ exports[`initially renders nothing when initialNumToRender is 0 1`] = `
 >
   <View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 100,
@@ -4136,7 +4112,6 @@ exports[`keeps viewport above last focused rendered 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 70,
@@ -4367,7 +4342,6 @@ exports[`keeps viewport below last focused rendered 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 50,
@@ -4505,7 +4479,6 @@ exports[`renders a zero-height tail spacer on initial render if getItemLayout no
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 0,
@@ -4615,7 +4588,6 @@ exports[`renders full tail spacer if all cells measured 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 50,
@@ -4893,7 +4865,6 @@ exports[`renders new items when data is updated with non-zero initialScrollIndex
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 20,
@@ -5033,7 +5004,6 @@ exports[`renders offset cells in initial render when initialScrollIndex set 1`] 
 >
   <View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 40,
@@ -5073,7 +5043,6 @@ exports[`renders offset cells in initial render when initialScrollIndex set 1`] 
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 20,
@@ -5183,7 +5152,6 @@ exports[`renders tail spacer up to last measured index if getItemLayout not defi
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 20,
@@ -5284,7 +5252,6 @@ exports[`renders tail spacer up to last measured with irregular layout when getI
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 17,
@@ -5358,7 +5325,6 @@ exports[`renders windowSize derived region at bottom 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 40,
@@ -5496,7 +5462,6 @@ exports[`renders windowSize derived region at top 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 60,
@@ -5570,7 +5535,6 @@ exports[`renders windowSize derived region in middle 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 10,
@@ -5634,7 +5598,6 @@ exports[`renders windowSize derived region in middle 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 10,
@@ -5726,7 +5689,6 @@ exports[`renders zero-height tail spacer on batch render if cells not yet measur
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 0,
@@ -5964,7 +5926,6 @@ exports[`retains initial render region when an item is appended 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 80,
@@ -6100,7 +6061,6 @@ exports[`retains intitial render if initialScrollIndex == 0 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 90,
@@ -6297,7 +6257,6 @@ exports[`unmounts sticky headers moved below viewport 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 150,
@@ -6397,7 +6356,6 @@ exports[`virtualizes away last focused index if item removed 1`] = `
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 70,
@@ -6588,7 +6546,6 @@ exports[`virtualizes away last focused item if focus changes to a new cell 1`] =
       />
     </View>
     <View
-      collapsable={true}
       style={
         Object {
           "height": 110,

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedSectionList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedSectionList-test.js.snap
@@ -973,7 +973,6 @@ exports[`VirtualizedSectionList renders all the bells and whistles 1`] = `
       }
     />
     <View
-      collapsable={true}
       onLayout={[Function]}
       style={
         Object {
@@ -1041,7 +1040,6 @@ exports[`VirtualizedSectionList renders empty list with empty component 1`] = `
     </View>
     <empty />
     <View
-      collapsable={true}
       onLayout={[Function]}
     >
       <footer />


### PR DESCRIPTION
## Summary

- sync `@react-native-macos/virtualized-lists` implementation and tests with the React Native merge-base
- retain one macOS-only delta for native vertical inversion so trackpad, mouse-wheel, and scrollbar behavior remain native
- keep horizontal inverted lists transform-based
- move opt-in keyboard selection state, callbacks, `isSelected`, and `selectRowAtIndex` into `FlatList`
- keep `ScrollView` generic; it only preserves native children when macOS native inversion is active

## Why

The fork duplicated upstream list implementation primarily for keyboard selection and native inversion. Selection is FlatList/listbox semantics, while VirtualizedList should remain generic virtualization infrastructure. Native vertical inversion still needs a minimal strategy clause because upstream transform inversion does not provide correct macOS scrolling interactions.

After this change, the virtualized-lists fork differs from the upstream merge-base in only `Lists/VirtualizedList.js`, where vertical macOS inversion omits transform styles.

## Behavior notes

- `FlatList` keeps the existing macOS keyboard-selection API.
- `SectionList` and direct `VirtualizedList` no longer expose the unused keyboard-selection API.
- Vertical inverted lists continue using native macOS inversion.
- Horizontal inverted lists use `scaleX(-1)` because AppKit native inversion is vertical only.

## Validation

- `yarn flow-check`
- 11 focused Jest suites: 189 passed, 2 skipped, 82 snapshots
- Prettier and ESLint on all changed source files
- verified the virtualized-lists package has exactly one implementation-file delta from upstream