### PR TITLE
feat(macos): port RedBox 2.0 to AppKit

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -94,6 +94,7 @@ let reactRendererConsistency = RNTarget(
 let reactDebug = RNTarget(
   name: .reactDebug,
   path: "ReactCommon/react/debug",
+  excludedPaths: ["tests", "redbox/tests"],
   dependencies: [.reactNativeDependencies]
 )
 /// React-jsi.podspec
@@ -384,7 +385,7 @@ let reactCoreModules = RNTarget(
   name: .reactCoreModules,
   path: "React/CoreModules",
   excludedPaths: ["PlatformStubs/RCTStatusBarManager.mm"],
-  dependencies: [.reactNativeDependencies, .jsi, .yoga, .reactTurboModuleCore]
+  dependencies: [.reactNativeDependencies, .jsi, .yoga, .reactTurboModuleCore, .reactFeatureFlags]
 )
 
 /// React-runtimeCore.podspec

--- a/packages/react-native/React/CoreModules/RCTJscSafeUrl+Internal.h
+++ b/packages/react-native/React/CoreModules/RCTJscSafeUrl+Internal.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ * Converts between standard URLs and JSC-safe URLs.
+ *
+ * JSC (JavaScriptCore) strips query strings from source URLs in stack traces
+ * as of iOS 16.4. Metro works around this by encoding the query string into
+ * the URL path. These methods convert between the two formats.
+ */
+@interface RCTJscSafeUrl : NSObject
+
++ (nonnull NSString *)normalUrlFromJscSafeUrl:(nonnull NSString *)url;
++ (nonnull NSString *)jscSafeUrlFromNormalUrl:(nonnull NSString *)url;
++ (BOOL)isJscSafeUrl:(nonnull NSString *)url;
+
+@end

--- a/packages/react-native/React/CoreModules/RCTJscSafeUrl.mm
+++ b/packages/react-native/React/CoreModules/RCTJscSafeUrl.mm
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTJscSafeUrl+Internal.h"
+
+#import <React/RCTDefines.h>
+#import <react/debug/redbox/JscSafeUrl.h>
+
+#if RCT_DEV_MENU
+
+using facebook::react::unstable_redbox::isJscSafeUrl;
+using facebook::react::unstable_redbox::toJscSafeUrl;
+using facebook::react::unstable_redbox::toNormalUrl;
+
+@implementation RCTJscSafeUrl
+
++ (NSString *)normalUrlFromJscSafeUrl:(NSString *)url
+{
+  return [NSString stringWithUTF8String:toNormalUrl(url.UTF8String).c_str()];
+}
+
++ (NSString *)jscSafeUrlFromNormalUrl:(NSString *)url
+{
+  return [NSString stringWithUTF8String:toJscSafeUrl(url.UTF8String).c_str()];
+}
+
++ (BOOL)isJscSafeUrl:(NSString *)url
+{
+  return isJscSafeUrl(url.UTF8String);
+}
+
+@end
+
+#endif

--- a/packages/react-native/React/CoreModules/RCTRedBox+Internal.h
+++ b/packages/react-native/React/CoreModules/RCTRedBox+Internal.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTDefines.h>
+#import <React/RCTUIKit.h> // [macOS]
+
+#if RCT_DEV_MENU
+
+@class RCTJSStackFrame;
+
+@protocol RCTRedBoxControllerActionDelegate <NSObject>
+
+- (void)redBoxController:(UIViewController *)redBoxController openStackFrameInEditor:(RCTJSStackFrame *)stackFrame;
+- (void)reloadFromRedBoxController:(UIViewController *)redBoxController;
+- (void)loadExtraDataViewController;
+
+@end
+
+@protocol RCTRedBoxControlling <NSObject>
+
+@property (nonatomic, weak) id<RCTRedBoxControllerActionDelegate> actionDelegate;
+
+- (void)showErrorMessage:(NSString *)message
+               withStack:(NSArray<RCTJSStackFrame *> *)stack
+                isUpdate:(BOOL)isUpdate
+             errorCookie:(int)errorCookie;
+
+- (void)dismiss;
+
+@end
+
+@protocol RCTRedBox2Controlling <RCTRedBoxControlling>
+
+@property (nonatomic, strong, nullable) NSURL *bundleURL;
+
+@end
+
+#endif

--- a/packages/react-native/React/CoreModules/RCTRedBox.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox.mm
@@ -16,775 +16,14 @@
 #import <React/RCTRedBoxExtraDataViewController.h>
 #import <React/RCTReloadCommand.h>
 #import <React/RCTUtils.h>
-
-#import <objc/runtime.h>
+#import <react/featureflags/ReactNativeFeatureFlags.h>
 
 #import "CoreModulesPlugins.h"
+#import "RCTRedBox+Internal.h"
+#import "RCTRedBox2Controller+Internal.h"
+#import "RCTRedBoxController+Internal.h"
 
 #if RCT_DEV_MENU
-
-@class RCTRedBoxController;
-
-#if !TARGET_OS_OSX // [macOS]
-@interface UIButton (RCTRedBox)
-#else // [macOS
-@interface NSButton (RCTRedBox)
-#endif // macOS]
-
-@property (nonatomic) RCTRedBoxButtonPressHandler rct_handler;
-
-#if !TARGET_OS_OSX // [macOS]
-- (void)rct_addBlock:(RCTRedBoxButtonPressHandler)handler forControlEvents:(UIControlEvents)controlEvents;
-#else // [macOS
-- (void)rct_addBlock:(RCTRedBoxButtonPressHandler)handler;
-#endif // macOS]
-
-@end
-
-#if !TARGET_OS_OSX // [macOS]
-@implementation UIButton (RCTRedBox)
-#else // [macOS
-@implementation NSButton (RCTRedBox)
-#endif // macOS]
-
-- (RCTRedBoxButtonPressHandler)rct_handler
-{
-  return objc_getAssociatedObject(self, @selector(rct_handler));
-}
-
-- (void)setRct_handler:(RCTRedBoxButtonPressHandler)rct_handler
-{
-  objc_setAssociatedObject(self, @selector(rct_handler), rct_handler, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-- (void)rct_callBlock
-{
-  if (self.rct_handler) {
-    self.rct_handler();
-  }
-}
-
-#if !TARGET_OS_OSX // [macOS]
-- (void)rct_addBlock:(RCTRedBoxButtonPressHandler)handler forControlEvents:(UIControlEvents)controlEvents;
-#else // [macOS
-- (void)rct_addBlock:(RCTRedBoxButtonPressHandler)handler
-#endif // macOS]
-{
-  self.rct_handler = handler;
-#if !TARGET_OS_OSX // [macOS]
-  [self addTarget:self action:@selector(rct_callBlock) forControlEvents:controlEvents];
-#else // [macOS
-  [self setTarget:self];
-  [self setAction:@selector(rct_callBlock)];
-#endif // macOS]
-}
-
-@end
-
-@protocol RCTRedBoxControllerActionDelegate <NSObject>
-
-- (void)redBoxController:(RCTRedBoxController *)redBoxController openStackFrameInEditor:(RCTJSStackFrame *)stackFrame;
-- (void)reloadFromRedBoxController:(RCTRedBoxController *)redBoxController;
-- (void)loadExtraDataViewController;
-
-@end
-
-#if !TARGET_OS_OSX // [macOS]
-@interface RCTRedBoxController : UIViewController <UITableViewDelegate, UITableViewDataSource>
-#else // [macOS
-@interface RCTRedBoxController : NSViewController <NSTableViewDelegate, NSTableViewDataSource>
-#endif // macOS]
-@property (nonatomic, weak) id<RCTRedBoxControllerActionDelegate> actionDelegate;
-@end
-
-@implementation RCTRedBoxController {
-#if !TARGET_OS_OSX // [macOS]
-  UITableView *_stackTraceTableView;
-#else // [macOS
-  NSTableView *_stackTraceTableView;
-#endif //  macOS]
-  NSString *_lastErrorMessage;
-  NSArray<RCTJSStackFrame *> *_lastStackTrace;
-  NSArray<NSString *> *_customButtonTitles;
-  NSArray<RCTRedBoxButtonPressHandler> *_customButtonHandlers;
-  int _lastErrorCookie;
-}
-
-- (instancetype)initWithCustomButtonTitles:(NSArray<NSString *> *)customButtonTitles
-                      customButtonHandlers:(NSArray<RCTRedBoxButtonPressHandler> *)customButtonHandlers
-{
-  if (self = [super init]) {
-    _lastErrorCookie = -1;
-    _customButtonTitles = customButtonTitles;
-    _customButtonHandlers = customButtonHandlers;
-  }
-
-  return self;
-}
-
-- (void)viewDidLoad
-{
-  [super viewDidLoad];
-#if !TARGET_OS_OSX // [macOS]
-  self.view.backgroundColor = [UIColor blackColor];
-#else // [macOS
-  self.view.wantsLayer = YES;
-  self.view.layer.backgroundColor = [[NSColor blackColor] CGColor];
-#endif // macOS]
-
-  const CGFloat buttonHeight = 60;
-
-  CGRect detailsFrame = self.view.bounds;
-  detailsFrame.size.height -= buttonHeight + (double)[self bottomSafeViewHeight];
-
-#if !TARGET_OS_OSX // [macOS]
-  _stackTraceTableView = [[UITableView alloc] initWithFrame:detailsFrame style:UITableViewStylePlain];
-  _stackTraceTableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  _stackTraceTableView.delegate = self;
-  _stackTraceTableView.dataSource = self;
-  _stackTraceTableView.backgroundColor = [UIColor clearColor];
-#if !TARGET_OS_TV
-  _stackTraceTableView.separatorColor = [UIColor colorWithWhite:1 alpha:0.3];
-  _stackTraceTableView.separatorStyle = UITableViewCellSeparatorStyleNone;
-#endif
-  _stackTraceTableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
-  [self.view addSubview:_stackTraceTableView];
-#else // [macOS
-  NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
-  scrollView.translatesAutoresizingMaskIntoConstraints = NO;
-  scrollView.autoresizesSubviews = YES;
-  scrollView.drawsBackground = NO;
-
-  _stackTraceTableView = [[NSTableView alloc] initWithFrame:NSZeroRect];
-  _stackTraceTableView.translatesAutoresizingMaskIntoConstraints = NO;
-  _stackTraceTableView.dataSource = self;
-  _stackTraceTableView.delegate = self;
-  _stackTraceTableView.headerView = nil;
-  _stackTraceTableView.allowsColumnReordering = NO;
-  _stackTraceTableView.allowsColumnResizing = NO;
-  _stackTraceTableView.columnAutoresizingStyle = NSTableViewFirstColumnOnlyAutoresizingStyle;
-  _stackTraceTableView.backgroundColor = [NSColor clearColor];
-  _stackTraceTableView.allowsTypeSelect = NO;
-  
-  NSTableColumn *tableColumn = [[NSTableColumn alloc] initWithIdentifier:@"info"];
-  [_stackTraceTableView addTableColumn:tableColumn];
-
-  scrollView.documentView = _stackTraceTableView;
-  [self.view addSubview:scrollView];
-#endif // macOS]
-
-#if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST || TARGET_OS_OSX // [macOS]
-  NSString *reloadText = @"Reload\n(\u2318R)";
-  NSString *dismissText = @"Dismiss\n(ESC)";
-  NSString *copyText = @"Copy\n(\u2325\u2318C)";
-  NSString *extraText = @"Extra Info\n(\u2318E)";
-#else
-  NSString *reloadText = @"Reload JS";
-  NSString *dismissText = @"Dismiss";
-  NSString *copyText = @"Copy";
-  NSString *extraText = @"Extra Info";
-#endif
-
-#if !TARGET_OS_OSX // [macOS]
-  UIButton *dismissButton = [self redBoxButton:dismissText
-                       accessibilityIdentifier:@"redbox-dismiss"
-                                      selector:@selector(dismiss)
-                                         block:nil];
-  UIButton *reloadButton = [self redBoxButton:reloadText
-                      accessibilityIdentifier:@"redbox-reload"
-                                     selector:@selector(reload)
-                                        block:nil];
-  UIButton *copyButton = [self redBoxButton:copyText
-                    accessibilityIdentifier:@"redbox-copy"
-                                   selector:@selector(copyStack)
-                                      block:nil];
-  UIButton *extraButton = [self redBoxButton:extraText
-                     accessibilityIdentifier:@"redbox-extra"
-                                    selector:@selector(showExtraDataViewController)
-                                       block:nil];
-#else // [macOS
-  NSButton *dismissButton = [self redBoxButton:dismissText
-                       accessibilityIdentifier:@"redbox-dismiss"
-                                      selector:@selector(dismiss)
-                                         block:nil];
-  [dismissButton setKeyEquivalent:@"\e"];
-  NSButton *reloadButton = [self redBoxButton:reloadText
-                      accessibilityIdentifier:@"redbox-reload"
-                                     selector:@selector(reload)
-                                        block:nil];
-  [reloadButton setKeyEquivalent:@"r"];
-  [reloadButton setKeyEquivalentModifierMask:NSEventModifierFlagCommand];
-  NSButton *copyButton = [self redBoxButton:copyText
-                    accessibilityIdentifier:@"redbox-copy"
-                                   selector:@selector(copyStack)
-                                      block:nil];
-  [copyButton setKeyEquivalent:@"c"];
-  [copyButton setKeyEquivalentModifierMask:NSEventModifierFlagOption | NSEventModifierFlagCommand];
-  NSButton *extraButton = [self redBoxButton:extraText
-                     accessibilityIdentifier:@"redbox-extra"
-                                    selector:@selector(showExtraDataViewController)
-                                       block:nil];
-#endif // macOS]
-
-  [NSLayoutConstraint activateConstraints:@[
-    [dismissButton.heightAnchor constraintEqualToConstant:buttonHeight],
-    [reloadButton.heightAnchor constraintEqualToConstant:buttonHeight],
-    [copyButton.heightAnchor constraintEqualToConstant:buttonHeight],
-    [extraButton.heightAnchor constraintEqualToConstant:buttonHeight]
-  ]];
-
-#if !TARGET_OS_OSX // [macOS]
-  UIStackView *buttonStackView = [[UIStackView alloc] init];
-  buttonStackView.translatesAutoresizingMaskIntoConstraints = NO;
-  buttonStackView.axis = UILayoutConstraintAxisHorizontal;
-  buttonStackView.distribution = UIStackViewDistributionFillEqually;
-  buttonStackView.alignment = UIStackViewAlignmentTop;
-  buttonStackView.backgroundColor = [UIColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:1];
-#else // [macOS
-  NSStackView *buttonStackView = [[NSStackView alloc] init];
-  buttonStackView.translatesAutoresizingMaskIntoConstraints = NO;
-  buttonStackView.orientation = NSUserInterfaceLayoutOrientationHorizontal;
-  buttonStackView.distribution = NSStackViewDistributionFillEqually;
-  buttonStackView.alignment = NSLayoutAttributeTop;
-  buttonStackView.wantsLayer = YES;
-  buttonStackView.layer.backgroundColor = [NSColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:1].CGColor;
-#endif // macOS]
-
-  [buttonStackView addArrangedSubview:dismissButton];
-  [buttonStackView addArrangedSubview:reloadButton];
-  [buttonStackView addArrangedSubview:copyButton];
-  [buttonStackView addArrangedSubview:extraButton];
-
-  [self.view addSubview:buttonStackView];
-
-  [NSLayoutConstraint activateConstraints:@[
-    [buttonStackView.heightAnchor constraintEqualToConstant:buttonHeight + [self bottomSafeViewHeight]],
-    [buttonStackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
-    [buttonStackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
-    [buttonStackView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
-  ]];
-
-
-  for (NSUInteger i = 0; i < [_customButtonTitles count]; i++) {
-#if !TARGET_OS_OSX // [macOS]
-    UIButton *button = [self redBoxButton:_customButtonTitles[i]
-                  accessibilityIdentifier:@""
-                                 selector:nil
-                                    block:_customButtonHandlers[i]];
-#else // [macOS
-  NSButton *button = [self redBoxButton:_customButtonTitles[i]
-                  accessibilityIdentifier:@""
-                                 selector:nil
-                                    block:_customButtonHandlers[i]];
-#endif // macOS]
-    [button.heightAnchor constraintEqualToConstant:buttonHeight].active = YES;
-    [buttonStackView addArrangedSubview:button];
-  }
-
-  RCTPlatformView *topBorder = [[RCTPlatformView alloc] init]; // [macOS]
-  topBorder.translatesAutoresizingMaskIntoConstraints = NO;
-#if !TARGET_OS_OSX // [macOS]
-  topBorder.backgroundColor = [UIColor colorWithRed:0.70 green:0.70 blue:0.70 alpha:1.0];
-#else // [macOS
-  topBorder.wantsLayer = true;
-  topBorder.layer.backgroundColor = [NSColor colorWithRed:0.70 green:0.70 blue:0.70 alpha:1.0].CGColor;
-#endif // macOS]
-  [topBorder.heightAnchor constraintEqualToConstant:1].active = YES;
-
-  [self.view addSubview:topBorder];
-
-  [NSLayoutConstraint activateConstraints:@[
-    [topBorder.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
-    [topBorder.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
-    [topBorder.bottomAnchor constraintEqualToAnchor:buttonStackView.topAnchor]
-  ]];
-
-#if TARGET_OS_OSX // [macOS
-  [NSLayoutConstraint activateConstraints:@[
-    [[scrollView leadingAnchor] constraintEqualToAnchor:[[self view] leadingAnchor]],
-    [[scrollView topAnchor] constraintEqualToAnchor:[[self view] topAnchor]],
-    [[scrollView trailingAnchor] constraintEqualToAnchor:[[self view] trailingAnchor]],
-    [[scrollView bottomAnchor] constraintEqualToAnchor:[topBorder topAnchor]],
-  ]];
-#endif // macOS]
-}
-
-#if !TARGET_OS_OSX // [macOS]
-- (UIButton *)redBoxButton:(NSString *)title
-    accessibilityIdentifier:(NSString *)accessibilityIdentifier
-                   selector:(SEL)selector
-                      block:(RCTRedBoxButtonPressHandler)block
-{
-  UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
-  button.autoresizingMask =
-      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleRightMargin;
-  button.accessibilityIdentifier = accessibilityIdentifier;
-  button.titleLabel.font = [UIFont systemFontOfSize:13];
-  button.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
-  button.titleLabel.textAlignment = NSTextAlignmentCenter;
-  button.backgroundColor = [UIColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:1];
-  [button setTitle:title forState:UIControlStateNormal];
-  [button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
-  [button setTitleColor:[UIColor colorWithWhite:1 alpha:0.5] forState:UIControlStateHighlighted];
-  if (selector) {
-    [button addTarget:self action:selector forControlEvents:UIControlEventTouchUpInside];
-  } else if (block) {
-    [button rct_addBlock:block forControlEvents:UIControlEventTouchUpInside];
-  }
-  return button;
-}
-#else // [macOS
-- (NSButton *)redBoxButton:(NSString *)title
-   accessibilityIdentifier:(NSString *)accessibilityIdentifier
-                  selector:(SEL)selector
-                     block:(RCTRedBoxButtonPressHandler)block
-{
-  NSButton *button = [[NSButton alloc] initWithFrame:NSZeroRect];
-  button.translatesAutoresizingMaskIntoConstraints = NO;
-  button.accessibilityIdentifier = @"accessibilityIdentifier";
-  button.bordered = NO;
-  NSAttributedString *attributedTitle = [[NSAttributedString alloc]
-                                         initWithString:title
-                                         attributes:@{NSForegroundColorAttributeName : [ NSColor whiteColor] }];
-  button.attributedTitle = attributedTitle;
-  [button setButtonType:NSButtonTypeMomentaryPushIn];
-  if (selector) {
-    button.target = self;
-    button.action = selector;
-  } else if (block) {
-    [button rct_addBlock:block];
-  }
-  return button;
-}
-#endif // macOS]
-
-- (NSInteger)bottomSafeViewHeight
-{
-#if TARGET_OS_MACCATALYST || TARGET_OS_OSX // [macOS]
-  return 0;
-#else
-  return RCTKeyWindow().safeAreaInsets.bottom;
-#endif
-}
-
-RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
-
-- (NSString *)stripAnsi:(NSString *)text
-{
-  NSError *error = nil;
-  NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\x1b\\[[0-9;]*m"
-                                                                         options:NSRegularExpressionCaseInsensitive
-                                                                           error:&error];
-  return [regex stringByReplacingMatchesInString:text options:0 range:NSMakeRange(0, [text length]) withTemplate:@""];
-}
-
-- (void)showErrorMessage:(NSString *)message
-               withStack:(NSArray<RCTJSStackFrame *> *)stack
-                isUpdate:(BOOL)isUpdate
-             errorCookie:(int)errorCookie
-{
-  // Remove ANSI color codes from the message
-  NSString *messageWithoutAnsi = [self stripAnsi:message];
-
-  BOOL isRootViewControllerPresented = self.presentingViewController != nil;
-  // Show if this is a new message, or if we're updating the previous message
-  BOOL isNew = !isRootViewControllerPresented && !isUpdate;
-  BOOL isUpdateForSameMessage = !isNew &&
-      (isRootViewControllerPresented && isUpdate &&
-       ((errorCookie == -1 && [_lastErrorMessage isEqualToString:messageWithoutAnsi]) ||
-        (errorCookie == _lastErrorCookie)));
-  if (isNew || isUpdateForSameMessage) {
-    _lastStackTrace = stack;
-    // message is displayed using UILabel, which is unable to render text of
-    // unlimited length, so we truncate it
-    _lastErrorMessage = [messageWithoutAnsi substringToIndex:MIN((NSUInteger)10000, messageWithoutAnsi.length)];
-    _lastErrorCookie = errorCookie;
-
-    [_stackTraceTableView reloadData];
-
-    if (!isRootViewControllerPresented) {
-#if !TARGET_OS_OSX // [macOS]
-      [_stackTraceTableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]
-                                  atScrollPosition:UITableViewScrollPositionTop
-                                          animated:NO];
-      [RCTKeyWindow().rootViewController presentViewController:self animated:YES completion:nil];
-#else // [macOS
-	  [_stackTraceTableView scrollRowToVisible:0];
-    [[RCTKeyWindow() contentViewController] presentViewControllerAsSheet:self];
-#endif // macOS]
-    }
-  }
-}
-
-- (void)dismiss
-{
-#if !TARGET_OS_OSX // [macOS]
-  [self dismissViewControllerAnimated:YES completion:nil];
-#else // [macOS
-  if (self.presentingViewController) {
-    [[RCTKeyWindow() contentViewController] dismissViewController:self];
-  }
-#endif // macOS]
-}
-
-- (void)reload
-{
-  if (_actionDelegate != nil) {
-    [_actionDelegate reloadFromRedBoxController:self];
-  } else {
-    // In bridgeless mode `RCTRedBox` gets deallocated, we need to notify listeners anyway.
-    RCTTriggerReloadCommandListeners(@"Redbox");
-    [self dismiss];
-  }
-}
-
-- (void)showExtraDataViewController
-{
-  [_actionDelegate loadExtraDataViewController];
-}
-
-- (void)copyStack
-{
-  NSMutableString *fullStackTrace;
-  
-  if (_lastErrorMessage != nil) {
-    fullStackTrace = [_lastErrorMessage mutableCopy];
-    [fullStackTrace appendString:@"\n\n"];
-  } else {
-    fullStackTrace = [NSMutableString string];
-  }
-  
-  for (RCTJSStackFrame *stackFrame in _lastStackTrace) {
-    [fullStackTrace appendString:[NSString stringWithFormat:@"%@\n", stackFrame.methodName]];
-    if (stackFrame.file) {
-      [fullStackTrace appendFormat:@"    %@\n", [self formatFrameSource:stackFrame]];
-    }
-  }
-#if !TARGET_OS_OSX && !TARGET_OS_TV // [macOS]
-  UIPasteboard *pb = [UIPasteboard generalPasteboard];
-  [pb setString:fullStackTrace];
-#elif TARGET_OS_OSX // [macOS
-  NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
-  [pasteboard clearContents];
-  [pasteboard setString:fullStackTrace forType:NSPasteboardTypeString];
-#endif // macOS]
-}
-
-- (NSString *)formatFrameSource:(RCTJSStackFrame *)stackFrame
-{
-  NSString *fileName = RCTNilIfNull(stackFrame.file) ? [stackFrame.file lastPathComponent] : @"<unknown file>";
-  NSString *lineInfo = [NSString stringWithFormat:@"%@:%lld", fileName, (long long)stackFrame.lineNumber];
-
-  if (stackFrame.column != 0) {
-    lineInfo = [lineInfo stringByAppendingFormat:@":%lld", (long long)stackFrame.column];
-  }
-  return lineInfo;
-}
-
-#pragma mark - TableView
-
-#if !TARGET_OS_OSX // [macOS]
-- (NSInteger)numberOfSectionsInTableView:(__unused UITableView *)tableView
-{
-  return 2;
-}
-
-- (NSInteger)tableView:(__unused UITableView *)tableView numberOfRowsInSection:(NSInteger)section
-{
-  return section == 0 ? 1 : _lastStackTrace.count;
-}
-#else // [macOS
-- (NSInteger)numberOfRowsInTableView:(__unused NSTableView *)tableView
-{
-  return (_lastErrorMessage != nil) + _lastStackTrace.count;
-}
-#endif // macOS]
-
-#if !TARGET_OS_OSX // [macOS]
-- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-  if (indexPath.section == 0) {
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"msg-cell"];
-    return [self reuseCell:cell forErrorMessage:_lastErrorMessage];
-  }
-  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"];
-  NSUInteger index = indexPath.row;
-  RCTJSStackFrame *stackFrame = _lastStackTrace[index];
-  return [self reuseCell:cell forStackFrame:stackFrame];
-}
-#else // [macOS
-- (nullable NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(nullable NSTableColumn *)tableColumn row:(NSInteger)row
-{
-  if (row == 0) {
-    NSTableCellView *cell = [tableView makeViewWithIdentifier:@"msg-cell" owner:nil];
-    return [self reuseCell:cell forErrorMessage:_lastErrorMessage];
-  }
-  NSTableCellView *cell = [tableView makeViewWithIdentifier:@"cell" owner:nil];
-  NSUInteger index = row - 1;
-  RCTJSStackFrame *stackFrame = _lastStackTrace[index];
-  return [self reuseCell:cell forStackFrame:stackFrame];
-
-}
-#endif // macOS]
-
-#if !TARGET_OS_OSX // [macOS]
-- (UITableViewCell *)reuseCell:(UITableViewCell *)cell forErrorMessage:(NSString *)message
-{
-  if (!cell) {
-    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"msg-cell"];
-    cell.textLabel.accessibilityIdentifier = @"redbox-error";
-    cell.textLabel.textColor = [UIColor whiteColor];
-
-    // Prefer a monofont for formatting messages that were designed
-    // to be displayed in a terminal.
-    cell.textLabel.font = [UIFont monospacedSystemFontOfSize:14 weight:UIFontWeightBold];
-
-    cell.textLabel.lineBreakMode = NSLineBreakByWordWrapping;
-    cell.textLabel.numberOfLines = 0;
-    cell.detailTextLabel.textColor = [UIColor whiteColor];
-    cell.backgroundColor = [UIColor colorWithRed:0.82 green:0.10 blue:0.15 alpha:1.0];
-    cell.selectionStyle = UITableViewCellSelectionStyleNone;
-  }
-
-  cell.textLabel.text = message;
-
-  return cell;
-}
-#else // [macOS
-- (NSTableCellView *)reuseCell:(NSTableCellView *)cell forErrorMessage:(NSString *)message
-{
-  if (!cell) {
-    cell = [[NSTableCellView alloc] initWithFrame:NSZeroRect];
-    cell.rowSizeStyle = NSTableViewRowSizeStyleCustom;
-    cell.textField.accessibilityIdentifier = @"red box-error";
-
-    NSTextField *label = [[NSTextField alloc] initWithFrame:NSZeroRect];
-    label.translatesAutoresizingMaskIntoConstraints = NO;
-    label.drawsBackground = NO;
-    label.bezeled = NO;
-    label.editable = NO;
-    
-    [cell addSubview:label];
-    cell.textField = label;
-    
-    [NSLayoutConstraint activateConstraints:@[
-      [[label leadingAnchor] constraintEqualToAnchor:[cell leadingAnchor] constant:5],
-      [[label topAnchor] constraintEqualToAnchor:[cell topAnchor] constant:5],
-      [[label trailingAnchor] constraintEqualToAnchor:[cell trailingAnchor] constant:-5],
-      [[label bottomAnchor] constraintEqualToAnchor:[cell bottomAnchor] constant:-5],
-    ]];
-
-    // Prefer a monofont for formatting messages that were designed
-    // to be displayed in a terminal.
-    cell.textField.font = [NSFont monospacedSystemFontOfSize:14 weight:NSFontWeightBold];
-
-    cell.textField.lineBreakMode = NSLineBreakByWordWrapping;
-    cell.textField.maximumNumberOfLines = 0;
-    cell.wantsLayer = true;
-    cell.layer.cornerRadius = 8.0;
-    cell.layer.cornerCurve = kCACornerCurveContinuous;
-    
-    cell.layer.backgroundColor = [NSColor colorWithRed:0.82 green:0.10 blue:0.15 alpha:1.0].CGColor;
-  }
-
-  NSDictionary<NSString *, id> *attributes = @{
-    NSForegroundColorAttributeName : [NSColor whiteColor],
-    NSFontAttributeName : [NSFont systemFontOfSize:16],
-  };
-  NSAttributedString *title = [[NSAttributedString alloc] initWithString:message attributes:attributes];
-  
-  cell.textField.attributedStringValue = title;
-
-  return cell;
-}
-#endif // macOS]
-
-#if !TARGET_OS_OSX // [macOS]
-- (UITableViewCell *)reuseCell:(UITableViewCell *)cell forStackFrame:(RCTJSStackFrame *)stackFrame
-{
-  if (!cell) {
-    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"cell"];
-    cell.textLabel.font = [UIFont fontWithName:@"Menlo-Regular" size:14];
-    cell.textLabel.lineBreakMode = NSLineBreakByCharWrapping;
-    cell.textLabel.numberOfLines = 2;
-    cell.detailTextLabel.textColor = [UIColor colorWithRed:0.70 green:0.70 blue:0.70 alpha:1.0];
-    cell.detailTextLabel.font = [UIFont fontWithName:@"Menlo-Regular" size:11];
-    cell.detailTextLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
-    cell.backgroundColor = [UIColor clearColor];
-    cell.selectedBackgroundView = [UIView new];
-    cell.selectedBackgroundView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.2];
-  }
-
-  cell.textLabel.text = stackFrame.methodName ?: @"(unnamed method)";
-  if (stackFrame.file) {
-    cell.detailTextLabel.text = [self formatFrameSource:stackFrame];
-  } else {
-    cell.detailTextLabel.text = @"";
-  }
-  cell.textLabel.textColor = stackFrame.collapse ? [UIColor lightGrayColor] : [UIColor whiteColor];
-  cell.detailTextLabel.textColor = stackFrame.collapse ? [UIColor colorWithRed:0.50 green:0.50 blue:0.50 alpha:1.0]
-                                                       : [UIColor colorWithRed:0.70 green:0.70 blue:0.70 alpha:1.0];
-  return cell;
-}
-#else // [macOS
-- (NSTableCellView *)reuseCell:(NSTableCellView *)cell forStackFrame:(RCTJSStackFrame *)stackFrame
-{
-  if (!cell) {
-    cell = [[NSTableCellView alloc] initWithFrame:NSZeroRect];
-
-    NSTextField *label = [[NSTextField alloc] initWithFrame:NSZeroRect];
-    label.translatesAutoresizingMaskIntoConstraints = NO;
-    label.backgroundColor = [NSColor clearColor];
-    label.bezeled = NO;
-    label.editable = NO;
-    
-    label.maximumNumberOfLines = 2;
-
-    [cell addSubview:label];
-    cell.textField = label;
-
-    [NSLayoutConstraint activateConstraints:@[
-      [[label leadingAnchor] constraintEqualToAnchor:[cell leadingAnchor] constant:5],
-      [[label topAnchor] constraintEqualToAnchor:[cell topAnchor]],
-      [[label trailingAnchor] constraintEqualToAnchor:[cell trailingAnchor] constant:-5],
-      [[label bottomAnchor] constraintEqualToAnchor:[cell bottomAnchor]],
-    ]];
-  }
-  
-  NSString *text = stackFrame.methodName ?: @"(unnamed method)";
-  
-  NSMutableParagraphStyle *textParagraphStyle = [NSMutableParagraphStyle new];
-  textParagraphStyle.lineBreakMode = NSLineBreakByCharWrapping;
-  
-  NSDictionary<NSString *, id> *textAttributes = @{
-    NSForegroundColorAttributeName : stackFrame.collapse ? [NSColor lightGrayColor] : [NSColor whiteColor],
-    NSFontAttributeName : [NSFont fontWithName:@"Menlo-Regular" size:14],
-    NSParagraphStyleAttributeName : textParagraphStyle,
-  };
-  
-  NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:text attributes:textAttributes];
-  
-  
-  NSMutableAttributedString *title = [attributedText mutableCopy];
-
-  // NSTableCellView doesn't contain a subtitle text field. Rather than define our own custom row view,
-  // let's append the detail text with a new line if it is needed.
-  if (stackFrame.file) {
-    cell.textField.maximumNumberOfLines = 3;
-    
-    NSString *detailText = [self formatFrameSource:stackFrame];
-    
-    NSMutableParagraphStyle *detailTextParagraphStyle = [NSMutableParagraphStyle new];
-    detailTextParagraphStyle.lineBreakMode = NSLineBreakByTruncatingMiddle;
-    
-    NSDictionary<NSString *, id> *detailTextAttributes = @{
-      NSForegroundColorAttributeName : stackFrame.collapse ?
-        [NSColor colorWithRed:0.50 green:0.50 blue:0.50 alpha:1.0] :
-        [NSColor colorWithRed:0.70 green:0.70 blue:0.70 alpha:1.0],
-      NSFontAttributeName : [NSFont fontWithName:@"Menlo-Regular" size:11],
-      NSParagraphStyleAttributeName : detailTextParagraphStyle,
-    };
-    NSAttributedString *attributedDetailText = [[NSAttributedString alloc] initWithString:detailText attributes:detailTextAttributes];
-    
-    [title appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n"]];
-    [title appendAttributedString:attributedDetailText];
-  }
-  
-  cell.textField.attributedStringValue = title;
-
-  return cell;
-}
-#endif // macOS]
-
-#if !TARGET_OS_OSX // [macOS]
-- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
-#else // [macOS
-- (CGFloat)tableView:(NSTableView *)tableView heightOfRow:(NSInteger)row
-#endif // macOS]
-{
-#if !TARGET_OS_OSX // [macOS]
-  if (indexPath.section == 0) {
-#else // [macOS
-  if (row == 0) {
-#endif // macOS]
-    NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
-    paragraphStyle.lineBreakMode = NSLineBreakByWordWrapping;
-
-    NSDictionary *attributes =
-#if !TARGET_OS_OSX // [macOS]
-        @{NSFontAttributeName : [UIFont boldSystemFontOfSize:16], NSParagraphStyleAttributeName : paragraphStyle};
-#else // [macOS
-        @{NSFontAttributeName : [NSFont boldSystemFontOfSize:16], NSParagraphStyleAttributeName : paragraphStyle};
-#endif // macOS]
-    CGRect boundingRect =
-        [_lastErrorMessage boundingRectWithSize:CGSizeMake(tableView.frame.size.width - 30, CGFLOAT_MAX)
-                                        options:NSStringDrawingUsesLineFragmentOrigin
-                                     attributes:attributes
-                                        context:nil];
-    return ceil(boundingRect.size.height) + 40;
-  } else {
-    return 50;
-  }
-}
-
-#if !TARGET_OS_OSX // [macOS]
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
-{
-  if (indexPath.section == 1) {
-    NSUInteger row = indexPath.row;
-    RCTJSStackFrame *stackFrame = _lastStackTrace[row];
-    [_actionDelegate redBoxController:self openStackFrameInEditor:stackFrame];
-  }
-  [tableView deselectRowAtIndexPath:indexPath animated:YES];
-}
-#else // [macOS
-- (BOOL)tableView:(__unused NSTableView *)tableView shouldSelectRow:(__unused NSInteger)row
-{
-  if (row != 0) {
-    NSUInteger index = row - 1;
-    RCTJSStackFrame *stackFrame = _lastStackTrace[index];
-    [_actionDelegate redBoxController:self openStackFrameInEditor:stackFrame];
-  }
-  return NO;
-}
-#endif // macOS]
-
-#pragma mark - Key commands
-
-#if !TARGET_OS_OSX // [macOS]
-- (NSArray<UIKeyCommand *> *)keyCommands
-{
-  // NOTE: We could use RCTKeyCommands for this, but since
-  // we control this window, we can use the standard, non-hacky
-  // mechanism instead
-
-  return @[
-    // Dismiss red box
-    [UIKeyCommand keyCommandWithInput:UIKeyInputEscape modifierFlags:0 action:@selector(dismiss)],
-
-    // Reload
-    [UIKeyCommand keyCommandWithInput:@"r" modifierFlags:UIKeyModifierCommand action:@selector(reload)],
-
-    // Copy = Cmd-Option C since Cmd-C in the simulator copies the pasteboard from
-    // the simulator to the desktop pasteboard.
-    [UIKeyCommand keyCommandWithInput:@"c"
-                        modifierFlags:UIKeyModifierCommand | UIKeyModifierAlternate
-                               action:@selector(copyStack)],
-
-    // Extra data
-    [UIKeyCommand keyCommandWithInput:@"e"
-                        modifierFlags:UIKeyModifierCommand
-                               action:@selector(showExtraDataViewController)]
-  ];
-}
-
-- (BOOL)canBecomeFirstResponder
-{
-  return YES;
-}
-#endif // [macOS]
-
-@end
 
 @interface RCTRedBox () <
     RCTInvalidating,
@@ -794,7 +33,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 @end
 
 @implementation RCTRedBox {
-  RCTRedBoxController *_controller;
+  id<RCTRedBoxControlling> _controller;
   NSMutableArray<id<RCTErrorCustomizer>> *_errorCustomizers;
   RCTRedBoxExtraDataViewController *_extraDataViewController;
   NSMutableArray<NSString *> *_customButtonTitles;
@@ -926,6 +165,14 @@ RCT_EXPORT_MODULE()
   [self showErrorMessage:message withParsedStack:stack isUpdate:YES errorCookie:errorCookie];
 }
 
+- (id<RCTRedBox2Controlling>)_redBox2Controller
+{
+  if ([_controller conformsToProtocol:@protocol(RCTRedBox2Controlling)]) {
+    return (id<RCTRedBox2Controlling>)_controller;
+  }
+  return nil;
+}
+
 - (void)showErrorMessage:(NSString *)message
          withParsedStack:(NSArray<RCTJSStackFrame *> *)stack
                 isUpdate:(BOOL)isUpdate
@@ -942,14 +189,25 @@ RCT_EXPORT_MODULE()
     [[self->_moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"collectRedBoxExtraData"
                                                                                 body:nil];
 #pragma clang diagnostic pop
-    if (!self->_controller) {
-      self->_controller = [[RCTRedBoxController alloc] initWithCustomButtonTitles:self->_customButtonTitles
-                                                             customButtonHandlers:self->_customButtonHandlers];
-      self->_controller.actionDelegate = self;
-    }
 
     RCTErrorInfo *errorInfo = [[RCTErrorInfo alloc] initWithErrorMessage:message stack:stack];
     errorInfo = [self _customizeError:errorInfo];
+
+    if (self->_controller == nullptr) {
+#if !TARGET_OS_OSX // [macOS]
+      if (facebook::react::ReactNativeFeatureFlags::redBoxV2IOS()) {
+        self->_controller = [[RCTRedBox2Controller alloc] initWithCustomButtonTitles:self->_customButtonTitles
+                                                                customButtonHandlers:self->_customButtonHandlers];
+      } else {
+#endif // [macOS]
+        self->_controller = [[RCTRedBoxController alloc] initWithCustomButtonTitles:self->_customButtonTitles
+                                                               customButtonHandlers:self->_customButtonHandlers];
+#if !TARGET_OS_OSX // [macOS]
+      }
+#endif // [macOS]
+      self->_controller.actionDelegate = self;
+    }
+    [self _redBox2Controller].bundleURL = self->_overrideBundleURL ?: self->_bundleManager.bundleURL;
     [self->_controller showErrorMessage:errorInfo.errorMessage
                               withStack:errorInfo.stack
                                isUpdate:isUpdate
@@ -957,21 +215,24 @@ RCT_EXPORT_MODULE()
   });
 }
 
-- (void)loadExtraDataViewController {
+- (void)loadExtraDataViewController
+{
   dispatch_async(dispatch_get_main_queue(), ^{
 #if !TARGET_OS_OSX // [macOS]
+    UIViewController *controller = static_cast<UIViewController *>(self->_controller);
     // Make sure the CMD+E shortcut doesn't call this twice
-    if (self->_extraDataViewController != nil && ![self->_controller presentedViewController]) {
-      [self->_controller presentViewController:self->_extraDataViewController animated:YES completion:nil];
+    if (self->_extraDataViewController != nil && ([controller presentedViewController] == nullptr)) {
+      [controller presentViewController:self->_extraDataViewController animated:YES completion:nil];
     }
 #else // [macOS
-    // Do nothing, as we haven't implemented `RCTRedBoxExtraDataViewController` on macOS yet
+    // RCTRedBoxExtraDataViewController is not implemented on macOS.
 #endif // macOS]
   });
 }
 
-RCT_EXPORT_METHOD(setExtraData:(NSDictionary *)extraData forIdentifier:(NSString *)identifier) {
-    [_extraDataViewController addExtraData:extraData forIdentifier:identifier];
+RCT_EXPORT_METHOD(setExtraData : (NSDictionary *)extraData forIdentifier : (NSString *)identifier)
+{
+  [_extraDataViewController addExtraData:extraData forIdentifier:identifier];
 }
 
 RCT_EXPORT_METHOD(dismiss)
@@ -986,7 +247,7 @@ RCT_EXPORT_METHOD(dismiss)
   [self dismiss];
 }
 
-- (void)redBoxController:(__unused RCTRedBoxController *)redBoxController
+- (void)redBoxController:(__unused UIViewController *)redBoxController
     openStackFrameInEditor:(RCTJSStackFrame *)stackFrame
 {
   NSURL *const bundleURL = _overrideBundleURL ?: _bundleManager.bundleURL;
@@ -1013,7 +274,7 @@ RCT_EXPORT_METHOD(dismiss)
   [self reloadFromRedBoxController:nil];
 }
 
-- (void)reloadFromRedBoxController:(__unused RCTRedBoxController *)redBoxController
+- (void)reloadFromRedBoxController:(__unused UIViewController *)redBoxController
 {
   if (_overrideReloadAction) {
     _overrideReloadAction();

--- a/packages/react-native/React/CoreModules/RCTRedBox.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox.mm
@@ -194,17 +194,13 @@ RCT_EXPORT_MODULE()
     errorInfo = [self _customizeError:errorInfo];
 
     if (self->_controller == nullptr) {
-#if !TARGET_OS_OSX // [macOS]
       if (facebook::react::ReactNativeFeatureFlags::redBoxV2IOS()) {
         self->_controller = [[RCTRedBox2Controller alloc] initWithCustomButtonTitles:self->_customButtonTitles
                                                                 customButtonHandlers:self->_customButtonHandlers];
       } else {
-#endif // [macOS]
         self->_controller = [[RCTRedBoxController alloc] initWithCustomButtonTitles:self->_customButtonTitles
                                                                customButtonHandlers:self->_customButtonHandlers];
-#if !TARGET_OS_OSX // [macOS]
       }
-#endif // [macOS]
       self->_controller.actionDelegate = self;
     }
     [self _redBox2Controller].bundleURL = self->_overrideBundleURL ?: self->_bundleManager.bundleURL;

--- a/packages/react-native/React/CoreModules/RCTRedBox2AnsiParser+Internal.h
+++ b/packages/react-native/React/CoreModules/RCTRedBox2AnsiParser+Internal.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTDefines.h> // [macOS]
+
+#if !TARGET_OS_OSX // [macOS]
+#import <UIKit/UIKit.h>
+
+/**
+ * Parses ANSI escape sequences in text and produces an NSAttributedString
+ * with the corresponding foreground/background colors applied.
+ *
+ * Uses the Afterglow color theme (matching LogBox's AnsiHighlight.js).
+ */
+@interface RCTRedBox2AnsiParser : NSObject
+
++ (NSAttributedString *)attributedStringFromAnsiText:(NSString *)text
+                                            baseFont:(UIFont *)font
+                                           baseColor:(UIColor *)color;
+
+@end
+
+#endif // [macOS]

--- a/packages/react-native/React/CoreModules/RCTRedBox2AnsiParser+Internal.h
+++ b/packages/react-native/React/CoreModules/RCTRedBox2AnsiParser+Internal.h
@@ -5,10 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <React/RCTDefines.h> // [macOS]
-
-#if !TARGET_OS_OSX // [macOS]
-#import <UIKit/UIKit.h>
+#import <React/RCTUIKit.h> // [macOS]
 
 /**
  * Parses ANSI escape sequences in text and produces an NSAttributedString
@@ -18,10 +15,14 @@
  */
 @interface RCTRedBox2AnsiParser : NSObject
 
+#if !TARGET_OS_OSX // [macOS]
 + (NSAttributedString *)attributedStringFromAnsiText:(NSString *)text
                                             baseFont:(UIFont *)font
                                            baseColor:(UIColor *)color;
+#else // [macOS
++ (NSAttributedString *)attributedStringFromAnsiText:(NSString *)text
+                                            baseFont:(UIFont *)font
+                                           baseColor:(RCTPlatformColor *)color;
+#endif // macOS]
 
 @end
-
-#endif // [macOS]

--- a/packages/react-native/React/CoreModules/RCTRedBox2AnsiParser.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox2AnsiParser.mm
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTRedBox2AnsiParser+Internal.h"
+
+#import <React/RCTDefines.h>
+#import <react/debug/redbox/AnsiParser.h>
+
+#if !TARGET_OS_OSX // [macOS]
+
+#if RCT_DEV_MENU
+
+using facebook::react::unstable_redbox::AnsiColor;
+using facebook::react::unstable_redbox::parseAnsi;
+
+static UIColor *RCTUIColorFromAnsiColor(const AnsiColor &c)
+{
+  return [UIColor colorWithRed:c.r / 255.0 green:c.g / 255.0 blue:c.b / 255.0 alpha:1.0];
+}
+
+@implementation RCTRedBox2AnsiParser
+
++ (NSAttributedString *)attributedStringFromAnsiText:(NSString *)text baseFont:(UIFont *)font baseColor:(UIColor *)color
+{
+  if (text == nil) {
+    return [[NSAttributedString alloc] init];
+  }
+
+  auto spans = parseAnsi(text.UTF8String);
+  NSMutableAttributedString *result =[NSMutableAttributedString new];
+  NSDictionary *baseAttributes = @{NSFontAttributeName : font, NSForegroundColorAttributeName : color};
+
+  for (const auto &span : spans) {
+    NSString *str = [NSString stringWithUTF8String:span.text.c_str()];
+    if (str == nil) {
+      continue;
+    }
+    NSMutableDictionary *attrs = [baseAttributes mutableCopy];
+    if (span.foregroundColor.has_value()) {
+      attrs[NSForegroundColorAttributeName] = RCTUIColorFromAnsiColor(*span.foregroundColor);
+    }
+    if (span.backgroundColor.has_value()) {
+      attrs[NSBackgroundColorAttributeName] = RCTUIColorFromAnsiColor(*span.backgroundColor);
+    }
+    [result appendAttributedString:[[NSAttributedString alloc] initWithString:str attributes:attrs]];
+  }
+
+  return result;
+}
+
+@end
+
+#endif
+
+#endif // [macOS]

--- a/packages/react-native/React/CoreModules/RCTRedBox2AnsiParser.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox2AnsiParser.mm
@@ -10,21 +10,32 @@
 #import <React/RCTDefines.h>
 #import <react/debug/redbox/AnsiParser.h>
 
-#if !TARGET_OS_OSX // [macOS]
-
 #if RCT_DEV_MENU
 
 using facebook::react::unstable_redbox::AnsiColor;
 using facebook::react::unstable_redbox::parseAnsi;
 
+#if !TARGET_OS_OSX // [macOS]
 static UIColor *RCTUIColorFromAnsiColor(const AnsiColor &c)
 {
   return [UIColor colorWithRed:c.r / 255.0 green:c.g / 255.0 blue:c.b / 255.0 alpha:1.0];
 }
+#else // [macOS
+static RCTPlatformColor *RCTUIColorFromAnsiColor(const AnsiColor &c)
+{
+  return [RCTPlatformColor colorWithRed:c.r / 255.0 green:c.g / 255.0 blue:c.b / 255.0 alpha:1.0];
+}
+#endif // macOS]
 
 @implementation RCTRedBox2AnsiParser
 
+#if !TARGET_OS_OSX // [macOS]
 + (NSAttributedString *)attributedStringFromAnsiText:(NSString *)text baseFont:(UIFont *)font baseColor:(UIColor *)color
+#else // [macOS
++ (NSAttributedString *)attributedStringFromAnsiText:(NSString *)text
+                                            baseFont:(UIFont *)font
+                                           baseColor:(RCTPlatformColor *)color
+#endif // macOS]
 {
   if (text == nil) {
     return [[NSAttributedString alloc] init];
@@ -55,5 +66,3 @@ static UIColor *RCTUIColorFromAnsiColor(const AnsiColor &c)
 @end
 
 #endif
-
-#endif // [macOS]

--- a/packages/react-native/React/CoreModules/RCTRedBox2Controller+Internal.h
+++ b/packages/react-native/React/CoreModules/RCTRedBox2Controller+Internal.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTDefines.h>
+
+#import "RCTRedBox+Internal.h"
+
+#if RCT_DEV_MENU
+
+typedef void (^RCTRedBox2ButtonPressHandler)(void);
+
+#if !TARGET_OS_OSX // [macOS]
+@interface RCTRedBox2Controller : UIViewController <RCTRedBox2Controlling, UITableViewDelegate, UITableViewDataSource>
+
+@property (nonatomic, weak) id<RCTRedBoxControllerActionDelegate> actionDelegate;
+
+- (instancetype)initWithCustomButtonTitles:(NSArray<NSString *> *)customButtonTitles
+                      customButtonHandlers:(NSArray<RCTRedBox2ButtonPressHandler> *)customButtonHandlers;
+
+- (void)showErrorMessage:(NSString *)message
+               withStack:(NSArray<RCTJSStackFrame *> *)stack
+                isUpdate:(BOOL)isUpdate
+             errorCookie:(int)errorCookie;
+
+/// The bundle URL used by the app, for the native HMR connection.
+@property (nonatomic, strong, nullable) NSURL *bundleURL;
+
+- (void)dismiss;
+@end
+#endif // [macOS]
+
+#endif

--- a/packages/react-native/React/CoreModules/RCTRedBox2Controller+Internal.h
+++ b/packages/react-native/React/CoreModules/RCTRedBox2Controller+Internal.h
@@ -15,6 +15,9 @@ typedef void (^RCTRedBox2ButtonPressHandler)(void);
 
 #if !TARGET_OS_OSX // [macOS]
 @interface RCTRedBox2Controller : UIViewController <RCTRedBox2Controlling, UITableViewDelegate, UITableViewDataSource>
+#else // [macOS
+@interface RCTRedBox2Controller : NSViewController <RCTRedBox2Controlling, NSTableViewDelegate, NSTableViewDataSource>
+#endif // macOS]
 
 @property (nonatomic, weak) id<RCTRedBoxControllerActionDelegate> actionDelegate;
 
@@ -31,6 +34,5 @@ typedef void (^RCTRedBox2ButtonPressHandler)(void);
 
 - (void)dismiss;
 @end
-#endif // [macOS]
 
 #endif

--- a/packages/react-native/React/CoreModules/RCTRedBox2Controller.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox2Controller.mm
@@ -1,0 +1,768 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTRedBox2Controller+Internal.h"
+
+#import <React/RCTDefines.h>
+#import <React/RCTJSStackFrame.h>
+#import <React/RCTReloadCommand.h>
+#import <React/RCTUtils.h>
+
+#include <array>
+
+#import "RCTJscSafeUrl+Internal.h"
+#import "RCTRedBox2AnsiParser+Internal.h"
+#import "RCTRedBox2ErrorParser+Internal.h"
+#import "RCTRedBoxHMRClient+Internal.h"
+
+// @lint-ignore-every CLANGTIDY clang-diagnostic-switch-default
+// NOTE: clang-diagnostic-switch-default conflicts with clang-diagnostic-switch-enum
+
+#if RCT_DEV_MENU
+
+#if !TARGET_OS_OSX // [macOS]
+
+#pragma mark - RCTRedBox2Controller
+
+// Color Palette (matching LogBoxStyle.js)
+static UIColor *RCTRedBox2BackgroundColor()
+{
+  return [UIColor colorWithRed:51.0 / 255 green:51.0 / 255 blue:51.0 / 255 alpha:1.0];
+}
+
+static UIColor *RCTRedBox2ErrorColor()
+{
+  return [UIColor colorWithRed:243.0 / 255 green:83.0 / 255 blue:105.0 / 255 alpha:1.0];
+}
+
+static UIColor *RCTRedBox2TextColor(CGFloat opacity)
+{
+  return [UIColor colorWithWhite:1.0 alpha:opacity];
+}
+
+enum class Section : uint8_t { Message, CodeFrame, CallStack, kMaxValue };
+static constexpr size_t kSectionCount = static_cast<size_t>(Section::kMaxValue);
+
+struct SectionState {
+  bool visible = false;
+};
+
+static const NSTimeInterval kAutoRetryInterval = 20.0;
+
+@implementation RCTRedBox2Controller {
+  UITableView *_stackTraceTableView;
+  UILabel *_headerTitleLabel;
+  UILabel *_errorCategoryLabel;
+  NSString *_lastErrorMessage;
+  NSArray<RCTJSStackFrame *> *_lastStackTrace;
+  NSArray<NSString *> *_customButtonTitles;
+  NSArray<RCTRedBox2ButtonPressHandler> *_customButtonHandlers;
+  int _lastErrorCookie;
+  RCTRedBox2ErrorData *_errorData;
+  std::array<SectionState, kSectionCount> _sectionStates;
+  NSTimer *_autoRetryTimer;
+  NSInteger _autoRetryCountdown;
+  UIButton *_reloadButton;
+  NSString *_reloadBaseText;
+  RCTRedBoxHMRClient *_hmrClient;
+}
+
+- (instancetype)initWithCustomButtonTitles:(NSArray<NSString *> *)customButtonTitles
+                      customButtonHandlers:(NSArray<RCTRedBox2ButtonPressHandler> *)customButtonHandlers
+{
+  self = [super init];
+  if (self != nullptr) {
+    _lastErrorCookie = -1;
+    _customButtonTitles = customButtonTitles;
+    _customButtonHandlers = customButtonHandlers;
+    self.modalPresentationStyle = UIModalPresentationFullScreen;
+  }
+  return self;
+}
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+  self.view.backgroundColor = RCTRedBox2BackgroundColor();
+
+  // Header bar (adds itself to self.view)
+  UIView *headerBar = [self createHeaderBar];
+
+  // Footer button bar
+  UIView *footerBar = [self createFooterBar];
+
+  // Stack trace table
+  _stackTraceTableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
+  _stackTraceTableView.translatesAutoresizingMaskIntoConstraints = NO;
+  _stackTraceTableView.delegate = self;
+  _stackTraceTableView.dataSource = self;
+  _stackTraceTableView.backgroundColor = [UIColor clearColor];
+#if !TARGET_OS_TV
+  _stackTraceTableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+#endif
+  _stackTraceTableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
+  _stackTraceTableView.bounces = NO;
+  [self.view addSubview:_stackTraceTableView];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [_stackTraceTableView.topAnchor constraintEqualToAnchor:headerBar.bottomAnchor],
+    [_stackTraceTableView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+    [_stackTraceTableView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+    [_stackTraceTableView.bottomAnchor constraintEqualToAnchor:footerBar.topAnchor],
+  ]];
+}
+
+#pragma mark - Header Bar
+
+- (UIView *)createHeaderBar
+{
+  UIView *headerContainer = [[UIView alloc] init];
+  headerContainer.translatesAutoresizingMaskIntoConstraints = NO;
+  headerContainer.backgroundColor = RCTRedBox2ErrorColor();
+
+  _headerTitleLabel = [[UILabel alloc] init];
+  _headerTitleLabel.translatesAutoresizingMaskIntoConstraints = NO;
+  _headerTitleLabel.textColor = [UIColor whiteColor];
+  _headerTitleLabel.font = [UIFont systemFontOfSize:16 weight:UIFontWeightSemibold];
+  _headerTitleLabel.textAlignment = NSTextAlignmentCenter;
+  [headerContainer addSubview:_headerTitleLabel];
+
+  [self.view addSubview:headerContainer];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [headerContainer.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+    [headerContainer.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+    [headerContainer.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+
+    [_headerTitleLabel.leadingAnchor constraintEqualToAnchor:headerContainer.leadingAnchor constant:12],
+    [_headerTitleLabel.trailingAnchor constraintEqualToAnchor:headerContainer.trailingAnchor constant:-12],
+    [_headerTitleLabel.bottomAnchor constraintEqualToAnchor:headerContainer.bottomAnchor constant:-12],
+    [_headerTitleLabel.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor constant:12],
+  ]];
+
+  return headerContainer;
+}
+
+#pragma mark - Footer Bar
+
+- (UIView *)createFooterBar
+{
+  const CGFloat buttonHeight = 48;
+
+  NSString *reloadText = @"Reload";
+  NSString *dismissText = @"Dismiss";
+  NSString *copyText = @"Copy";
+
+  UIButton *dismissButton = [self footerButton:dismissText
+                       accessibilityIdentifier:@"redbox-dismiss"
+                                      selector:@selector(dismiss)];
+  _reloadBaseText = reloadText;
+  _reloadButton = [self footerButton:reloadText accessibilityIdentifier:@"redbox-reload" selector:@selector(reload)];
+  UIButton *copyButton = [self footerButton:copyText
+                    accessibilityIdentifier:@"redbox-copy"
+                                   selector:@selector(copyStack)];
+
+  UIStackView *buttonStackView = [[UIStackView alloc] init];
+  buttonStackView.translatesAutoresizingMaskIntoConstraints = NO;
+  buttonStackView.axis = UILayoutConstraintAxisHorizontal;
+  buttonStackView.distribution = UIStackViewDistributionFillEqually;
+  buttonStackView.alignment = UIStackViewAlignmentTop;
+  buttonStackView.backgroundColor = RCTRedBox2BackgroundColor();
+
+  [buttonStackView addArrangedSubview:dismissButton];
+  [buttonStackView addArrangedSubview:_reloadButton];
+  [buttonStackView addArrangedSubview:copyButton];
+
+  for (NSUInteger i = 0; i < [_customButtonTitles count]; i++) {
+    UIButton *button = [self footerButton:_customButtonTitles[i]
+                  accessibilityIdentifier:@""
+                                  handler:_customButtonHandlers[i]];
+    [buttonStackView addArrangedSubview:button];
+  }
+
+  // Shadow layer above footer
+  buttonStackView.layer.shadowColor = [UIColor blackColor].CGColor;
+  buttonStackView.layer.shadowOffset = CGSizeMake(0, -2);
+  buttonStackView.layer.shadowRadius = 2;
+  buttonStackView.layer.shadowOpacity = 0.5;
+
+  [self.view addSubview:buttonStackView];
+
+  CGFloat bottomInset = [self bottomSafeViewHeight];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [buttonStackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+    [buttonStackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+    [buttonStackView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+    [buttonStackView.heightAnchor constraintEqualToConstant:buttonHeight + bottomInset],
+  ]];
+
+  for (UIButton *btn in buttonStackView.arrangedSubviews) {
+    [btn.heightAnchor constraintEqualToConstant:buttonHeight].active = YES;
+  }
+
+  return buttonStackView;
+}
+
+- (UIButton *)styledButton:(NSString *)title accessibilityIdentifier:(NSString *)accessibilityIdentifier
+{
+  UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
+  button.accessibilityIdentifier = accessibilityIdentifier;
+  button.titleLabel.font = [UIFont systemFontOfSize:14];
+  button.titleLabel.textAlignment = NSTextAlignmentCenter;
+  button.backgroundColor = RCTRedBox2BackgroundColor();
+  [button setTitle:title forState:UIControlStateNormal];
+  [button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+  [button setTitleColor:RCTRedBox2TextColor(0.5) forState:UIControlStateHighlighted];
+  return button;
+}
+
+- (UIButton *)footerButton:(NSString *)title
+    accessibilityIdentifier:(NSString *)accessibilityIdentifier
+                   selector:(SEL)selector
+{
+  UIButton *button = [self styledButton:title accessibilityIdentifier:accessibilityIdentifier];
+  [button addTarget:self action:selector forControlEvents:UIControlEventTouchUpInside];
+  return button;
+}
+
+- (UIButton *)footerButton:(NSString *)title
+    accessibilityIdentifier:(NSString *)accessibilityIdentifier
+                    handler:(RCTRedBox2ButtonPressHandler)handler
+{
+  UIButton *button = [self styledButton:title accessibilityIdentifier:accessibilityIdentifier];
+  [button addAction:[UIAction actionWithHandler:^(__unused UIAction *action) {
+            handler();
+          }]
+      forControlEvents:UIControlEventTouchUpInside];
+  return button;
+}
+
+- (CGFloat)bottomSafeViewHeight
+{
+#if TARGET_OS_MACCATALYST
+  return 0;
+#else
+  return RCTKeyWindow().safeAreaInsets.bottom;
+#endif
+}
+
+#pragma mark - Error Display
+
+- (NSString *)stripAnsi:(NSString *)text
+{
+  NSError *error = nil;
+  NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\x1b\\[[0-9;]*m"
+                                                                         options:NSRegularExpressionCaseInsensitive
+                                                                           error:&error];
+  return [regex stringByReplacingMatchesInString:text options:0 range:NSMakeRange(0, [text length]) withTemplate:@""];
+}
+
+- (void)showErrorMessage:(NSString *)message
+               withStack:(NSArray<RCTJSStackFrame *> *)stack
+                isUpdate:(BOOL)isUpdate
+             errorCookie:(int)errorCookie
+{
+  // Remove ANSI color codes from the message
+  NSString *messageWithoutAnsi = [self stripAnsi:message];
+
+  BOOL isRootViewControllerPresented = self.presentingViewController != nil;
+  // Show if this is a new message, or if we're updating the previous message
+  BOOL isNew = !isRootViewControllerPresented && !isUpdate;
+  BOOL isUpdateForSameMessage = !isNew &&
+      (isRootViewControllerPresented && isUpdate &&
+       ((errorCookie == -1 && [_lastErrorMessage isEqualToString:messageWithoutAnsi]) ||
+        (errorCookie == _lastErrorCookie)));
+  if (isNew || isUpdateForSameMessage) {
+    _lastStackTrace = stack;
+    // message is displayed using UILabel, which is unable to render text of
+    // unlimited length, so we truncate it
+    _lastErrorMessage = [messageWithoutAnsi substringToIndex:MIN((NSUInteger)10000, messageWithoutAnsi.length)];
+    _lastErrorCookie = errorCookie;
+
+    // Parse the message to extract structure (title, code frame, etc.)
+    _errorData = [RCTRedBox2ErrorParser parseErrorMessage:message name:nil componentStack:nil isFatal:YES];
+    [self updateSectionVisibility];
+
+    [_stackTraceTableView reloadData];
+
+    if (!isRootViewControllerPresented) {
+      [RCTKeyWindow().rootViewController presentViewController:self animated:NO completion:nil];
+    }
+
+    // Update all UI from _errorData (view is now guaranteed to be loaded)
+    _headerTitleLabel.text = _errorData.isCompileError ? @"Failed to compile" : @"Error";
+    [_stackTraceTableView reloadData];
+    [_stackTraceTableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]
+                                atScrollPosition:UITableViewScrollPositionTop
+                                        animated:NO];
+
+    [self startAutoRetryIfApplicable];
+    [self _startHMRClient];
+  }
+}
+
+- (void)dismiss
+{
+  [self stopAutoRetry];
+  [self dismissViewControllerAnimated:NO completion:nil];
+}
+
+- (void)reload
+{
+  [self _stopHMRClient];
+  [self stopAutoRetry];
+  if (_actionDelegate != nil) {
+    [_actionDelegate reloadFromRedBoxController:self];
+  } else {
+    // In bridgeless mode `RCTRedBox` gets deallocated, we need to notify listeners anyway.
+    RCTTriggerReloadCommandListeners(@"Redbox");
+    [self dismiss];
+  }
+}
+
+#pragma mark - Native HMR Connection
+
+- (void)_startHMRClient
+{
+  [self _stopHMRClient];
+  if (!_bundleURL) {
+    return;
+  }
+  __weak __typeof(self) weakSelf = self;
+  _hmrClient = [[RCTRedBoxHMRClient alloc] initWithBundleURL:_bundleURL
+                                                onFileChange:^{
+                                                  [weakSelf reload];
+                                                }];
+  [_hmrClient start];
+}
+
+- (void)_stopHMRClient
+{
+  [_hmrClient stop];
+  _hmrClient = nil;
+}
+
+#pragma mark - Auto-Retry
+
+- (void)startAutoRetryIfApplicable
+{
+  [self stopAutoRetry];
+  if (!_errorData.isRetryable) {
+    return;
+  }
+  _autoRetryCountdown = (NSInteger)kAutoRetryInterval;
+  [self updateReloadButtonTitle];
+  _autoRetryTimer = [NSTimer scheduledTimerWithTimeInterval:1.0
+                                                     target:self
+                                                   selector:@selector(autoRetryTick)
+                                                   userInfo:nil
+                                                    repeats:YES];
+}
+
+- (void)stopAutoRetry
+{
+  [_autoRetryTimer invalidate];
+  _autoRetryTimer = nil;
+  if (_reloadButton) {
+    [_reloadButton setTitle:_reloadBaseText forState:UIControlStateNormal];
+  }
+}
+
+- (void)autoRetryTick
+{
+  _autoRetryCountdown--;
+  if (_autoRetryCountdown <= 0) {
+    [self stopAutoRetry];
+    [self reload];
+  } else {
+    [self updateReloadButtonTitle];
+  }
+}
+
+- (void)updateReloadButtonTitle
+{
+  NSString *title = [NSString stringWithFormat:@"%@ (%lds)", _reloadBaseText, (long)_autoRetryCountdown];
+  [_reloadButton setTitle:title forState:UIControlStateNormal];
+}
+
+- (void)copyStack
+{
+  NSMutableString *fullStackTrace;
+
+  if (_lastErrorMessage != nil) {
+    fullStackTrace = [_lastErrorMessage mutableCopy];
+    [fullStackTrace appendString:@"\n\n"];
+  } else {
+    fullStackTrace = [NSMutableString string];
+  }
+
+  for (RCTJSStackFrame *stackFrame in _lastStackTrace) {
+    [fullStackTrace appendString:[NSString stringWithFormat:@"%@\n", stackFrame.methodName]];
+    if (stackFrame.file != nullptr) {
+      [fullStackTrace appendFormat:@"    %@\n", [self formatFrameSource:stackFrame]];
+    }
+  }
+#if !TARGET_OS_TV
+  UIPasteboard *pb = [UIPasteboard generalPasteboard];
+  [pb setString:fullStackTrace];
+#endif
+}
+
+- (NSString *)formatFrameSource:(RCTJSStackFrame *)stackFrame
+{
+  NSString *file = [RCTJscSafeUrl normalUrlFromJscSafeUrl:stackFrame.file];
+  // Strip query string (e.g. ?platform=ios&dev=true) before extracting the filename.
+  NSRange queryRange = [file rangeOfString:@"?"];
+  if (queryRange.location != NSNotFound) {
+    file = [file substringToIndex:queryRange.location];
+  }
+  NSString *fileName = RCTNilIfNull(file) ? [file lastPathComponent] : @"<unknown file>";
+  NSString *lineInfo = [NSString stringWithFormat:@"%@:%lld", fileName, (long long)stackFrame.lineNumber];
+
+  if (stackFrame.column != 0) {
+    lineInfo = [lineInfo stringByAppendingFormat:@":%lld", (long long)stackFrame.column];
+  }
+  return lineInfo;
+}
+
+#pragma mark - Section Helpers
+
+- (void)updateSectionVisibility
+{
+  _sectionStates = {};
+  _sectionStates[static_cast<size_t>(Section::Message)].visible = true;
+  _sectionStates[static_cast<size_t>(Section::CodeFrame)].visible = _errorData.codeFrame.length > 0;
+  _sectionStates[static_cast<size_t>(Section::CallStack)].visible =
+      _lastStackTrace.count > 0 && _errorData.codeFrame.length == 0;
+}
+
+- (NSInteger)visibleSectionCount
+{
+  NSInteger count = 0;
+  for (size_t i = 0; i < kSectionCount; i++) {
+    if (_sectionStates[i].visible) {
+      count++;
+    }
+  }
+  return count;
+}
+
+- (Section)sectionForIndex:(NSInteger)index
+{
+  NSInteger visible = 0;
+  for (size_t i = 0; i < kSectionCount; i++) {
+    if (_sectionStates[i].visible) {
+      if (visible == index) {
+        return static_cast<Section>(i);
+      }
+      visible++;
+    }
+  }
+  RCTAssert(NO, @"Invalid section index %ld", (long)index);
+  return Section::kMaxValue;
+}
+
+- (NSString *)displayMessage
+{
+  return _errorData.message.length > 0 ? [self stripAnsi:_errorData.message] : _lastErrorMessage;
+}
+
+#pragma mark - TableView DataSource & Delegate
+
+- (NSInteger)numberOfSectionsInTableView:(__unused UITableView *)tableView
+{
+  return [self visibleSectionCount];
+}
+
+- (NSInteger)tableView:(__unused UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+  if ([self sectionForIndex:section] == Section::CallStack) {
+    return static_cast<NSInteger>(_lastStackTrace.count);
+  }
+  return 1;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  switch ([self sectionForIndex:indexPath.section]) {
+    case Section::Message: {
+      UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"msg-cell"];
+      return [self reuseCell:cell forErrorMessage:[self displayMessage]];
+    }
+    case Section::CodeFrame: {
+      UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"code-cell"];
+      return [self reuseCell:cell forCodeFrame:_errorData];
+    }
+    case Section::CallStack:
+    case Section::kMaxValue:
+      break;
+  }
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"];
+  NSUInteger index = indexPath.row;
+  RCTJSStackFrame *stackFrame = _lastStackTrace[index];
+  return [self reuseCell:cell forStackFrame:stackFrame];
+}
+
+- (UITableViewCell *)reuseCell:(UITableViewCell *)cell forErrorMessage:(NSString *)message
+{
+  if (cell == nullptr) {
+    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"msg-cell"];
+    cell.backgroundColor = RCTRedBox2BackgroundColor();
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+
+    // Error category label (e.g. "Syntax Error", "Uncaught Error")
+    _errorCategoryLabel = [[UILabel alloc] init];
+    _errorCategoryLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    _errorCategoryLabel.textColor = RCTRedBox2ErrorColor();
+    _errorCategoryLabel.font = [UIFont systemFontOfSize:21 weight:UIFontWeightBold];
+    _errorCategoryLabel.numberOfLines = 1;
+    [cell.contentView addSubview:_errorCategoryLabel];
+
+    // Error message label
+    UILabel *messageLabel = [[UILabel alloc] init];
+    messageLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    messageLabel.accessibilityIdentifier = @"redbox-error";
+    messageLabel.textColor = [UIColor whiteColor];
+    messageLabel.font = [UIFont systemFontOfSize:14 weight:UIFontWeightMedium];
+    messageLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    messageLabel.numberOfLines = 0;
+    messageLabel.tag = 100;
+    [cell.contentView addSubview:messageLabel];
+
+    [NSLayoutConstraint activateConstraints:@[
+      [_errorCategoryLabel.topAnchor constraintEqualToAnchor:cell.contentView.topAnchor constant:15],
+      [_errorCategoryLabel.leadingAnchor constraintEqualToAnchor:cell.contentView.leadingAnchor constant:12],
+      [_errorCategoryLabel.trailingAnchor constraintEqualToAnchor:cell.contentView.trailingAnchor constant:-12],
+
+      [messageLabel.topAnchor constraintEqualToAnchor:_errorCategoryLabel.bottomAnchor constant:10],
+      [messageLabel.leadingAnchor constraintEqualToAnchor:cell.contentView.leadingAnchor constant:12],
+      [messageLabel.trailingAnchor constraintEqualToAnchor:cell.contentView.trailingAnchor constant:-12],
+      [messageLabel.bottomAnchor constraintEqualToAnchor:cell.contentView.bottomAnchor constant:-15],
+    ]];
+  }
+
+  _errorCategoryLabel.text = _errorData.title;
+  UILabel *messageLabel = [cell.contentView viewWithTag:100];
+  messageLabel.text = message;
+
+  return cell;
+}
+
+- (UITableViewCell *)reuseCell:(UITableViewCell *)cell forStackFrame:(RCTJSStackFrame *)stackFrame
+{
+  if (cell == nullptr) {
+    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"cell"];
+    cell.textLabel.font = [UIFont fontWithName:@"Menlo-Regular" size:14];
+    cell.textLabel.lineBreakMode = NSLineBreakByCharWrapping;
+    cell.textLabel.numberOfLines = 2;
+    cell.detailTextLabel.font = [UIFont systemFontOfSize:12 weight:UIFontWeightLight];
+    cell.detailTextLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+    cell.backgroundColor = [UIColor clearColor];
+    cell.selectedBackgroundView = [UIView new];
+    cell.selectedBackgroundView.backgroundColor = RCTRedBox2BackgroundColor();
+    cell.selectedBackgroundView.layer.cornerRadius = 5;
+  }
+
+  cell.textLabel.text = stackFrame.methodName ?: @"(unnamed method)";
+  if (stackFrame.file != nullptr) {
+    cell.detailTextLabel.text = [self formatFrameSource:stackFrame];
+  } else {
+    cell.detailTextLabel.text = @"";
+  }
+
+  if (stackFrame.collapse) {
+    cell.textLabel.textColor = RCTRedBox2TextColor(0.4);
+    cell.detailTextLabel.textColor = RCTRedBox2TextColor(0.3);
+  } else {
+    cell.textLabel.textColor = [UIColor whiteColor];
+    cell.detailTextLabel.textColor = RCTRedBox2TextColor(0.8);
+  }
+
+  return cell;
+}
+
+- (UITableViewCell *)reuseCell:(UITableViewCell *)cell forCodeFrame:(RCTRedBox2ErrorData *)errorData
+{
+  if (cell == nullptr) {
+    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"code-cell"];
+    cell.backgroundColor = [UIColor clearColor];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+  }
+
+  // Remove old subviews
+  for (UIView *subview in cell.contentView.subviews) {
+    [subview removeFromSuperview];
+  }
+
+  // Code frame container with rounded corners
+  UIView *container = [[UIView alloc] init];
+  container.translatesAutoresizingMaskIntoConstraints = NO;
+  container.backgroundColor = RCTRedBox2BackgroundColor();
+  container.layer.cornerRadius = 3;
+  container.clipsToBounds = YES;
+  [cell.contentView addSubview:container];
+
+  // Render code frame with ANSI syntax highlighting
+  UIFont *codeFont = [UIFont fontWithName:@"Menlo-Regular" size:12];
+  NSAttributedString *highlighted = [RCTRedBox2AnsiParser attributedStringFromAnsiText:errorData.codeFrame
+                                                                              baseFont:codeFont
+                                                                             baseColor:[UIColor whiteColor]];
+
+  UILabel *codeLabel = [[UILabel alloc] init];
+  codeLabel.translatesAutoresizingMaskIntoConstraints = NO;
+  codeLabel.attributedText = highlighted;
+  codeLabel.numberOfLines = 0;
+  codeLabel.lineBreakMode = NSLineBreakByClipping;
+
+  UIScrollView *codeScrollView = [[UIScrollView alloc] init];
+  codeScrollView.translatesAutoresizingMaskIntoConstraints = NO;
+  codeScrollView.showsHorizontalScrollIndicator = YES;
+  codeScrollView.showsVerticalScrollIndicator = NO;
+  codeScrollView.bounces = NO;
+  [codeScrollView addSubview:codeLabel];
+  [container addSubview:codeScrollView];
+
+  // File name label below the code frame
+  UILabel *fileLabel = [[UILabel alloc] init];
+  fileLabel.translatesAutoresizingMaskIntoConstraints = NO;
+  NSString *fileName = errorData.codeFrameFileName.lastPathComponent ?: errorData.codeFrameFileName;
+  if (errorData.codeFrameRow > 0) {
+    fileLabel.text = [NSString
+        stringWithFormat:@"%@ (%ld:%ld)", fileName, (long)errorData.codeFrameRow, (long)errorData.codeFrameColumn + 1];
+  } else if (fileName.length > 0) {
+    fileLabel.text = fileName;
+  }
+  fileLabel.textColor = RCTRedBox2TextColor(0.5);
+  fileLabel.font = [UIFont fontWithName:@"Menlo-Regular" size:12];
+  fileLabel.textAlignment = NSTextAlignmentCenter;
+  [cell.contentView addSubview:fileLabel];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [container.topAnchor constraintEqualToAnchor:cell.contentView.topAnchor constant:5],
+    [container.leadingAnchor constraintEqualToAnchor:cell.contentView.leadingAnchor constant:10],
+    [container.trailingAnchor constraintEqualToAnchor:cell.contentView.trailingAnchor constant:-10],
+
+    [codeScrollView.topAnchor constraintEqualToAnchor:container.topAnchor constant:10],
+    [codeScrollView.leadingAnchor constraintEqualToAnchor:container.leadingAnchor constant:10],
+    [codeScrollView.trailingAnchor constraintEqualToAnchor:container.trailingAnchor constant:-10],
+    [codeScrollView.bottomAnchor constraintEqualToAnchor:container.bottomAnchor constant:-10],
+
+    [codeLabel.topAnchor constraintEqualToAnchor:codeScrollView.topAnchor],
+    [codeLabel.leadingAnchor constraintEqualToAnchor:codeScrollView.leadingAnchor],
+    [codeLabel.trailingAnchor constraintEqualToAnchor:codeScrollView.trailingAnchor],
+    [codeLabel.bottomAnchor constraintEqualToAnchor:codeScrollView.bottomAnchor],
+    [codeLabel.heightAnchor constraintEqualToAnchor:codeScrollView.heightAnchor],
+
+    [fileLabel.topAnchor constraintEqualToAnchor:container.bottomAnchor constant:10],
+    [fileLabel.leadingAnchor constraintEqualToAnchor:cell.contentView.leadingAnchor constant:10],
+    [fileLabel.trailingAnchor constraintEqualToAnchor:cell.contentView.trailingAnchor constant:-10],
+    [fileLabel.bottomAnchor constraintEqualToAnchor:cell.contentView.bottomAnchor constant:-10],
+  ]];
+
+  return cell;
+}
+
+- (CGFloat)tableView:(__unused UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  auto section = [self sectionForIndex:indexPath.section];
+  if (section == Section::Message || section == Section::CodeFrame) {
+    return UITableViewAutomaticDimension;
+  }
+  return 50;
+}
+
+- (CGFloat)tableView:(__unused UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  switch ([self sectionForIndex:indexPath.section]) {
+    case Section::Message:
+      return 100;
+    case Section::CodeFrame:
+      return 200;
+    case Section::CallStack:
+    case Section::kMaxValue:
+      return 50;
+  }
+}
+
+- (UIView *)sectionHeaderViewWithTitle:(NSString *)title
+{
+  UIView *headerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 38)];
+  headerView.backgroundColor = [UIColor clearColor];
+
+  UILabel *label = [[UILabel alloc] init];
+  label.translatesAutoresizingMaskIntoConstraints = NO;
+  label.text = title;
+  label.textColor = [UIColor whiteColor];
+  label.font = [UIFont systemFontOfSize:18 weight:UIFontWeightSemibold];
+  [headerView addSubview:label];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [label.leadingAnchor constraintEqualToAnchor:headerView.leadingAnchor constant:12],
+    [label.trailingAnchor constraintEqualToAnchor:headerView.trailingAnchor constant:-12],
+    [label.bottomAnchor constraintEqualToAnchor:headerView.bottomAnchor constant:-10],
+  ]];
+
+  return headerView;
+}
+
+- (UIView *)tableView:(__unused UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+{
+  switch ([self sectionForIndex:section]) {
+    case Section::CodeFrame:
+      return [self sectionHeaderViewWithTitle:@"Source"];
+    case Section::CallStack:
+      return [self sectionHeaderViewWithTitle:@"Call Stack"];
+    case Section::Message:
+    case Section::kMaxValue:
+      return nil;
+  }
+}
+
+- (CGFloat)tableView:(__unused UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+  auto s = [self sectionForIndex:section];
+  return (s == Section::CodeFrame || s == Section::CallStack) ? 38 : 0;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  if ([self sectionForIndex:indexPath.section] == Section::CallStack) {
+    NSUInteger row = indexPath.row;
+    RCTJSStackFrame *stackFrame = _lastStackTrace[row];
+    [_actionDelegate redBoxController:self openStackFrameInEditor:stackFrame];
+  }
+  [tableView deselectRowAtIndexPath:indexPath animated:YES];
+}
+
+#pragma mark - Key Commands
+
+- (NSArray<UIKeyCommand *> *)keyCommands
+{
+  return @[
+    // Dismiss red box
+    [UIKeyCommand keyCommandWithInput:UIKeyInputEscape modifierFlags:0 action:@selector(dismiss)],
+    // Reload
+    [UIKeyCommand keyCommandWithInput:@"r" modifierFlags:UIKeyModifierCommand action:@selector(reload)],
+    // Copy = Cmd-Option C since Cmd-C in the simulator copies the pasteboard from
+    // the simulator to the desktop pasteboard.
+    [UIKeyCommand keyCommandWithInput:@"c"
+                        modifierFlags:UIKeyModifierCommand | UIKeyModifierAlternate
+                               action:@selector(copyStack)],
+  ];
+}
+
+- (BOOL)canBecomeFirstResponder
+{
+  return YES;
+}
+
+@end
+
+#endif // [macOS]
+
+#endif

--- a/packages/react-native/React/CoreModules/RCTRedBox2Controller.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox2Controller.mm
@@ -13,6 +13,9 @@
 #import <React/RCTUtils.h>
 
 #include <array>
+#if TARGET_OS_OSX // [macOS
+#import <objc/runtime.h>
+#endif // macOS]
 
 #import "RCTJscSafeUrl+Internal.h"
 #import "RCTRedBox2AnsiParser+Internal.h"
@@ -24,11 +27,10 @@
 
 #if RCT_DEV_MENU
 
-#if !TARGET_OS_OSX // [macOS]
-
 #pragma mark - RCTRedBox2Controller
 
 // Color Palette (matching LogBoxStyle.js)
+#if !TARGET_OS_OSX // [macOS]
 static UIColor *RCTRedBox2BackgroundColor()
 {
   return [UIColor colorWithRed:51.0 / 255 green:51.0 / 255 blue:51.0 / 255 alpha:1.0];
@@ -43,6 +45,22 @@ static UIColor *RCTRedBox2TextColor(CGFloat opacity)
 {
   return [UIColor colorWithWhite:1.0 alpha:opacity];
 }
+#else // [macOS
+static RCTUIColor *RCTRedBox2BackgroundColor()
+{
+  return [RCTUIColor colorWithRed:51.0 / 255 green:51.0 / 255 blue:51.0 / 255 alpha:1.0];
+}
+
+static RCTUIColor *RCTRedBox2ErrorColor()
+{
+  return [RCTUIColor colorWithRed:243.0 / 255 green:83.0 / 255 blue:105.0 / 255 alpha:1.0];
+}
+
+static RCTUIColor *RCTRedBox2TextColor(CGFloat opacity)
+{
+  return [RCTUIColor colorWithWhite:1.0 alpha:opacity];
+}
+#endif // macOS]
 
 enum class Section : uint8_t { Message, CodeFrame, CallStack, kMaxValue };
 static constexpr size_t kSectionCount = static_cast<size_t>(Section::kMaxValue);
@@ -52,11 +70,51 @@ struct SectionState {
 };
 
 static const NSTimeInterval kAutoRetryInterval = 20.0;
+#if TARGET_OS_OSX // [macOS
+// AppKit has no per-control block-based action, so associate the handler with the button.
+@interface NSButton (RCTRedBox2)
+@property (nonatomic) RCTRedBox2ButtonPressHandler rb2_handler;
+- (void)rb2_addBlock:(RCTRedBox2ButtonPressHandler)handler;
+@end
+
+@implementation NSButton (RCTRedBox2)
+
+- (RCTRedBox2ButtonPressHandler)rb2_handler
+{
+  return objc_getAssociatedObject(self, @selector(rb2_handler));
+}
+
+- (void)setRb2_handler:(RCTRedBox2ButtonPressHandler)rb2_handler
+{
+  objc_setAssociatedObject(self, @selector(rb2_handler), rb2_handler, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (void)rb2_callBlock
+{
+  if (self.rb2_handler) {
+    self.rb2_handler();
+  }
+}
+
+- (void)rb2_addBlock:(RCTRedBox2ButtonPressHandler)handler
+{
+  self.rb2_handler = handler;
+  [self setTarget:self];
+  [self setAction:@selector(rb2_callBlock)];
+}
+
+@end
+#endif // macOS]
 
 @implementation RCTRedBox2Controller {
+#if !TARGET_OS_OSX // [macOS]
   UITableView *_stackTraceTableView;
   UILabel *_headerTitleLabel;
   UILabel *_errorCategoryLabel;
+#else // [macOS
+  NSTableView *_stackTraceTableView;
+  NSTextField *_headerTitleLabel;
+#endif // macOS]
   NSString *_lastErrorMessage;
   NSArray<RCTJSStackFrame *> *_lastStackTrace;
   NSArray<NSString *> *_customButtonTitles;
@@ -66,7 +124,11 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
   std::array<SectionState, kSectionCount> _sectionStates;
   NSTimer *_autoRetryTimer;
   NSInteger _autoRetryCountdown;
+#if !TARGET_OS_OSX // [macOS]
   UIButton *_reloadButton;
+#else // [macOS
+  NSButton *_reloadButton;
+#endif // macOS]
   NSString *_reloadBaseText;
   RCTRedBoxHMRClient *_hmrClient;
 }
@@ -79,7 +141,9 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
     _lastErrorCookie = -1;
     _customButtonTitles = customButtonTitles;
     _customButtonHandlers = customButtonHandlers;
+#if !TARGET_OS_OSX // [macOS]
     self.modalPresentationStyle = UIModalPresentationFullScreen;
+#endif // [macOS]
   }
   return self;
 }
@@ -87,15 +151,29 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
 - (void)viewDidLoad
 {
   [super viewDidLoad];
+#if !TARGET_OS_OSX // [macOS]
   self.view.backgroundColor = RCTRedBox2BackgroundColor();
+#else // [macOS
+  self.view.wantsLayer = YES;
+  self.view.layer.backgroundColor = RCTRedBox2BackgroundColor().CGColor;
+#endif // macOS]
 
   // Header bar (adds itself to self.view)
+#if !TARGET_OS_OSX // [macOS]
   UIView *headerBar = [self createHeaderBar];
+#else // [macOS
+  RCTPlatformView *headerBar = [self createHeaderBar];
+#endif // macOS]
 
   // Footer button bar
+#if !TARGET_OS_OSX // [macOS]
   UIView *footerBar = [self createFooterBar];
+#else // [macOS
+  RCTPlatformView *footerBar = [self createFooterBar];
+#endif // macOS]
 
   // Stack trace table
+#if !TARGET_OS_OSX // [macOS]
   _stackTraceTableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
   _stackTraceTableView.translatesAutoresizingMaskIntoConstraints = NO;
   _stackTraceTableView.delegate = self;
@@ -114,10 +192,43 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
     [_stackTraceTableView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
     [_stackTraceTableView.bottomAnchor constraintEqualToAnchor:footerBar.topAnchor],
   ]];
+#else // [macOS
+  NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
+  scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+  scrollView.drawsBackground = NO;
+  scrollView.hasVerticalScroller = YES;
+
+  _stackTraceTableView = [[NSTableView alloc] initWithFrame:NSZeroRect];
+  _stackTraceTableView.translatesAutoresizingMaskIntoConstraints = NO;
+  _stackTraceTableView.dataSource = self;
+  _stackTraceTableView.delegate = self;
+  _stackTraceTableView.headerView = nil;
+  _stackTraceTableView.backgroundColor = [NSColor clearColor];
+  _stackTraceTableView.selectionHighlightStyle = NSTableViewSelectionHighlightStyleNone;
+  _stackTraceTableView.usesAutomaticRowHeights = YES;
+  _stackTraceTableView.intercellSpacing = NSMakeSize(0, 0);
+  _stackTraceTableView.allowsColumnReordering = NO;
+  _stackTraceTableView.allowsColumnResizing = NO;
+  _stackTraceTableView.columnAutoresizingStyle = NSTableViewFirstColumnOnlyAutoresizingStyle;
+
+  NSTableColumn *tableColumn = [[NSTableColumn alloc] initWithIdentifier:@"info"];
+  [_stackTraceTableView addTableColumn:tableColumn];
+
+  scrollView.documentView = _stackTraceTableView;
+  [self.view addSubview:scrollView];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [scrollView.topAnchor constraintEqualToAnchor:headerBar.bottomAnchor],
+    [scrollView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+    [scrollView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+    [scrollView.bottomAnchor constraintEqualToAnchor:footerBar.topAnchor],
+  ]];
+#endif // macOS]
 }
 
 #pragma mark - Header Bar
 
+#if !TARGET_OS_OSX // [macOS]
 - (UIView *)createHeaderBar
 {
   UIView *headerContainer = [[UIView alloc] init];
@@ -146,9 +257,40 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
 
   return headerContainer;
 }
+#else // [macOS
+- (RCTPlatformView *)createHeaderBar
+{
+  NSView *headerContainer = [[NSView alloc] init];
+  headerContainer.translatesAutoresizingMaskIntoConstraints = NO;
+  headerContainer.wantsLayer = YES;
+  headerContainer.layer.backgroundColor = RCTRedBox2ErrorColor().CGColor;
+
+  _headerTitleLabel = [self makeLabel];
+  _headerTitleLabel.textColor = [NSColor whiteColor];
+  _headerTitleLabel.font = [NSFont systemFontOfSize:16 weight:NSFontWeightSemibold];
+  _headerTitleLabel.alignment = NSTextAlignmentCenter;
+  [headerContainer addSubview:_headerTitleLabel];
+
+  [self.view addSubview:headerContainer];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [headerContainer.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+    [headerContainer.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+    [headerContainer.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+
+    [_headerTitleLabel.leadingAnchor constraintEqualToAnchor:headerContainer.leadingAnchor constant:12],
+    [_headerTitleLabel.trailingAnchor constraintEqualToAnchor:headerContainer.trailingAnchor constant:-12],
+    [_headerTitleLabel.bottomAnchor constraintEqualToAnchor:headerContainer.bottomAnchor constant:-12],
+    [_headerTitleLabel.topAnchor constraintEqualToAnchor:headerContainer.topAnchor constant:12],
+  ]];
+
+  return headerContainer;
+}
+#endif // macOS]
 
 #pragma mark - Footer Bar
 
+#if !TARGET_OS_OSX // [macOS]
 - (UIView *)createFooterBar
 {
   const CGFloat buttonHeight = 48;
@@ -207,7 +349,70 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
 
   return buttonStackView;
 }
+#else // [macOS
+- (RCTPlatformView *)createFooterBar
+{
+  const CGFloat buttonHeight = 48;
 
+  NSString *reloadText = @"Reload";
+  NSString *dismissText = @"Dismiss";
+  NSString *copyText = @"Copy";
+
+  NSButton *dismissButton = [self footerButton:dismissText
+                       accessibilityIdentifier:@"redbox-dismiss"
+                                      selector:@selector(dismiss)];
+  [dismissButton setKeyEquivalent:@"\e"];
+  _reloadBaseText = reloadText;
+  _reloadButton = [self footerButton:reloadText accessibilityIdentifier:@"redbox-reload" selector:@selector(reload)];
+  [_reloadButton setKeyEquivalent:@"r"];
+  [_reloadButton setKeyEquivalentModifierMask:NSEventModifierFlagCommand];
+  NSButton *copyButton = [self footerButton:copyText
+                    accessibilityIdentifier:@"redbox-copy"
+                                   selector:@selector(copyStack)];
+  [copyButton setKeyEquivalent:@"c"];
+  [copyButton setKeyEquivalentModifierMask:NSEventModifierFlagOption | NSEventModifierFlagCommand];
+
+  NSStackView *buttonStackView = [[NSStackView alloc] init];
+  buttonStackView.translatesAutoresizingMaskIntoConstraints = NO;
+  buttonStackView.orientation = NSUserInterfaceLayoutOrientationHorizontal;
+  buttonStackView.distribution = NSStackViewDistributionFillEqually;
+  buttonStackView.alignment = NSLayoutAttributeCenterY;
+  buttonStackView.wantsLayer = YES;
+  buttonStackView.layer.backgroundColor = RCTRedBox2BackgroundColor().CGColor;
+
+  [buttonStackView addArrangedSubview:dismissButton];
+  [buttonStackView addArrangedSubview:_reloadButton];
+  [buttonStackView addArrangedSubview:copyButton];
+
+  for (NSUInteger i = 0; i < [_customButtonTitles count]; i++) {
+    NSButton *button = [self footerButton:_customButtonTitles[i]
+                  accessibilityIdentifier:@""
+                                  handler:_customButtonHandlers[i]];
+    [buttonStackView addArrangedSubview:button];
+  }
+
+  // Shadow layer above footer
+  buttonStackView.layer.shadowColor = [NSColor blackColor].CGColor;
+  buttonStackView.layer.shadowOffset = CGSizeMake(0, -2);
+  buttonStackView.layer.shadowRadius = 2;
+  buttonStackView.layer.shadowOpacity = 0.5;
+
+  [self.view addSubview:buttonStackView];
+
+  CGFloat bottomInset = [self bottomSafeViewHeight];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [buttonStackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+    [buttonStackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+    [buttonStackView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+    [buttonStackView.heightAnchor constraintEqualToConstant:buttonHeight + bottomInset],
+  ]];
+
+  return buttonStackView;
+}
+#endif // macOS]
+
+#if !TARGET_OS_OSX // [macOS]
 - (UIButton *)styledButton:(NSString *)title accessibilityIdentifier:(NSString *)accessibilityIdentifier
 {
   UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
@@ -241,10 +446,68 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
       forControlEvents:UIControlEventTouchUpInside];
   return button;
 }
+#else // [macOS
+- (NSTextField *)makeLabel
+{
+  NSTextField *label = [[NSTextField alloc] initWithFrame:NSZeroRect];
+  label.translatesAutoresizingMaskIntoConstraints = NO;
+  label.drawsBackground = NO;
+  label.bezeled = NO;
+  label.editable = NO;
+  label.selectable = NO;
+  label.lineBreakMode = NSLineBreakByWordWrapping;
+  label.maximumNumberOfLines = 0;
+  return label;
+}
+
+- (NSAttributedString *)attributedButtonTitle:(NSString *)title
+{
+  NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
+  paragraphStyle.alignment = NSTextAlignmentCenter;
+  return [[NSAttributedString alloc] initWithString:title
+                                         attributes:@{
+                                           NSForegroundColorAttributeName : [NSColor whiteColor],
+                                           NSFontAttributeName : [NSFont systemFontOfSize:14],
+                                           NSParagraphStyleAttributeName : paragraphStyle,
+                                         }];
+}
+
+- (NSButton *)styledButton:(NSString *)title accessibilityIdentifier:(NSString *)accessibilityIdentifier
+{
+  NSButton *button = [[NSButton alloc] initWithFrame:NSZeroRect];
+  button.translatesAutoresizingMaskIntoConstraints = NO;
+  button.accessibilityIdentifier = accessibilityIdentifier;
+  button.bordered = NO;
+  button.wantsLayer = YES;
+  button.layer.backgroundColor = RCTRedBox2BackgroundColor().CGColor;
+  [button setButtonType:NSButtonTypeMomentaryPushIn];
+  button.attributedTitle = [self attributedButtonTitle:title];
+  return button;
+}
+
+- (NSButton *)footerButton:(NSString *)title
+    accessibilityIdentifier:(NSString *)accessibilityIdentifier
+                   selector:(SEL)selector
+{
+  NSButton *button = [self styledButton:title accessibilityIdentifier:accessibilityIdentifier];
+  button.target = self;
+  button.action = selector;
+  return button;
+}
+
+- (NSButton *)footerButton:(NSString *)title
+    accessibilityIdentifier:(NSString *)accessibilityIdentifier
+                    handler:(RCTRedBox2ButtonPressHandler)handler
+{
+  NSButton *button = [self styledButton:title accessibilityIdentifier:accessibilityIdentifier];
+  [button rb2_addBlock:handler];
+  return button;
+}
+#endif // macOS]
 
 - (CGFloat)bottomSafeViewHeight
 {
-#if TARGET_OS_MACCATALYST
+#if TARGET_OS_MACCATALYST || TARGET_OS_OSX // [macOS]
   return 0;
 #else
   return RCTKeyWindow().safeAreaInsets.bottom;
@@ -291,15 +554,25 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
     [_stackTraceTableView reloadData];
 
     if (!isRootViewControllerPresented) {
+#if !TARGET_OS_OSX // [macOS]
       [RCTKeyWindow().rootViewController presentViewController:self animated:NO completion:nil];
+#else // [macOS
+      [[RCTKeyWindow() contentViewController] presentViewControllerAsSheet:self];
+#endif // macOS]
     }
 
     // Update all UI from _errorData (view is now guaranteed to be loaded)
+#if !TARGET_OS_OSX // [macOS]
     _headerTitleLabel.text = _errorData.isCompileError ? @"Failed to compile" : @"Error";
     [_stackTraceTableView reloadData];
     [_stackTraceTableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]
                                 atScrollPosition:UITableViewScrollPositionTop
                                         animated:NO];
+#else // [macOS
+    _headerTitleLabel.stringValue = _errorData.isCompileError ? @"Failed to compile" : @"Error";
+    [_stackTraceTableView reloadData];
+    [_stackTraceTableView scrollRowToVisible:0];
+#endif // macOS]
 
     [self startAutoRetryIfApplicable];
     [self _startHMRClient];
@@ -309,7 +582,13 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
 - (void)dismiss
 {
   [self stopAutoRetry];
+#if !TARGET_OS_OSX // [macOS]
   [self dismissViewControllerAnimated:NO completion:nil];
+#else // [macOS
+  if (self.presentingViewController) {
+    [[RCTKeyWindow() contentViewController] dismissViewController:self];
+  }
+#endif // macOS]
 }
 
 - (void)reload
@@ -369,7 +648,11 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
   [_autoRetryTimer invalidate];
   _autoRetryTimer = nil;
   if (_reloadButton) {
+#if !TARGET_OS_OSX // [macOS]
     [_reloadButton setTitle:_reloadBaseText forState:UIControlStateNormal];
+#else // [macOS
+    _reloadButton.attributedTitle = [self attributedButtonTitle:_reloadBaseText];
+#endif // macOS]
   }
 }
 
@@ -387,7 +670,11 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
 - (void)updateReloadButtonTitle
 {
   NSString *title = [NSString stringWithFormat:@"%@ (%lds)", _reloadBaseText, (long)_autoRetryCountdown];
+#if !TARGET_OS_OSX // [macOS]
   [_reloadButton setTitle:title forState:UIControlStateNormal];
+#else // [macOS
+  _reloadButton.attributedTitle = [self attributedButtonTitle:title];
+#endif // macOS]
 }
 
 - (void)copyStack
@@ -407,10 +694,16 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
       [fullStackTrace appendFormat:@"    %@\n", [self formatFrameSource:stackFrame]];
     }
   }
+#if !TARGET_OS_OSX // [macOS]
 #if !TARGET_OS_TV
   UIPasteboard *pb = [UIPasteboard generalPasteboard];
   [pb setString:fullStackTrace];
 #endif
+#else // [macOS
+  NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+  [pasteboard clearContents];
+  [pasteboard setString:fullStackTrace forType:NSPasteboardTypeString];
+#endif // macOS]
 }
 
 - (NSString *)formatFrameSource:(RCTJSStackFrame *)stackFrame
@@ -474,6 +767,7 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
 
 #pragma mark - TableView DataSource & Delegate
 
+#if !TARGET_OS_OSX // [macOS]
 - (NSInteger)numberOfSectionsInTableView:(__unused UITableView *)tableView
 {
   return [self visibleSectionCount];
@@ -738,9 +1032,262 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
   }
   [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }
+#else // [macOS
+
+// macOS AppKit NSTableView has no notion of sections, so the RedBox 2.0 sections
+// (Message, optional Source/Code Frame, optional Call Stack) are flattened into a
+// single list of rows, with lightweight header rows for the Source/Call Stack groups.
+typedef NS_ENUM(NSInteger, RCTRedBox2MacRowKind) {
+  RCTRedBox2MacRowKindMessage,
+  RCTRedBox2MacRowKindSourceHeader,
+  RCTRedBox2MacRowKindCodeFrame,
+  RCTRedBox2MacRowKindCallStackHeader,
+  RCTRedBox2MacRowKindStackFrame,
+};
+
+- (RCTRedBox2MacRowKind)macRowKindForRow:(NSInteger)row stackIndex:(NSInteger *)outStackIndex
+{
+  if (outStackIndex != nullptr) {
+    *outStackIndex = 0;
+  }
+  NSInteger current = 0;
+  if (_sectionStates[static_cast<size_t>(Section::Message)].visible) {
+    if (row == current) {
+      return RCTRedBox2MacRowKindMessage;
+    }
+    current++;
+  }
+  if (_sectionStates[static_cast<size_t>(Section::CodeFrame)].visible) {
+    if (row == current) {
+      return RCTRedBox2MacRowKindSourceHeader;
+    }
+    current++;
+    if (row == current) {
+      return RCTRedBox2MacRowKindCodeFrame;
+    }
+    current++;
+  }
+  if (_sectionStates[static_cast<size_t>(Section::CallStack)].visible) {
+    if (row == current) {
+      return RCTRedBox2MacRowKindCallStackHeader;
+    }
+    current++;
+    if (outStackIndex != nullptr) {
+      *outStackIndex = row - current;
+    }
+    return RCTRedBox2MacRowKindStackFrame;
+  }
+  return RCTRedBox2MacRowKindMessage;
+}
+
+- (NSInteger)numberOfRowsInTableView:(__unused NSTableView *)tableView
+{
+  NSInteger count = 0;
+  if (_sectionStates[static_cast<size_t>(Section::Message)].visible) {
+    count += 1;
+  }
+  if (_sectionStates[static_cast<size_t>(Section::CodeFrame)].visible) {
+    count += 2; // "Source" header + code frame
+  }
+  if (_sectionStates[static_cast<size_t>(Section::CallStack)].visible) {
+    count += 1 + static_cast<NSInteger>(_lastStackTrace.count); // "Call Stack" header + frames
+  }
+  return count;
+}
+
+- (nullable NSView *)tableView:(__unused NSTableView *)tableView
+            viewForTableColumn:(nullable __unused NSTableColumn *)tableColumn
+                           row:(NSInteger)row
+{
+  NSInteger stackIndex = 0;
+  switch ([self macRowKindForRow:row stackIndex:&stackIndex]) {
+    case RCTRedBox2MacRowKindMessage:
+      return [self macMessageCell];
+    case RCTRedBox2MacRowKindSourceHeader:
+      return [self macHeaderCellWithTitle:@"Source"];
+    case RCTRedBox2MacRowKindCodeFrame:
+      return [self macCodeFrameCell:_errorData];
+    case RCTRedBox2MacRowKindCallStackHeader:
+      return [self macHeaderCellWithTitle:@"Call Stack"];
+    case RCTRedBox2MacRowKindStackFrame:
+      return [self macStackFrameCell:_lastStackTrace[stackIndex]];
+  }
+  return nil;
+}
+
+- (NSView *)macMessageCell
+{
+  NSView *cell = [[NSView alloc] initWithFrame:NSZeroRect];
+  cell.wantsLayer = YES;
+  cell.layer.backgroundColor = RCTRedBox2BackgroundColor().CGColor;
+
+  NSTextField *categoryLabel = [self makeLabel];
+  categoryLabel.textColor = RCTRedBox2ErrorColor();
+  categoryLabel.font = [NSFont systemFontOfSize:21 weight:NSFontWeightBold];
+  categoryLabel.maximumNumberOfLines = 1;
+  categoryLabel.stringValue = _errorData.title ?: @"";
+  [cell addSubview:categoryLabel];
+
+  NSTextField *messageLabel = [self makeLabel];
+  messageLabel.accessibilityIdentifier = @"redbox-error";
+  messageLabel.textColor = [NSColor whiteColor];
+  messageLabel.font = [NSFont systemFontOfSize:14 weight:NSFontWeightMedium];
+  messageLabel.stringValue = [self displayMessage] ?: @"";
+  [cell addSubview:messageLabel];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [categoryLabel.topAnchor constraintEqualToAnchor:cell.topAnchor constant:15],
+    [categoryLabel.leadingAnchor constraintEqualToAnchor:cell.leadingAnchor constant:12],
+    [categoryLabel.trailingAnchor constraintEqualToAnchor:cell.trailingAnchor constant:-12],
+
+    [messageLabel.topAnchor constraintEqualToAnchor:categoryLabel.bottomAnchor constant:10],
+    [messageLabel.leadingAnchor constraintEqualToAnchor:cell.leadingAnchor constant:12],
+    [messageLabel.trailingAnchor constraintEqualToAnchor:cell.trailingAnchor constant:-12],
+    [messageLabel.bottomAnchor constraintEqualToAnchor:cell.bottomAnchor constant:-15],
+  ]];
+
+  return cell;
+}
+
+- (NSView *)macHeaderCellWithTitle:(NSString *)title
+{
+  NSView *cell = [[NSView alloc] initWithFrame:NSZeroRect];
+
+  NSTextField *label = [self makeLabel];
+  label.textColor = [NSColor whiteColor];
+  label.font = [NSFont systemFontOfSize:18 weight:NSFontWeightSemibold];
+  label.maximumNumberOfLines = 1;
+  label.stringValue = title;
+  [cell addSubview:label];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [label.leadingAnchor constraintEqualToAnchor:cell.leadingAnchor constant:12],
+    [label.trailingAnchor constraintEqualToAnchor:cell.trailingAnchor constant:-12],
+    [label.topAnchor constraintEqualToAnchor:cell.topAnchor constant:8],
+    [label.bottomAnchor constraintEqualToAnchor:cell.bottomAnchor constant:-10],
+  ]];
+
+  return cell;
+}
+
+- (NSView *)macCodeFrameCell:(RCTRedBox2ErrorData *)errorData
+{
+  NSView *cell = [[NSView alloc] initWithFrame:NSZeroRect];
+
+  NSView *container = [[NSView alloc] initWithFrame:NSZeroRect];
+  container.translatesAutoresizingMaskIntoConstraints = NO;
+  container.wantsLayer = YES;
+  container.layer.backgroundColor = RCTRedBox2BackgroundColor().CGColor;
+  container.layer.cornerRadius = 3;
+  [cell addSubview:container];
+
+  // Render code frame with ANSI syntax highlighting
+  NSFont *codeFont = [NSFont fontWithName:@"Menlo-Regular" size:12];
+  NSAttributedString *highlighted = [RCTRedBox2AnsiParser attributedStringFromAnsiText:errorData.codeFrame
+                                                                              baseFont:codeFont
+                                                                             baseColor:[NSColor whiteColor]];
+
+  NSTextField *codeLabel = [self makeLabel];
+  codeLabel.attributedStringValue = highlighted;
+  codeLabel.lineBreakMode = NSLineBreakByClipping;
+  [container addSubview:codeLabel];
+
+  // File name label below the code frame
+  NSTextField *fileLabel = [self makeLabel];
+  NSString *fileName = errorData.codeFrameFileName.lastPathComponent ?: errorData.codeFrameFileName;
+  if (errorData.codeFrameRow > 0) {
+    fileLabel.stringValue = [NSString
+        stringWithFormat:@"%@ (%ld:%ld)", fileName, (long)errorData.codeFrameRow, (long)errorData.codeFrameColumn + 1];
+  } else if (fileName.length > 0) {
+    fileLabel.stringValue = fileName;
+  }
+  fileLabel.textColor = RCTRedBox2TextColor(0.5);
+  fileLabel.font = [NSFont fontWithName:@"Menlo-Regular" size:12];
+  fileLabel.alignment = NSTextAlignmentCenter;
+  fileLabel.maximumNumberOfLines = 1;
+  [cell addSubview:fileLabel];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [container.topAnchor constraintEqualToAnchor:cell.topAnchor constant:5],
+    [container.leadingAnchor constraintEqualToAnchor:cell.leadingAnchor constant:10],
+    [container.trailingAnchor constraintEqualToAnchor:cell.trailingAnchor constant:-10],
+
+    [codeLabel.topAnchor constraintEqualToAnchor:container.topAnchor constant:10],
+    [codeLabel.leadingAnchor constraintEqualToAnchor:container.leadingAnchor constant:10],
+    [codeLabel.trailingAnchor constraintEqualToAnchor:container.trailingAnchor constant:-10],
+    [codeLabel.bottomAnchor constraintEqualToAnchor:container.bottomAnchor constant:-10],
+
+    [fileLabel.topAnchor constraintEqualToAnchor:container.bottomAnchor constant:10],
+    [fileLabel.leadingAnchor constraintEqualToAnchor:cell.leadingAnchor constant:10],
+    [fileLabel.trailingAnchor constraintEqualToAnchor:cell.trailingAnchor constant:-10],
+    [fileLabel.bottomAnchor constraintEqualToAnchor:cell.bottomAnchor constant:-10],
+  ]];
+
+  return cell;
+}
+
+- (NSView *)macStackFrameCell:(RCTJSStackFrame *)stackFrame
+{
+  NSView *cell = [[NSView alloc] initWithFrame:NSZeroRect];
+
+  NSTextField *label = [self makeLabel];
+  label.maximumNumberOfLines = 2;
+  [cell addSubview:label];
+
+  NSMutableParagraphStyle *textParagraphStyle = [NSMutableParagraphStyle new];
+  textParagraphStyle.lineBreakMode = NSLineBreakByCharWrapping;
+
+  NSDictionary<NSString *, id> *textAttributes = @{
+    NSForegroundColorAttributeName : stackFrame.collapse ? RCTRedBox2TextColor(0.4) : [NSColor whiteColor],
+    NSFontAttributeName : [NSFont fontWithName:@"Menlo-Regular" size:14],
+    NSParagraphStyleAttributeName : textParagraphStyle,
+  };
+  NSString *text = stackFrame.methodName ?: @"(unnamed method)";
+  NSMutableAttributedString *title = [[NSMutableAttributedString alloc] initWithString:text attributes:textAttributes];
+
+  if (stackFrame.file != nullptr) {
+    label.maximumNumberOfLines = 3;
+
+    NSMutableParagraphStyle *detailParagraphStyle = [NSMutableParagraphStyle new];
+    detailParagraphStyle.lineBreakMode = NSLineBreakByTruncatingMiddle;
+
+    NSDictionary<NSString *, id> *detailAttributes = @{
+      NSForegroundColorAttributeName : stackFrame.collapse ? RCTRedBox2TextColor(0.3) : RCTRedBox2TextColor(0.8),
+      NSFontAttributeName : [NSFont systemFontOfSize:12 weight:NSFontWeightLight],
+      NSParagraphStyleAttributeName : detailParagraphStyle,
+    };
+    NSAttributedString *detail = [[NSAttributedString alloc] initWithString:[self formatFrameSource:stackFrame]
+                                                                 attributes:detailAttributes];
+    [title appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n"]];
+    [title appendAttributedString:detail];
+  }
+
+  label.attributedStringValue = title;
+
+  [NSLayoutConstraint activateConstraints:@[
+    [label.leadingAnchor constraintEqualToAnchor:cell.leadingAnchor constant:12],
+    [label.trailingAnchor constraintEqualToAnchor:cell.trailingAnchor constant:-12],
+    [label.topAnchor constraintEqualToAnchor:cell.topAnchor constant:8],
+    [label.bottomAnchor constraintEqualToAnchor:cell.bottomAnchor constant:-8],
+  ]];
+
+  return cell;
+}
+
+- (BOOL)tableView:(__unused NSTableView *)tableView shouldSelectRow:(NSInteger)row
+{
+  NSInteger stackIndex = 0;
+  if ([self macRowKindForRow:row stackIndex:&stackIndex] == RCTRedBox2MacRowKindStackFrame) {
+    RCTJSStackFrame *stackFrame = _lastStackTrace[stackIndex];
+    [_actionDelegate redBoxController:self openStackFrameInEditor:stackFrame];
+  }
+  return NO;
+}
+#endif // macOS]
 
 #pragma mark - Key Commands
 
+#if !TARGET_OS_OSX // [macOS]
 - (NSArray<UIKeyCommand *> *)keyCommands
 {
   return @[
@@ -760,9 +1307,8 @@ static const NSTimeInterval kAutoRetryInterval = 20.0;
 {
   return YES;
 }
+#endif // [macOS]
 
 @end
-
-#endif // [macOS]
 
 #endif

--- a/packages/react-native/React/CoreModules/RCTRedBox2ErrorParser+Internal.h
+++ b/packages/react-native/React/CoreModules/RCTRedBox2ErrorParser+Internal.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ * Structured error data extracted from a raw error message.
+ * Mirrors LogBoxLog.js / parseLogBoxLog.js data model.
+ */
+@interface RCTRedBox2ErrorData : NSObject
+
+/// Display title, e.g. "Syntax Error", "Render Error", "Uncaught Error"
+@property (nonatomic, copy) NSString *title;
+/// The error message body (code frame stripped out)
+@property (nonatomic, copy) NSString *message;
+/// Raw code frame text with ANSI escape codes preserved (nil if not a syntax/transform error)
+@property (nonatomic, copy, nullable) NSString *codeFrame;
+/// Source file path for the code frame
+@property (nonatomic, copy, nullable) NSString *codeFrameFileName;
+/// Line number in the source file
+@property (nonatomic, assign) NSInteger codeFrameRow;
+/// Column number in the source file
+@property (nonatomic, assign) NSInteger codeFrameColumn;
+/// Whether this is a compile-time error (syntax, transform, resolution) vs a runtime error
+@property (nonatomic, assign) BOOL isCompileError;
+/// Whether auto-retry is appropriate (compile errors, connectivity failures, etc.)
+@property (nonatomic, assign) BOOL isRetryable;
+
+@end
+
+/**
+ * Parses raw error messages into structured RCTRedBox2ErrorData.
+ * ObjC port of parseLogBoxLog.js / parseLogBoxException.
+ */
+@interface RCTRedBox2ErrorParser : NSObject
+
++ (RCTRedBox2ErrorData *)parseErrorMessage:(NSString *)message
+                                      name:(nullable NSString *)name
+                            componentStack:(nullable NSString *)componentStack
+                                   isFatal:(BOOL)isFatal;
+
+@end

--- a/packages/react-native/React/CoreModules/RCTRedBox2ErrorParser.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox2ErrorParser.mm
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTRedBox2ErrorParser+Internal.h"
+
+#import <React/RCTDefines.h>
+#import <react/debug/redbox/RedBoxErrorParser.h>
+
+#if RCT_DEV_MENU
+
+using facebook::react::unstable_redbox::ParsedError;
+using facebook::react::unstable_redbox::parseErrorMessage;
+
+static RCTRedBox2ErrorData *RCTRedBox2ErrorDataFromParsedError(const ParsedError &parsed)
+{
+  RCTRedBox2ErrorData *data = [[RCTRedBox2ErrorData alloc] init];
+  data.title = [NSString stringWithUTF8String:parsed.title.c_str()];
+  data.message = [NSString stringWithUTF8String:parsed.message.c_str()];
+  data.isCompileError = parsed.isCompileError;
+  data.isRetryable = parsed.isRetryable;
+
+  if (parsed.codeFrame.has_value()) {
+    const auto &cf = *parsed.codeFrame;
+    data.codeFrame = [NSString stringWithUTF8String:cf.content.c_str()];
+    data.codeFrameFileName = [NSString stringWithUTF8String:cf.fileName.c_str()];
+    data.codeFrameRow = cf.row;
+    data.codeFrameColumn = cf.column;
+  }
+
+  return data;
+}
+
+@implementation RCTRedBox2ErrorData
+@end
+
+@implementation RCTRedBox2ErrorParser
+
++ (RCTRedBox2ErrorData *)parseErrorMessage:(NSString *)message
+                                      name:(nullable NSString *)name
+                            componentStack:(nullable NSString *)componentStack
+                                   isFatal:(BOOL)isFatal
+{
+  auto parsed = parseErrorMessage(
+      (message != nullptr) ? std::string(message.UTF8String) : std::string(),
+      (name != nullptr) ? std::string(name.UTF8String) : std::string(),
+      (componentStack != nullptr) ? std::string(componentStack.UTF8String) : std::string(),
+      isFatal);
+  return RCTRedBox2ErrorDataFromParsedError(parsed);
+}
+
+@end
+
+#endif

--- a/packages/react-native/React/CoreModules/RCTRedBoxController+Internal.h
+++ b/packages/react-native/React/CoreModules/RCTRedBoxController+Internal.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTDefines.h>
+
+#import "RCTRedBox+Internal.h"
+#import "RCTRedBox.h"
+
+#if RCT_DEV_MENU
+
+#if !TARGET_OS_OSX // [macOS]
+@interface RCTRedBoxController : UIViewController <RCTRedBoxControlling, UITableViewDelegate, UITableViewDataSource>
+#else // [macOS
+@interface RCTRedBoxController : NSViewController <RCTRedBoxControlling, NSTableViewDelegate, NSTableViewDataSource>
+#endif // macOS]
+
+@property (nonatomic, weak) id<RCTRedBoxControllerActionDelegate> actionDelegate;
+
+- (instancetype)initWithCustomButtonTitles:(NSArray<NSString *> *)customButtonTitles
+                      customButtonHandlers:(NSArray<RCTRedBoxButtonPressHandler> *)customButtonHandlers;
+
+- (void)showErrorMessage:(NSString *)message
+               withStack:(NSArray<RCTJSStackFrame *> *)stack
+                isUpdate:(BOOL)isUpdate
+             errorCookie:(int)errorCookie;
+
+- (void)dismiss;
+
+@end
+
+#endif

--- a/packages/react-native/React/CoreModules/RCTRedBoxController.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBoxController.mm
@@ -1,0 +1,764 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTRedBoxController+Internal.h"
+
+#import <React/RCTDefines.h>
+#import <React/RCTJSStackFrame.h>
+#import <React/RCTReloadCommand.h>
+#import <React/RCTUtils.h>
+
+#import <objc/runtime.h>
+
+#if RCT_DEV_MENU
+
+#if !TARGET_OS_OSX // [macOS]
+@interface UIButton (RCTRedBox)
+#else // [macOS
+@interface NSButton (RCTRedBox)
+#endif // macOS]
+
+@property (nonatomic) RCTRedBoxButtonPressHandler rct_handler;
+
+#if !TARGET_OS_OSX // [macOS]
+- (void)rct_addBlock:(RCTRedBoxButtonPressHandler)handler forControlEvents:(UIControlEvents)controlEvents;
+#else // [macOS
+- (void)rct_addBlock:(RCTRedBoxButtonPressHandler)handler;
+#endif // macOS]
+
+@end
+
+#if !TARGET_OS_OSX // [macOS]
+@implementation UIButton (RCTRedBox)
+#else // [macOS
+@implementation NSButton (RCTRedBox)
+#endif // macOS]
+
+- (RCTRedBoxButtonPressHandler)rct_handler
+{
+  return objc_getAssociatedObject(self, @selector(rct_handler));
+}
+
+- (void)setRct_handler:(RCTRedBoxButtonPressHandler)rct_handler
+{
+  objc_setAssociatedObject(self, @selector(rct_handler), rct_handler, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (void)rct_callBlock
+{
+  if (self.rct_handler) {
+    self.rct_handler();
+  }
+}
+
+#if !TARGET_OS_OSX // [macOS]
+- (void)rct_addBlock:(RCTRedBoxButtonPressHandler)handler forControlEvents:(UIControlEvents)controlEvents
+#else // [macOS
+- (void)rct_addBlock:(RCTRedBoxButtonPressHandler)handler
+#endif // macOS]
+{
+  self.rct_handler = handler;
+#if !TARGET_OS_OSX // [macOS]
+  [self addTarget:self action:@selector(rct_callBlock) forControlEvents:controlEvents];
+#else // [macOS
+  [self setTarget:self];
+  [self setAction:@selector(rct_callBlock)];
+#endif // macOS]
+}
+
+@end
+
+@implementation RCTRedBoxController {
+#if !TARGET_OS_OSX // [macOS]
+  UITableView *_stackTraceTableView;
+#else // [macOS
+  NSTableView *_stackTraceTableView;
+#endif // macOS]
+  NSString *_lastErrorMessage;
+  NSArray<RCTJSStackFrame *> *_lastStackTrace;
+  NSArray<NSString *> *_customButtonTitles;
+  NSArray<RCTRedBoxButtonPressHandler> *_customButtonHandlers;
+  int _lastErrorCookie;
+}
+
+- (instancetype)initWithCustomButtonTitles:(NSArray<NSString *> *)customButtonTitles
+                      customButtonHandlers:(NSArray<RCTRedBoxButtonPressHandler> *)customButtonHandlers
+{
+  if (self = [super init]) {
+    _lastErrorCookie = -1;
+    _customButtonTitles = customButtonTitles;
+    _customButtonHandlers = customButtonHandlers;
+  }
+
+  return self;
+}
+
+- (void)viewDidLoad
+{
+  [super viewDidLoad];
+#if !TARGET_OS_OSX // [macOS]
+  self.view.backgroundColor = [UIColor blackColor];
+#else // [macOS
+  self.view.wantsLayer = YES;
+  self.view.layer.backgroundColor = [[NSColor blackColor] CGColor];
+#endif // macOS]
+
+  const CGFloat buttonHeight = 60;
+
+  CGRect detailsFrame = self.view.bounds;
+  detailsFrame.size.height -= buttonHeight + (double)[self bottomSafeViewHeight];
+
+#if !TARGET_OS_OSX // [macOS]
+  _stackTraceTableView = [[UITableView alloc] initWithFrame:detailsFrame style:UITableViewStylePlain];
+  _stackTraceTableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  _stackTraceTableView.delegate = self;
+  _stackTraceTableView.dataSource = self;
+  _stackTraceTableView.backgroundColor = [UIColor clearColor];
+#if !TARGET_OS_TV
+  _stackTraceTableView.separatorColor = [UIColor colorWithWhite:1 alpha:0.3];
+  _stackTraceTableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+#endif
+  _stackTraceTableView.indicatorStyle = UIScrollViewIndicatorStyleWhite;
+  [self.view addSubview:_stackTraceTableView];
+#else // [macOS
+  NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
+  scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+  scrollView.autoresizesSubviews = YES;
+  scrollView.drawsBackground = NO;
+
+  _stackTraceTableView = [[NSTableView alloc] initWithFrame:NSZeroRect];
+  _stackTraceTableView.translatesAutoresizingMaskIntoConstraints = NO;
+  _stackTraceTableView.dataSource = self;
+  _stackTraceTableView.delegate = self;
+  _stackTraceTableView.headerView = nil;
+  _stackTraceTableView.allowsColumnReordering = NO;
+  _stackTraceTableView.allowsColumnResizing = NO;
+  _stackTraceTableView.columnAutoresizingStyle = NSTableViewFirstColumnOnlyAutoresizingStyle;
+  _stackTraceTableView.backgroundColor = [NSColor clearColor];
+  _stackTraceTableView.allowsTypeSelect = NO;
+
+  NSTableColumn *tableColumn = [[NSTableColumn alloc] initWithIdentifier:@"info"];
+  [_stackTraceTableView addTableColumn:tableColumn];
+
+  scrollView.documentView = _stackTraceTableView;
+  [self.view addSubview:scrollView];
+#endif // macOS]
+
+#if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST || TARGET_OS_OSX // [macOS]
+  NSString *reloadText = @"Reload\n(\u2318R)";
+  NSString *dismissText = @"Dismiss\n(ESC)";
+  NSString *copyText = @"Copy\n(\u2325\u2318C)";
+  NSString *extraText = @"Extra Info\n(\u2318E)";
+#else
+  NSString *reloadText = @"Reload JS";
+  NSString *dismissText = @"Dismiss";
+  NSString *copyText = @"Copy";
+  NSString *extraText = @"Extra Info";
+#endif
+
+#if !TARGET_OS_OSX // [macOS]
+  UIButton *dismissButton = [self redBoxButton:dismissText
+                       accessibilityIdentifier:@"redbox-dismiss"
+                                      selector:@selector(dismiss)
+                                         block:nil];
+  UIButton *reloadButton = [self redBoxButton:reloadText
+                      accessibilityIdentifier:@"redbox-reload"
+                                     selector:@selector(reload)
+                                        block:nil];
+  UIButton *copyButton = [self redBoxButton:copyText
+                    accessibilityIdentifier:@"redbox-copy"
+                                   selector:@selector(copyStack)
+                                      block:nil];
+  UIButton *extraButton = [self redBoxButton:extraText
+                     accessibilityIdentifier:@"redbox-extra"
+                                    selector:@selector(showExtraDataViewController)
+                                       block:nil];
+#else // [macOS
+  NSButton *dismissButton = [self redBoxButton:dismissText
+                       accessibilityIdentifier:@"redbox-dismiss"
+                                      selector:@selector(dismiss)
+                                         block:nil];
+  [dismissButton setKeyEquivalent:@"\e"];
+  NSButton *reloadButton = [self redBoxButton:reloadText
+                      accessibilityIdentifier:@"redbox-reload"
+                                     selector:@selector(reload)
+                                        block:nil];
+  [reloadButton setKeyEquivalent:@"r"];
+  [reloadButton setKeyEquivalentModifierMask:NSEventModifierFlagCommand];
+  NSButton *copyButton = [self redBoxButton:copyText
+                    accessibilityIdentifier:@"redbox-copy"
+                                   selector:@selector(copyStack)
+                                      block:nil];
+  [copyButton setKeyEquivalent:@"c"];
+  [copyButton setKeyEquivalentModifierMask:NSEventModifierFlagOption | NSEventModifierFlagCommand];
+  NSButton *extraButton = [self redBoxButton:extraText
+                     accessibilityIdentifier:@"redbox-extra"
+                                    selector:@selector(showExtraDataViewController)
+                                       block:nil];
+#endif // macOS]
+
+  [NSLayoutConstraint activateConstraints:@[
+    [dismissButton.heightAnchor constraintEqualToConstant:buttonHeight],
+    [reloadButton.heightAnchor constraintEqualToConstant:buttonHeight],
+    [copyButton.heightAnchor constraintEqualToConstant:buttonHeight],
+    [extraButton.heightAnchor constraintEqualToConstant:buttonHeight]
+  ]];
+
+#if !TARGET_OS_OSX // [macOS]
+  UIStackView *buttonStackView = [[UIStackView alloc] init];
+  buttonStackView.translatesAutoresizingMaskIntoConstraints = NO;
+  buttonStackView.axis = UILayoutConstraintAxisHorizontal;
+  buttonStackView.distribution = UIStackViewDistributionFillEqually;
+  buttonStackView.alignment = UIStackViewAlignmentTop;
+  buttonStackView.backgroundColor = [UIColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:1];
+#else // [macOS
+  NSStackView *buttonStackView = [[NSStackView alloc] init];
+  buttonStackView.translatesAutoresizingMaskIntoConstraints = NO;
+  buttonStackView.orientation = NSUserInterfaceLayoutOrientationHorizontal;
+  buttonStackView.distribution = NSStackViewDistributionFillEqually;
+  buttonStackView.alignment = NSLayoutAttributeTop;
+  buttonStackView.wantsLayer = YES;
+  buttonStackView.layer.backgroundColor = [NSColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:1].CGColor;
+#endif // macOS]
+
+  [buttonStackView addArrangedSubview:dismissButton];
+  [buttonStackView addArrangedSubview:reloadButton];
+  [buttonStackView addArrangedSubview:copyButton];
+  [buttonStackView addArrangedSubview:extraButton];
+
+  [self.view addSubview:buttonStackView];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [buttonStackView.heightAnchor constraintEqualToConstant:buttonHeight + [self bottomSafeViewHeight]],
+    [buttonStackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+    [buttonStackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+    [buttonStackView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
+  ]];
+
+
+  for (NSUInteger i = 0; i < [_customButtonTitles count]; i++) {
+#if !TARGET_OS_OSX // [macOS]
+    UIButton *button = [self redBoxButton:_customButtonTitles[i]
+                  accessibilityIdentifier:@""
+                                 selector:nil
+                                    block:_customButtonHandlers[i]];
+#else // [macOS
+  NSButton *button = [self redBoxButton:_customButtonTitles[i]
+                  accessibilityIdentifier:@""
+                                 selector:nil
+                                    block:_customButtonHandlers[i]];
+#endif // macOS]
+    [button.heightAnchor constraintEqualToConstant:buttonHeight].active = YES;
+    [buttonStackView addArrangedSubview:button];
+  }
+
+  RCTPlatformView *topBorder = [[RCTPlatformView alloc] init]; // [macOS]
+  topBorder.translatesAutoresizingMaskIntoConstraints = NO;
+#if !TARGET_OS_OSX // [macOS]
+  topBorder.backgroundColor = [UIColor colorWithRed:0.70 green:0.70 blue:0.70 alpha:1.0];
+#else // [macOS
+  topBorder.wantsLayer = true;
+  topBorder.layer.backgroundColor = [NSColor colorWithRed:0.70 green:0.70 blue:0.70 alpha:1.0].CGColor;
+#endif // macOS]
+  [topBorder.heightAnchor constraintEqualToConstant:1].active = YES;
+
+  [self.view addSubview:topBorder];
+
+  [NSLayoutConstraint activateConstraints:@[
+    [topBorder.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+    [topBorder.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+    [topBorder.bottomAnchor constraintEqualToAnchor:buttonStackView.topAnchor]
+  ]];
+
+#if TARGET_OS_OSX // [macOS
+  [NSLayoutConstraint activateConstraints:@[
+    [[scrollView leadingAnchor] constraintEqualToAnchor:[[self view] leadingAnchor]],
+    [[scrollView topAnchor] constraintEqualToAnchor:[[self view] topAnchor]],
+    [[scrollView trailingAnchor] constraintEqualToAnchor:[[self view] trailingAnchor]],
+    [[scrollView bottomAnchor] constraintEqualToAnchor:[topBorder topAnchor]],
+  ]];
+#endif // macOS]
+}
+
+#if !TARGET_OS_OSX // [macOS]
+- (UIButton *)redBoxButton:(NSString *)title
+    accessibilityIdentifier:(NSString *)accessibilityIdentifier
+                   selector:(SEL)selector
+                      block:(RCTRedBoxButtonPressHandler)block
+{
+  UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
+  button.autoresizingMask =
+      UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleRightMargin;
+  button.accessibilityIdentifier = accessibilityIdentifier;
+  button.titleLabel.font = [UIFont systemFontOfSize:13];
+  button.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
+  button.titleLabel.textAlignment = NSTextAlignmentCenter;
+  button.backgroundColor = [UIColor colorWithRed:0.1 green:0.1 blue:0.1 alpha:1];
+  [button setTitle:title forState:UIControlStateNormal];
+  [button setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+  [button setTitleColor:[UIColor colorWithWhite:1 alpha:0.5] forState:UIControlStateHighlighted];
+  if (selector) {
+    [button addTarget:self action:selector forControlEvents:UIControlEventTouchUpInside];
+  } else if (block) {
+    [button rct_addBlock:block forControlEvents:UIControlEventTouchUpInside];
+  }
+  return button;
+}
+#else // [macOS
+- (NSButton *)redBoxButton:(NSString *)title
+   accessibilityIdentifier:(NSString *)accessibilityIdentifier
+                  selector:(SEL)selector
+                     block:(RCTRedBoxButtonPressHandler)block
+{
+  NSButton *button = [[NSButton alloc] initWithFrame:NSZeroRect];
+  button.translatesAutoresizingMaskIntoConstraints = NO;
+  button.accessibilityIdentifier = @"accessibilityIdentifier";
+  button.bordered = NO;
+  NSAttributedString *attributedTitle = [[NSAttributedString alloc]
+                                         initWithString:title
+                                         attributes:@{NSForegroundColorAttributeName : [ NSColor whiteColor] }];
+  button.attributedTitle = attributedTitle;
+  [button setButtonType:NSButtonTypeMomentaryPushIn];
+  if (selector) {
+    button.target = self;
+    button.action = selector;
+  } else if (block) {
+    [button rct_addBlock:block];
+  }
+  return button;
+}
+#endif // macOS]
+
+- (NSInteger)bottomSafeViewHeight
+{
+#if TARGET_OS_MACCATALYST || TARGET_OS_OSX // [macOS]
+  return 0;
+#else
+  return RCTKeyWindow().safeAreaInsets.bottom;
+#endif
+}
+
+RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
+
+- (NSString *)stripAnsi:(NSString *)text
+{
+  NSError *error = nil;
+  NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\x1b\\[[0-9;]*m"
+                                                                         options:NSRegularExpressionCaseInsensitive
+                                                                           error:&error];
+  return [regex stringByReplacingMatchesInString:text options:0 range:NSMakeRange(0, [text length]) withTemplate:@""];
+}
+
+- (void)showErrorMessage:(NSString *)message
+               withStack:(NSArray<RCTJSStackFrame *> *)stack
+                isUpdate:(BOOL)isUpdate
+             errorCookie:(int)errorCookie
+{
+  // Remove ANSI color codes from the message
+  NSString *messageWithoutAnsi = [self stripAnsi:message];
+
+  BOOL isRootViewControllerPresented = self.presentingViewController != nil;
+  // Show if this is a new message, or if we're updating the previous message
+  BOOL isNew = !isRootViewControllerPresented && !isUpdate;
+  BOOL isUpdateForSameMessage = !isNew &&
+      (isRootViewControllerPresented && isUpdate &&
+       ((errorCookie == -1 && [_lastErrorMessage isEqualToString:messageWithoutAnsi]) ||
+        (errorCookie == _lastErrorCookie)));
+  if (isNew || isUpdateForSameMessage) {
+    _lastStackTrace = stack;
+    // message is displayed using UILabel, which is unable to render text of
+    // unlimited length, so we truncate it
+    _lastErrorMessage = [messageWithoutAnsi substringToIndex:MIN((NSUInteger)10000, messageWithoutAnsi.length)];
+    _lastErrorCookie = errorCookie;
+
+    [_stackTraceTableView reloadData];
+
+    if (!isRootViewControllerPresented) {
+#if !TARGET_OS_OSX // [macOS]
+      [_stackTraceTableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]
+                                  atScrollPosition:UITableViewScrollPositionTop
+                                          animated:NO];
+      [RCTKeyWindow().rootViewController presentViewController:self animated:YES completion:nil];
+#else // [macOS
+	  [_stackTraceTableView scrollRowToVisible:0];
+    [[RCTKeyWindow() contentViewController] presentViewControllerAsSheet:self];
+#endif // macOS]
+    }
+  }
+}
+
+- (void)dismiss
+{
+#if !TARGET_OS_OSX // [macOS]
+  [self dismissViewControllerAnimated:YES completion:nil];
+#else // [macOS
+  if (self.presentingViewController) {
+    [[RCTKeyWindow() contentViewController] dismissViewController:self];
+  }
+#endif // macOS]
+}
+
+- (void)reload
+{
+  if (_actionDelegate != nil) {
+    [_actionDelegate reloadFromRedBoxController:self];
+  } else {
+    // In bridgeless mode `RCTRedBox` gets deallocated, we need to notify listeners anyway.
+    RCTTriggerReloadCommandListeners(@"Redbox");
+    [self dismiss];
+  }
+}
+
+- (void)showExtraDataViewController
+{
+  [_actionDelegate loadExtraDataViewController];
+}
+
+- (void)copyStack
+{
+  NSMutableString *fullStackTrace;
+
+  if (_lastErrorMessage != nil) {
+    fullStackTrace = [_lastErrorMessage mutableCopy];
+    [fullStackTrace appendString:@"\n\n"];
+  } else {
+    fullStackTrace = [NSMutableString string];
+  }
+
+  for (RCTJSStackFrame *stackFrame in _lastStackTrace) {
+    [fullStackTrace appendString:[NSString stringWithFormat:@"%@\n", stackFrame.methodName]];
+    if (stackFrame.file) {
+      [fullStackTrace appendFormat:@"    %@\n", [self formatFrameSource:stackFrame]];
+    }
+  }
+#if !TARGET_OS_OSX && !TARGET_OS_TV // [macOS]
+  UIPasteboard *pb = [UIPasteboard generalPasteboard];
+  [pb setString:fullStackTrace];
+#elif TARGET_OS_OSX // [macOS
+  NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+  [pasteboard clearContents];
+  [pasteboard setString:fullStackTrace forType:NSPasteboardTypeString];
+#endif // macOS]
+}
+
+- (NSString *)formatFrameSource:(RCTJSStackFrame *)stackFrame
+{
+  NSString *fileName = RCTNilIfNull(stackFrame.file) ? [stackFrame.file lastPathComponent] : @"<unknown file>";
+  NSString *lineInfo = [NSString stringWithFormat:@"%@:%lld", fileName, (long long)stackFrame.lineNumber];
+
+  if (stackFrame.column != 0) {
+    lineInfo = [lineInfo stringByAppendingFormat:@":%lld", (long long)stackFrame.column];
+  }
+  return lineInfo;
+}
+
+#pragma mark - TableView
+
+#if !TARGET_OS_OSX // [macOS]
+- (NSInteger)numberOfSectionsInTableView:(__unused UITableView *)tableView
+{
+  return 2;
+}
+
+- (NSInteger)tableView:(__unused UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+  return section == 0 ? 1 : _lastStackTrace.count;
+}
+#else // [macOS
+- (NSInteger)numberOfRowsInTableView:(__unused NSTableView *)tableView
+{
+  return (_lastErrorMessage != nil) + _lastStackTrace.count;
+}
+#endif // macOS]
+
+#if !TARGET_OS_OSX // [macOS]
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  if (indexPath.section == 0) {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"msg-cell"];
+    return [self reuseCell:cell forErrorMessage:_lastErrorMessage];
+  }
+  UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"cell"];
+  NSUInteger index = indexPath.row;
+  RCTJSStackFrame *stackFrame = _lastStackTrace[index];
+  return [self reuseCell:cell forStackFrame:stackFrame];
+}
+#else // [macOS
+- (nullable NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(nullable NSTableColumn *)tableColumn row:(NSInteger)row
+{
+  if (row == 0) {
+    NSTableCellView *cell = [tableView makeViewWithIdentifier:@"msg-cell" owner:nil];
+    return [self reuseCell:cell forErrorMessage:_lastErrorMessage];
+  }
+  NSTableCellView *cell = [tableView makeViewWithIdentifier:@"cell" owner:nil];
+  NSUInteger index = row - 1;
+  RCTJSStackFrame *stackFrame = _lastStackTrace[index];
+  return [self reuseCell:cell forStackFrame:stackFrame];
+
+}
+#endif // macOS]
+
+#if !TARGET_OS_OSX // [macOS]
+- (UITableViewCell *)reuseCell:(UITableViewCell *)cell forErrorMessage:(NSString *)message
+{
+  if (!cell) {
+    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"msg-cell"];
+    cell.textLabel.accessibilityIdentifier = @"redbox-error";
+    cell.textLabel.textColor = [UIColor whiteColor];
+
+    // Prefer a monofont for formatting messages that were designed
+    // to be displayed in a terminal.
+    cell.textLabel.font = [UIFont monospacedSystemFontOfSize:14 weight:UIFontWeightBold];
+
+    cell.textLabel.lineBreakMode = NSLineBreakByWordWrapping;
+    cell.textLabel.numberOfLines = 0;
+    cell.detailTextLabel.textColor = [UIColor whiteColor];
+    cell.backgroundColor = [UIColor colorWithRed:0.82 green:0.10 blue:0.15 alpha:1.0];
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
+  }
+
+  cell.textLabel.text = message;
+
+  return cell;
+}
+#else // [macOS
+- (NSTableCellView *)reuseCell:(NSTableCellView *)cell forErrorMessage:(NSString *)message
+{
+  if (!cell) {
+    cell = [[NSTableCellView alloc] initWithFrame:NSZeroRect];
+    cell.rowSizeStyle = NSTableViewRowSizeStyleCustom;
+    cell.textField.accessibilityIdentifier = @"red box-error";
+
+    NSTextField *label = [[NSTextField alloc] initWithFrame:NSZeroRect];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.drawsBackground = NO;
+    label.bezeled = NO;
+    label.editable = NO;
+
+    [cell addSubview:label];
+    cell.textField = label;
+
+    [NSLayoutConstraint activateConstraints:@[
+      [[label leadingAnchor] constraintEqualToAnchor:[cell leadingAnchor] constant:5],
+      [[label topAnchor] constraintEqualToAnchor:[cell topAnchor] constant:5],
+      [[label trailingAnchor] constraintEqualToAnchor:[cell trailingAnchor] constant:-5],
+      [[label bottomAnchor] constraintEqualToAnchor:[cell bottomAnchor] constant:-5],
+    ]];
+
+    // Prefer a monofont for formatting messages that were designed
+    // to be displayed in a terminal.
+    cell.textField.font = [NSFont monospacedSystemFontOfSize:14 weight:NSFontWeightBold];
+
+    cell.textField.lineBreakMode = NSLineBreakByWordWrapping;
+    cell.textField.maximumNumberOfLines = 0;
+    cell.wantsLayer = true;
+    cell.layer.cornerRadius = 8.0;
+    cell.layer.cornerCurve = kCACornerCurveContinuous;
+
+    cell.layer.backgroundColor = [NSColor colorWithRed:0.82 green:0.10 blue:0.15 alpha:1.0].CGColor;
+  }
+
+  NSDictionary<NSString *, id> *attributes = @{
+    NSForegroundColorAttributeName : [NSColor whiteColor],
+    NSFontAttributeName : [NSFont systemFontOfSize:16],
+  };
+  NSAttributedString *title = [[NSAttributedString alloc] initWithString:message attributes:attributes];
+
+  cell.textField.attributedStringValue = title;
+
+  return cell;
+}
+#endif // macOS]
+
+#if !TARGET_OS_OSX // [macOS]
+- (UITableViewCell *)reuseCell:(UITableViewCell *)cell forStackFrame:(RCTJSStackFrame *)stackFrame
+{
+  if (!cell) {
+    cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"cell"];
+    cell.textLabel.font = [UIFont fontWithName:@"Menlo-Regular" size:14];
+    cell.textLabel.lineBreakMode = NSLineBreakByCharWrapping;
+    cell.textLabel.numberOfLines = 2;
+    cell.detailTextLabel.textColor = [UIColor colorWithRed:0.70 green:0.70 blue:0.70 alpha:1.0];
+    cell.detailTextLabel.font = [UIFont fontWithName:@"Menlo-Regular" size:11];
+    cell.detailTextLabel.lineBreakMode = NSLineBreakByTruncatingMiddle;
+    cell.backgroundColor = [UIColor clearColor];
+    cell.selectedBackgroundView = [UIView new];
+    cell.selectedBackgroundView.backgroundColor = [UIColor colorWithWhite:0 alpha:0.2];
+  }
+
+  cell.textLabel.text = stackFrame.methodName ?: @"(unnamed method)";
+  if (stackFrame.file) {
+    cell.detailTextLabel.text = [self formatFrameSource:stackFrame];
+  } else {
+    cell.detailTextLabel.text = @"";
+  }
+  cell.textLabel.textColor = stackFrame.collapse ? [UIColor lightGrayColor] : [UIColor whiteColor];
+  cell.detailTextLabel.textColor = stackFrame.collapse ? [UIColor colorWithRed:0.50 green:0.50 blue:0.50 alpha:1.0]
+                                                       : [UIColor colorWithRed:0.70 green:0.70 blue:0.70 alpha:1.0];
+  return cell;
+}
+#else // [macOS
+- (NSTableCellView *)reuseCell:(NSTableCellView *)cell forStackFrame:(RCTJSStackFrame *)stackFrame
+{
+  if (!cell) {
+    cell = [[NSTableCellView alloc] initWithFrame:NSZeroRect];
+
+    NSTextField *label = [[NSTextField alloc] initWithFrame:NSZeroRect];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.backgroundColor = [NSColor clearColor];
+    label.bezeled = NO;
+    label.editable = NO;
+
+    label.maximumNumberOfLines = 2;
+
+    [cell addSubview:label];
+    cell.textField = label;
+
+    [NSLayoutConstraint activateConstraints:@[
+      [[label leadingAnchor] constraintEqualToAnchor:[cell leadingAnchor] constant:5],
+      [[label topAnchor] constraintEqualToAnchor:[cell topAnchor]],
+      [[label trailingAnchor] constraintEqualToAnchor:[cell trailingAnchor] constant:-5],
+      [[label bottomAnchor] constraintEqualToAnchor:[cell bottomAnchor]],
+    ]];
+  }
+
+  NSString *text = stackFrame.methodName ?: @"(unnamed method)";
+
+  NSMutableParagraphStyle *textParagraphStyle = [NSMutableParagraphStyle new];
+  textParagraphStyle.lineBreakMode = NSLineBreakByCharWrapping;
+
+  NSDictionary<NSString *, id> *textAttributes = @{
+    NSForegroundColorAttributeName : stackFrame.collapse ? [NSColor lightGrayColor] : [NSColor whiteColor],
+    NSFontAttributeName : [NSFont fontWithName:@"Menlo-Regular" size:14],
+    NSParagraphStyleAttributeName : textParagraphStyle,
+  };
+
+  NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:text attributes:textAttributes];
+
+
+  NSMutableAttributedString *title = [attributedText mutableCopy];
+
+  // NSTableCellView doesn't contain a subtitle text field. Rather than define our own custom row view,
+  // let's append the detail text with a new line if it is needed.
+  if (stackFrame.file) {
+    cell.textField.maximumNumberOfLines = 3;
+
+    NSString *detailText = [self formatFrameSource:stackFrame];
+
+    NSMutableParagraphStyle *detailTextParagraphStyle = [NSMutableParagraphStyle new];
+    detailTextParagraphStyle.lineBreakMode = NSLineBreakByTruncatingMiddle;
+
+    NSDictionary<NSString *, id> *detailTextAttributes = @{
+      NSForegroundColorAttributeName : stackFrame.collapse ?
+        [NSColor colorWithRed:0.50 green:0.50 blue:0.50 alpha:1.0] :
+        [NSColor colorWithRed:0.70 green:0.70 blue:0.70 alpha:1.0],
+      NSFontAttributeName : [NSFont fontWithName:@"Menlo-Regular" size:11],
+      NSParagraphStyleAttributeName : detailTextParagraphStyle,
+    };
+    NSAttributedString *attributedDetailText = [[NSAttributedString alloc] initWithString:detailText attributes:detailTextAttributes];
+
+    [title appendAttributedString:[[NSAttributedString alloc] initWithString:@"\n"]];
+    [title appendAttributedString:attributedDetailText];
+  }
+
+  cell.textField.attributedStringValue = title;
+
+  return cell;
+}
+#endif // macOS]
+
+#if !TARGET_OS_OSX // [macOS]
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
+#else // [macOS
+- (CGFloat)tableView:(NSTableView *)tableView heightOfRow:(NSInteger)row
+#endif // macOS]
+{
+#if !TARGET_OS_OSX // [macOS]
+  if (indexPath.section == 0) {
+#else // [macOS
+  if (row == 0) {
+#endif // macOS]
+    NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
+    paragraphStyle.lineBreakMode = NSLineBreakByWordWrapping;
+
+    NSDictionary *attributes =
+#if !TARGET_OS_OSX // [macOS]
+        @{NSFontAttributeName : [UIFont boldSystemFontOfSize:16], NSParagraphStyleAttributeName : paragraphStyle};
+#else // [macOS
+        @{NSFontAttributeName : [NSFont boldSystemFontOfSize:16], NSParagraphStyleAttributeName : paragraphStyle};
+#endif // macOS]
+    CGRect boundingRect =
+        [_lastErrorMessage boundingRectWithSize:CGSizeMake(tableView.frame.size.width - 30, CGFLOAT_MAX)
+                                        options:NSStringDrawingUsesLineFragmentOrigin
+                                     attributes:attributes
+                                        context:nil];
+    return ceil(boundingRect.size.height) + 40;
+  } else {
+    return 50;
+  }
+}
+
+#if !TARGET_OS_OSX // [macOS]
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+  if (indexPath.section == 1) {
+    NSUInteger row = indexPath.row;
+    RCTJSStackFrame *stackFrame = _lastStackTrace[row];
+    [_actionDelegate redBoxController:self openStackFrameInEditor:stackFrame];
+  }
+  [tableView deselectRowAtIndexPath:indexPath animated:YES];
+}
+#else // [macOS
+- (BOOL)tableView:(__unused NSTableView *)tableView shouldSelectRow:(__unused NSInteger)row
+{
+  if (row != 0) {
+    NSUInteger index = row - 1;
+    RCTJSStackFrame *stackFrame = _lastStackTrace[index];
+    [_actionDelegate redBoxController:self openStackFrameInEditor:stackFrame];
+  }
+  return NO;
+}
+#endif // macOS]
+
+#pragma mark - Key commands
+
+#if !TARGET_OS_OSX // [macOS]
+- (NSArray<UIKeyCommand *> *)keyCommands
+{
+  // NOTE: We could use RCTKeyCommands for this, but since
+  // we control this window, we can use the standard, non-hacky
+  // mechanism instead
+
+  return @[
+    // Dismiss red box
+    [UIKeyCommand keyCommandWithInput:UIKeyInputEscape modifierFlags:0 action:@selector(dismiss)],
+
+    // Reload
+    [UIKeyCommand keyCommandWithInput:@"r" modifierFlags:UIKeyModifierCommand action:@selector(reload)],
+
+    // Copy = Cmd-Option C since Cmd-C in the simulator copies the pasteboard from
+    // the simulator to the desktop pasteboard.
+    [UIKeyCommand keyCommandWithInput:@"c"
+                        modifierFlags:UIKeyModifierCommand | UIKeyModifierAlternate
+                               action:@selector(copyStack)],
+
+    // Extra data
+    [UIKeyCommand keyCommandWithInput:@"e"
+                        modifierFlags:UIKeyModifierCommand
+                               action:@selector(showExtraDataViewController)]
+  ];
+}
+
+- (BOOL)canBecomeFirstResponder
+{
+  return YES;
+}
+#endif // [macOS]
+
+@end
+
+#endif

--- a/packages/react-native/React/CoreModules/RCTRedBoxHMRClient+Internal.h
+++ b/packages/react-native/React/CoreModules/RCTRedBoxHMRClient+Internal.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <React/RCTDefines.h>
+
+#if RCT_DEV_MENU
+
+/**
+ * Minimal native HMR client that connects to Metro's /hot WebSocket endpoint
+ * while RedBox 2.0 is displayed. When Metro detects a file change
+ * (update-start), this client triggers a reload so the user's fix is picked up
+ * automatically — even when the JS runtime has no active HMR connection.
+ */
+@interface RCTRedBoxHMRClient : NSObject <NSURLSessionWebSocketDelegate>
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL onFileChange:(void (^)(void))onFileChange;
+- (void)start;
+- (void)stop;
+@end
+
+#endif

--- a/packages/react-native/React/CoreModules/RCTRedBoxHMRClient.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBoxHMRClient.mm
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTRedBoxHMRClient+Internal.h"
+
+#if RCT_DEV_MENU
+
+@implementation RCTRedBoxHMRClient {
+  NSURL *_bundleURL;
+  NSURLSessionWebSocketTask *_webSocketTask;
+  NSURLSession *_session;
+  void (^_onFileChange)(void);
+  BOOL _stopped;
+}
+
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL onFileChange:(void (^)(void))onFileChange
+{
+  if (self = [super init]) {
+    _bundleURL = bundleURL;
+    _onFileChange = [onFileChange copy];
+  }
+  return self;
+}
+
+- (void)start
+{
+  if (![_bundleURL.scheme hasPrefix:@"http"]) {
+    return;
+  }
+
+  NSURLComponents *components = [[NSURLComponents alloc] initWithURL:_bundleURL resolvingAgainstBaseURL:NO];
+  components.scheme = [_bundleURL.scheme isEqualToString:@"https"] ? @"wss" : @"ws";
+  components.path = @"/hot";
+  components.query = nil;
+  components.fragment = nil;
+  NSURL *wsURL = components.URL;
+  if (!wsURL) {
+    return;
+  }
+
+  _session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
+                                           delegate:self
+                                      delegateQueue:nil];
+  _webSocketTask = [_session webSocketTaskWithURL:wsURL];
+  [_webSocketTask resume];
+}
+
+- (void)stop
+{
+  _stopped = YES;
+  _onFileChange = nil;
+  [_webSocketTask cancel];
+  _webSocketTask = nil;
+  [_session invalidateAndCancel];
+  _session = nil;
+}
+
+- (void)URLSession:(__unused NSURLSession *)session
+          webSocketTask:(__unused NSURLSessionWebSocketTask *)webSocketTask
+    didOpenWithProtocol:(__unused NSString *)protocol
+{
+  NSDictionary *registration = @{
+    @"type" : @"register-entrypoints",
+    @"entryPoints" : @[ _bundleURL.absoluteString ],
+  };
+  NSData *json = [NSJSONSerialization dataWithJSONObject:registration options:0 error:nil];
+  NSURLSessionWebSocketMessage *msg = [[NSURLSessionWebSocketMessage alloc]
+      initWithString:[[NSString alloc] initWithData:json encoding:NSUTF8StringEncoding]];
+  [_webSocketTask sendMessage:msg
+            completionHandler:^(__unused NSError *error){
+            }];
+  [self _listenForNextMessage];
+}
+
+- (void)_listenForNextMessage
+{
+  if (_stopped) {
+    return;
+  }
+  __weak __typeof(self) weakSelf = self;
+  [_webSocketTask receiveMessageWithCompletionHandler:^(NSURLSessionWebSocketMessage *message, NSError *error) {
+    if (error || !message) {
+      return;
+    }
+    [weakSelf _handleMessage:message];
+    [weakSelf _listenForNextMessage];
+  }];
+}
+
+- (void)_handleMessage:(NSURLSessionWebSocketMessage *)message
+{
+  if (message.type != NSURLSessionWebSocketMessageTypeString || _stopped) {
+    return;
+  }
+  NSData *data = [message.string dataUsingEncoding:NSUTF8StringEncoding];
+  NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+  if ([json[@"type"] isEqualToString:@"update-start"]) {
+    // Ignore the initial update that fires when the client first registers.
+    // Only react to subsequent file changes.
+    NSDictionary *body = json[@"body"];
+    if ([body isKindOfClass:[NSDictionary class]] && [body[@"isInitialUpdate"] boolValue]) {
+      return;
+    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (self->_onFileChange) {
+        self->_onFileChange();
+      }
+    });
+  }
+}
+
+- (void)URLSession:(__unused NSURLSession *)session
+       webSocketTask:(__unused NSURLSessionWebSocketTask *)task
+    didCloseWithCode:(__unused NSURLSessionWebSocketCloseCode)closeCode
+              reason:(__unused NSData *)reason
+{
+}
+
+@end
+
+#endif

--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -55,6 +55,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/CoreModulesHeaders", version
   s.dependency "React-RCTImage", version
   s.dependency "React-jsi", version
+  add_dependency(s, "React-featureflags")
   s.dependency 'React-RCTBlob'
   add_dependency(s, "React-debug")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<156d4f5f35037184b6fc61ff1d856028>>
+ * @generated SignedSource<<fb10ba0f792d84448e791ca6b744e6f3>>
  */
 
 /**
@@ -425,6 +425,18 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun preventShadowTreeCommitExhaustion(): Boolean = accessor.preventShadowTreeCommitExhaustion()
+
+  /**
+   * Use the redesigned RedBox error overlay on Android, styled to match the LogBox visual language.
+   */
+  @JvmStatic
+  public fun redBoxV2Android(): Boolean = accessor.redBoxV2Android()
+
+  /**
+   * Use the redesigned RedBox error overlay on iOS, styled to match the LogBox visual language.
+   */
+  @JvmStatic
+  public fun redBoxV2IOS(): Boolean = accessor.redBoxV2IOS()
 
   /**
    * Function used to enable / disable Pressibility from using W3C Pointer Events for its hover callbacks

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0875d5e54d884a26d37bb4eb2acc57d5>>
+ * @generated SignedSource<<a9911f49da9cbc9200c981e10270d4c5>>
  */
 
 /**
@@ -86,6 +86,8 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var perfMonitorV2EnabledCache: Boolean? = null
   private var preparedTextCacheSizeCache: Double? = null
   private var preventShadowTreeCommitExhaustionCache: Boolean? = null
+  private var redBoxV2AndroidCache: Boolean? = null
+  private var redBoxV2IOSCache: Boolean? = null
   private var shouldPressibilityUseW3CPointerEventsForHoverCache: Boolean? = null
   private var shouldTriggerResponderTransferOnScrollAndroidCache: Boolean? = null
   private var skipActivityIdentityAssertionOnHostPauseCache: Boolean? = null
@@ -696,6 +698,24 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.preventShadowTreeCommitExhaustion()
       preventShadowTreeCommitExhaustionCache = cached
+    }
+    return cached
+  }
+
+  override fun redBoxV2Android(): Boolean {
+    var cached = redBoxV2AndroidCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.redBoxV2Android()
+      redBoxV2AndroidCache = cached
+    }
+    return cached
+  }
+
+  override fun redBoxV2IOS(): Boolean {
+    var cached = redBoxV2IOSCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.redBoxV2IOS()
+      redBoxV2IOSCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<948a9beebe2ff00791a03455eb774eee>>
+ * @generated SignedSource<<0c49d0a7595b0b5cbd064e4fab4e83fd>>
  */
 
 /**
@@ -159,6 +159,10 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun preparedTextCacheSize(): Double
 
   @DoNotStrip @JvmStatic public external fun preventShadowTreeCommitExhaustion(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun redBoxV2Android(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun redBoxV2IOS(): Boolean
 
   @DoNotStrip @JvmStatic public external fun shouldPressibilityUseW3CPointerEventsForHover(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<89c61520177334f93c65ff92c2fc74a6>>
+ * @generated SignedSource<<f073ef33f654cb5602407126a036c9b5>>
  */
 
 /**
@@ -89,7 +89,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enableImmediateUpdateModeForContentOffsetChanges(): Boolean = false
 
-  override fun enableImperativeFocus(): Boolean = false
+  override fun enableImperativeFocus(): Boolean = true
 
   override fun enableInteropViewManagerClassLookUpOptimizationIOS(): Boolean = false
 
@@ -154,6 +154,10 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun preparedTextCacheSize(): Double = 200.0
 
   override fun preventShadowTreeCommitExhaustion(): Boolean = false
+
+  override fun redBoxV2Android(): Boolean = false
+
+  override fun redBoxV2IOS(): Boolean = false
 
   override fun shouldPressibilityUseW3CPointerEventsForHover(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<669708c311abe9ffc8f7783219e2baad>>
+ * @generated SignedSource<<06283f7293ad5a6ef6fca7e27cbb96f7>>
  */
 
 /**
@@ -90,6 +90,8 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var perfMonitorV2EnabledCache: Boolean? = null
   private var preparedTextCacheSizeCache: Double? = null
   private var preventShadowTreeCommitExhaustionCache: Boolean? = null
+  private var redBoxV2AndroidCache: Boolean? = null
+  private var redBoxV2IOSCache: Boolean? = null
   private var shouldPressibilityUseW3CPointerEventsForHoverCache: Boolean? = null
   private var shouldTriggerResponderTransferOnScrollAndroidCache: Boolean? = null
   private var skipActivityIdentityAssertionOnHostPauseCache: Boolean? = null
@@ -766,6 +768,26 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.preventShadowTreeCommitExhaustion()
       accessedFeatureFlags.add("preventShadowTreeCommitExhaustion")
       preventShadowTreeCommitExhaustionCache = cached
+    }
+    return cached
+  }
+
+  override fun redBoxV2Android(): Boolean {
+    var cached = redBoxV2AndroidCache
+    if (cached == null) {
+      cached = currentProvider.redBoxV2Android()
+      accessedFeatureFlags.add("redBoxV2Android")
+      redBoxV2AndroidCache = cached
+    }
+    return cached
+  }
+
+  override fun redBoxV2IOS(): Boolean {
+    var cached = redBoxV2IOSCache
+    if (cached == null) {
+      cached = currentProvider.redBoxV2IOS()
+      accessedFeatureFlags.add("redBoxV2IOS")
+      redBoxV2IOSCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<db06b64a8d1b9ab99b368fea41185d62>>
+ * @generated SignedSource<<ac5df245d85541b8ee07225d53115879>>
  */
 
 /**
@@ -154,6 +154,10 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun preparedTextCacheSize(): Double
 
   @DoNotStrip public fun preventShadowTreeCommitExhaustion(): Boolean
+
+  @DoNotStrip public fun redBoxV2Android(): Boolean
+
+  @DoNotStrip public fun redBoxV2IOS(): Boolean
 
   @DoNotStrip public fun shouldPressibilityUseW3CPointerEventsForHover(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0b95d68522d63d51d3e524aeecff246a>>
+ * @generated SignedSource<<2960f980bfbeed928a109e4e596a93ec>>
  */
 
 /**
@@ -432,6 +432,18 @@ class ReactNativeFeatureFlagsJavaProvider
   bool preventShadowTreeCommitExhaustion() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("preventShadowTreeCommitExhaustion");
+    return method(javaProvider_);
+  }
+
+  bool redBoxV2Android() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("redBoxV2Android");
+    return method(javaProvider_);
+  }
+
+  bool redBoxV2IOS() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("redBoxV2IOS");
     return method(javaProvider_);
   }
 
@@ -883,6 +895,16 @@ bool JReactNativeFeatureFlagsCxxInterop::preventShadowTreeCommitExhaustion(
   return ReactNativeFeatureFlags::preventShadowTreeCommitExhaustion();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::redBoxV2Android(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::redBoxV2Android();
+}
+
+bool JReactNativeFeatureFlagsCxxInterop::redBoxV2IOS(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::redBoxV2IOS();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::shouldPressibilityUseW3CPointerEventsForHover(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::shouldPressibilityUseW3CPointerEventsForHover();
@@ -1207,6 +1229,12 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "preventShadowTreeCommitExhaustion",
         JReactNativeFeatureFlagsCxxInterop::preventShadowTreeCommitExhaustion),
+      makeNativeMethod(
+        "redBoxV2Android",
+        JReactNativeFeatureFlagsCxxInterop::redBoxV2Android),
+      makeNativeMethod(
+        "redBoxV2IOS",
+        JReactNativeFeatureFlagsCxxInterop::redBoxV2IOS),
       makeNativeMethod(
         "shouldPressibilityUseW3CPointerEventsForHover",
         JReactNativeFeatureFlagsCxxInterop::shouldPressibilityUseW3CPointerEventsForHover),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6b7e2af51ba9d64ae4e474dfa104a7c3>>
+ * @generated SignedSource<<2b5ee310ae035b946a9c1499cb6795f9>>
  */
 
 /**
@@ -226,6 +226,12 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool preventShadowTreeCommitExhaustion(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool redBoxV2Android(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool redBoxV2IOS(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool shouldPressibilityUseW3CPointerEventsForHover(

--- a/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
@@ -9,7 +9,8 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_debug_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_debug OBJECT ${react_debug_SRC})
+file(GLOB react_debug_redbox_SRC CONFIGURE_DEPENDS redbox/*.cpp)
+add_library(react_debug OBJECT ${react_debug_SRC} ${react_debug_redbox_SRC})
 
 target_include_directories(react_debug PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCommon/react/debug/React-debug.podspec
+++ b/packages/react-native/ReactCommon/react/debug/React-debug.podspec
@@ -25,10 +25,16 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = podspec_sources("**/*.{cpp,h}", "**/*.h")
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = "react/debug"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "DEFINES_MODULE" => "YES" }
 
   resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: "React_debug")
+
+  s.subspec "redbox" do |ss|
+    ss.source_files         = podspec_sources("redbox/*.{cpp,h}", "redbox/*.h")
+    ss.exclude_files        = "redbox/tests/**/*.{cpp,h}"
+    ss.header_dir           = "react/debug/redbox"
+  end
 end

--- a/packages/react-native/ReactCommon/react/debug/redbox/AnsiParser.cpp
+++ b/packages/react-native/ReactCommon/react/debug/redbox/AnsiParser.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "AnsiParser.h"
+
+#include <optional>
+
+#include <regex> // NOLINT(facebook-hte-BadInclude-regex)
+
+// @lint-ignore-every CLANGTIDY facebook-hte-StdRegexIsAwful
+namespace facebook::react::unstable_redbox {
+
+namespace {
+
+// Afterglow theme colors (matching AnsiHighlight.js)
+std::optional<AnsiColor> ansiColor(int code) {
+  switch (code) {
+    case 30:
+      return AnsiColor{.r = 27, .g = 27, .b = 27}; // black
+    case 31:
+      return AnsiColor{.r = 187, .g = 86, .b = 83}; // red
+    case 32:
+      return AnsiColor{.r = 144, .g = 157, .b = 98}; // green
+    case 33:
+      return AnsiColor{.r = 234, .g = 193, .b = 121}; // yellow
+    case 34:
+      return AnsiColor{.r = 125, .g = 169, .b = 199}; // blue
+    case 35:
+      return AnsiColor{.r = 176, .g = 101, .b = 151}; // magenta
+    case 36:
+      return AnsiColor{.r = 140, .g = 220, .b = 216}; // cyan
+    case 37:
+      return std::nullopt; // white = default
+    case 90:
+      return AnsiColor{.r = 98, .g = 98, .b = 98}; // bright black
+    case 91:
+      return AnsiColor{.r = 187, .g = 86, .b = 83}; // bright red
+    case 92:
+      return AnsiColor{.r = 144, .g = 157, .b = 98}; // bright green
+    case 93:
+      return AnsiColor{.r = 234, .g = 193, .b = 121}; // bright yellow
+    case 94:
+      return AnsiColor{.r = 125, .g = 169, .b = 199}; // bright blue
+    case 95:
+      return AnsiColor{.r = 176, .g = 101, .b = 151}; // bright magenta
+    case 96:
+      return AnsiColor{.r = 140, .g = 220, .b = 216}; // bright cyan
+    case 97:
+      return AnsiColor{.r = 247, .g = 247, .b = 247}; // bright white
+    default:
+      return std::nullopt;
+  }
+}
+
+const std::regex& ansiRegex() {
+  static const std::regex re(R"(\x1b\[([0-9;]*)m)");
+  return re;
+}
+
+int parseSgrCode(const std::string& params, size_t& pos) {
+  size_t next = params.find(';', pos);
+  if (next == std::string::npos) {
+    next = params.size();
+  }
+  int code = 0;
+  for (size_t i = pos; i < next; ++i) {
+    code = code * 10 + (params[i] - '0');
+  }
+  pos = next + 1;
+  return code;
+}
+
+} // namespace
+
+std::vector<AnsiSpan> parseAnsi(const std::string& text) {
+  std::vector<AnsiSpan> spans;
+  std::optional<AnsiColor> currentFg;
+  std::optional<AnsiColor> currentBg;
+  auto it = std::sregex_iterator(text.begin(), text.end(), ansiRegex());
+  auto end = std::sregex_iterator();
+  size_t lastEnd = 0;
+
+  for (; it != end; ++it) {
+    const auto& match = *it;
+    auto matchStart = static_cast<size_t>(match.position());
+
+    if (matchStart > lastEnd) {
+      spans.push_back(
+          AnsiSpan{
+              .text = text.substr(lastEnd, matchStart - lastEnd),
+              .foregroundColor = currentFg,
+              .backgroundColor = currentBg});
+    }
+    lastEnd = matchStart + match.length();
+
+    std::string params = match[1].str();
+    // ESC[m (no params) is equivalent to ESC[0m (reset all attributes)
+    if (params.empty()) {
+      currentFg = std::nullopt;
+      currentBg = std::nullopt;
+    }
+    size_t pos = 0;
+    while (pos < params.size()) {
+      int code = parseSgrCode(params, pos);
+      if (code == 0) {
+        currentFg = std::nullopt;
+        currentBg = std::nullopt;
+      } else if ((code >= 30 && code <= 37) || (code >= 90 && code <= 97)) {
+        currentFg = ansiColor(code);
+      } else if ((code >= 40 && code <= 47) || (code >= 100 && code <= 107)) {
+        currentBg = ansiColor(code - 10);
+      } else if (code == 39) {
+        currentFg = std::nullopt;
+      } else if (code == 49) {
+        currentBg = std::nullopt;
+      }
+    }
+  }
+
+  if (lastEnd < text.size()) {
+    spans.push_back(
+        AnsiSpan{
+            .text = text.substr(lastEnd),
+            .foregroundColor = currentFg,
+            .backgroundColor = currentBg});
+  }
+
+  return spans;
+}
+
+std::string stripAnsi(const std::string& text) {
+  return std::regex_replace(text, ansiRegex(), "");
+}
+
+} // namespace facebook::react::unstable_redbox

--- a/packages/react-native/ReactCommon/react/debug/redbox/AnsiParser.h
+++ b/packages/react-native/ReactCommon/react/debug/redbox/AnsiParser.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace facebook::react::unstable_redbox {
+
+struct AnsiColor {
+  uint8_t r, g, b;
+};
+
+struct AnsiSpan {
+  std::string text;
+  std::optional<AnsiColor> foregroundColor;
+  std::optional<AnsiColor> backgroundColor;
+};
+
+/**
+ * Parse ANSI escape sequences in text and produce a list of styled spans.
+ * Uses the Afterglow color theme (matching LogBox's AnsiHighlight.js).
+ */
+std::vector<AnsiSpan> parseAnsi(const std::string &text);
+
+/** Strip all ANSI escape sequences from text. */
+std::string stripAnsi(const std::string &text);
+
+} // namespace facebook::react::unstable_redbox

--- a/packages/react-native/ReactCommon/react/debug/redbox/JscSafeUrl.cpp
+++ b/packages/react-native/ReactCommon/react/debug/redbox/JscSafeUrl.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "JscSafeUrl.h"
+
+#include <cassert>
+#include <regex> // NOLINT(facebook-hte-BadInclude-regex)
+#include <stdexcept>
+#include <string_view>
+
+// @lint-ignore-every CLANGTIDY facebook-hte-StdRegexIsAwful
+
+namespace facebook::react::unstable_redbox {
+
+namespace {
+
+// We use regex-based URL parsing as defined in RFC 3986 because it's easier to
+// determine whether the input is a complete URI, a path-absolute or a
+// path-rootless (as defined in the spec), and be as faithful to the input as
+// possible. This will match any string, and does not imply validity.
+//
+// https://www.rfc-editor.org/rfc/rfc3986#appendix-B
+const std::regex& uriRegex() {
+  static const std::regex re(
+      R"(^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?)");
+  return re;
+}
+
+struct ParsedUri {
+  std::string_view schemeAndAuthority;
+  std::string_view path;
+  bool hasQueryPart = false;
+  std::string_view queryWithoutQuestionMark;
+  std::string_view fragmentWithHash;
+};
+
+ParsedUri rfc3986Parse(std::string_view url) {
+  std::cmatch match;
+  if (!std::regex_match(
+          url.data(), url.data() + url.size(), match, uriRegex())) {
+    throw std::runtime_error("Unexpected error - failed to regex-match URL");
+  }
+
+  // match[1] = scheme with colon (e.g. "http:")
+  // match[3] = authority with slashes (e.g. "//host")
+  // match[5] = path
+  // match[6] = query with question mark (e.g. "?key=val")
+  // match[7] = query without question mark
+  // match[8] = fragment with hash (e.g. "#frag")
+
+  auto viewOf = [&](int group) -> std::string_view {
+    if (!match[group].matched) {
+      return {};
+    }
+    return {match[group].first, static_cast<size_t>(match[group].length())};
+  };
+
+  // schemeAndAuthority = (match[1] || "") + (match[3] || "")
+  // These are contiguous when both present, but may be individually absent.
+  std::string_view schemeAndAuthority;
+  if (match[1].matched && match[3].matched) {
+    assert(match[1].second == match[3].first);
+    schemeAndAuthority = {
+        match[1].first, static_cast<size_t>(match[3].second - match[1].first)};
+  } else if (match[1].matched) {
+    schemeAndAuthority = viewOf(1);
+  } else if (match[3].matched) {
+    schemeAndAuthority = viewOf(3);
+  }
+
+  return ParsedUri{
+      .schemeAndAuthority = schemeAndAuthority,
+      .path = viewOf(5),
+      .hasQueryPart = match[6].matched,
+      .queryWithoutQuestionMark = viewOf(7),
+      .fragmentWithHash = viewOf(8),
+  };
+}
+
+} // namespace
+
+bool isJscSafeUrl(std::string_view url) {
+  return !rfc3986Parse(url).hasQueryPart;
+}
+
+std::string toNormalUrl(std::string url) {
+  auto parsed = rfc3986Parse(url);
+  auto markerPos = parsed.path.find("//&");
+  if (markerPos == std::string_view::npos) {
+    return url;
+  }
+
+  // path before //&, then ?, then path after //&
+  std::string_view pathBefore = parsed.path.substr(0, markerPos);
+  std::string_view pathAfter = parsed.path.substr(markerPos + 3);
+
+  // We don't expect JSC urls to also have query strings, but interpret
+  // liberally and append them.
+  bool hasExistingQuery = !parsed.queryWithoutQuestionMark.empty();
+
+  // Likewise, JSC URLs will usually have their fragments stripped, but
+  // preserve if we find one.
+  size_t totalSize = parsed.schemeAndAuthority.size() + pathBefore.size() +
+      1 /* ? */ + pathAfter.size() +
+      (hasExistingQuery ? 1 + parsed.queryWithoutQuestionMark.size() : 0) +
+      parsed.fragmentWithHash.size();
+
+  std::string result;
+  result.reserve(totalSize);
+  result += parsed.schemeAndAuthority;
+  result += pathBefore;
+  result += '?';
+  result += pathAfter;
+  if (hasExistingQuery) {
+    result += '&';
+    result += parsed.queryWithoutQuestionMark;
+  }
+  result += parsed.fragmentWithHash;
+  assert(result.size() == totalSize);
+  return result;
+}
+
+std::string toJscSafeUrl(std::string url) {
+  if (!rfc3986Parse(url).hasQueryPart) {
+    return url;
+  }
+  url = toNormalUrl(std::move(url));
+  auto parsed = rfc3986Parse(url);
+  if (!parsed.queryWithoutQuestionMark.empty() &&
+      (parsed.path.empty() || parsed.path == "/")) {
+    throw std::invalid_argument(
+        "The given URL \"" + url +
+        "\" has an empty path and cannot be converted to a JSC-safe format.");
+  }
+
+  // Query strings may contain '?' (e.g. in key or value names) - these
+  // must be percent-encoded to form a valid path, and not be stripped.
+  // Count them first so we can preallocate exactly.
+  bool hasQuery = !parsed.queryWithoutQuestionMark.empty();
+  size_t questionMarks = 0;
+  if (hasQuery) {
+    for (char c : parsed.queryWithoutQuestionMark) {
+      if (c == '?') {
+        questionMarks++;
+      }
+    }
+  }
+
+  // Each '?' becomes "%3F" (+2 bytes), plus "//&" delimiter (+3 bytes)
+  size_t totalSize = parsed.schemeAndAuthority.size() + parsed.path.size() +
+      (hasQuery ? 3 + parsed.queryWithoutQuestionMark.size() + questionMarks * 2
+                : 0) +
+      // We expect JSC to strip this - we don't handle fragments for now.
+      parsed.fragmentWithHash.size();
+
+  std::string result;
+  result.reserve(totalSize);
+  result += parsed.schemeAndAuthority;
+  result += parsed.path;
+  if (hasQuery) {
+    result += "//&";
+    for (char c : parsed.queryWithoutQuestionMark) {
+      if (c == '?') {
+        result += "%3F";
+      } else {
+        result += c;
+      }
+    }
+  }
+  result += parsed.fragmentWithHash;
+  assert(result.size() == totalSize);
+  return result;
+}
+
+} // namespace facebook::react::unstable_redbox

--- a/packages/react-native/ReactCommon/react/debug/redbox/JscSafeUrl.h
+++ b/packages/react-native/ReactCommon/react/debug/redbox/JscSafeUrl.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace facebook::react::unstable_redbox {
+
+/**
+ * These functions are for handling of query-string free URLs, necessitated
+ * by query string stripping of URLs in JavaScriptCore stack traces
+ * introduced in iOS 16.4. This is a direct port of https://www.npmjs.com/package/jsc-safe-url.
+ *
+ * See https://github.com/facebook/react-native/issues/36794 for context.
+ */
+
+bool isJscSafeUrl(std::string_view url);
+std::string toNormalUrl(std::string url);
+std::string toJscSafeUrl(std::string url);
+
+} // namespace facebook::react::unstable_redbox

--- a/packages/react-native/ReactCommon/react/debug/redbox/RedBoxErrorParser.cpp
+++ b/packages/react-native/ReactCommon/react/debug/redbox/RedBoxErrorParser.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RedBoxErrorParser.h"
+
+#include <regex> // NOLINT(facebook-hte-BadInclude-regex)
+#include <unordered_set>
+
+// @lint-ignore-every CLANGTIDY facebook-hte-StdRegexIsAwful
+namespace facebook::react::unstable_redbox {
+
+namespace {
+
+const std::regex& metroErrorRegex() {
+  static const std::regex re(
+      R"(^(?:InternalError Metro has encountered an error:) (.*): (.*) \((\d+):(\d+)\)\n\n([\s\S]+))");
+  return re;
+}
+
+const std::regex& babelTransformErrorRegex() {
+  static const std::regex re(
+      R"(^(?:TransformError )?(?:SyntaxError: |ReferenceError: )(.*): (.*) \((\d+):(\d+)\)\n\n([\s\S]+))");
+  return re;
+}
+
+const std::regex& bundleLoadErrorRegex() {
+  static const std::regex re(R"(^(\w+) in (\S+): (.+) \((\d+):(\d+)\))");
+  return re;
+}
+
+const std::regex& babelCodeFrameErrorRegex() {
+  static const std::regex re(
+      R"(^(?:TransformError )?(?:.*):? (?:.*?)(\/.*): ([\s\S]+?)\n([ >]{2}[\d\s]+ \|[\s\S]+|\x1b[\s\S]+))");
+  return re;
+}
+
+bool startsWithTransformError(const std::string& msg) {
+  return msg.rfind("TransformError ", 0) == 0;
+}
+
+const std::unordered_set<std::string>& knownBundleLoadErrorTypes() {
+  static const std::unordered_set<std::string> types{
+      "SyntaxError", "ReferenceError", "TypeError", "UnableToResolveError"};
+  return types;
+}
+
+} // namespace
+
+ParsedError parseErrorMessage(
+    const std::string& message,
+    const std::string& name,
+    const std::string& componentStack,
+    bool isFatal) {
+  std::smatch match;
+
+  if (message.empty()) {
+    return ParsedError{
+        .title = isFatal ? "Uncaught Error" : "Error",
+        .message = "",
+        .codeFrame = std::nullopt,
+        .isCompileError = false,
+    };
+  }
+
+  // 1. Metro internal error
+  if (std::regex_search(message, match, metroErrorRegex())) {
+    return ParsedError{
+        .title = match[1].str().empty() ? "Metro Error" : match[1].str(),
+        .message = match[2].str(),
+        .codeFrame =
+            CodeFrame{
+                .content = match[5].str(),
+                .fileName = "",
+                .row = std::stoi(match[3].str()),
+                .column = std::stoi(match[4].str()),
+            },
+        .isCompileError = true,
+    };
+  }
+
+  // 2. Babel transform error
+  if (std::regex_search(message, match, babelTransformErrorRegex())) {
+    return ParsedError{
+        .title = "Syntax Error",
+        .message = match[2].str(),
+        .codeFrame =
+            CodeFrame{
+                .content = match[5].str(),
+                .fileName = match[1].str(),
+                .row = std::stoi(match[3].str()),
+                .column = std::stoi(match[4].str()),
+            },
+        .isCompileError = true,
+    };
+  }
+
+  // 3. Bundle loading error: "ErrorType in /path: message (line:col)"
+  if (std::regex_search(message, match, bundleLoadErrorRegex())) {
+    const auto& errorType = match[1].str();
+    if (knownBundleLoadErrorTypes().count(errorType) > 0) {
+      std::string title = errorType == "UnableToResolveError"
+          ? "Module Not Found"
+          : "Syntax Error";
+      std::optional<std::string> codeFrameContent;
+      auto newlinePos = message.find('\n');
+      if (newlinePos != std::string::npos) {
+        codeFrameContent = message.substr(newlinePos + 1);
+      }
+      return ParsedError{
+          .title = title,
+          .message = match[3].str(),
+          .codeFrame =
+              CodeFrame{
+                  .content = codeFrameContent.value_or(""),
+                  .fileName = match[2].str(),
+                  .row = std::stoi(match[4].str()),
+                  .column = std::stoi(match[5].str()),
+              },
+          .isCompileError = true,
+      };
+    }
+  }
+
+  // 4. Babel code frame error
+  if (std::regex_search(message, match, babelCodeFrameErrorRegex())) {
+    return ParsedError{
+        .title = "Syntax Error",
+        .message = match[2].str(),
+        .codeFrame =
+            CodeFrame{
+                .content = match[3].str(),
+                .fileName = match[1].str(),
+            },
+        .isCompileError = true,
+    };
+  }
+
+  // 5. Generic transform error (no code frame)
+  if (startsWithTransformError(message)) {
+    return ParsedError{
+        .title = "Syntax Error",
+        .message = message,
+        .codeFrame = std::nullopt,
+        .isCompileError = true,
+    };
+  }
+
+  // 6. Determine title from context (matching LogBoxInspectorHeader title map)
+  std::string title;
+  if (!name.empty()) {
+    title = name;
+  } else if (!componentStack.empty()) {
+    title = "Render Error";
+  } else if (isFatal) {
+    title = "Uncaught Error";
+  } else {
+    title = "Error";
+  }
+  return ParsedError{
+      .title = title,
+      .message = message,
+      .codeFrame = std::nullopt,
+      .isCompileError = false,
+  };
+}
+
+} // namespace facebook::react::unstable_redbox

--- a/packages/react-native/ReactCommon/react/debug/redbox/RedBoxErrorParser.h
+++ b/packages/react-native/ReactCommon/react/debug/redbox/RedBoxErrorParser.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace facebook::react::unstable_redbox {
+
+struct CodeFrame {
+  std::string content;
+  std::string fileName;
+  int row = 0;
+  int column = 0;
+};
+
+struct ParsedError {
+  std::string title;
+  std::string message;
+  std::optional<CodeFrame> codeFrame;
+  bool isCompileError = false;
+  bool isRetryable = true;
+};
+
+/**
+ * Parse a raw error message into structured components.
+ * C++ port of parseLogBoxException from parseLogBoxLog.js.
+ */
+ParsedError parseErrorMessage(
+    const std::string &message,
+    const std::string &name = "",
+    const std::string &componentStack = "",
+    bool isFatal = true);
+
+} // namespace facebook::react::unstable_redbox

--- a/packages/react-native/ReactCommon/react/debug/redbox/tests/AnsiParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/debug/redbox/tests/AnsiParserTest.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/debug/redbox/AnsiParser.h>
+
+using namespace facebook::react::unstable_redbox;
+
+TEST(AnsiParserTest, ParsesPlainText) {
+  auto spans = parseAnsi("hello world");
+  ASSERT_EQ(spans.size(), 1);
+  EXPECT_EQ(spans[0].text, "hello world");
+  EXPECT_FALSE(spans[0].foregroundColor.has_value());
+  EXPECT_FALSE(spans[0].backgroundColor.has_value());
+}
+
+TEST(AnsiParserTest, ParsesRedForeground) {
+  auto spans = parseAnsi("\x1b[31mred text\x1b[0m normal");
+  ASSERT_EQ(spans.size(), 2);
+  EXPECT_EQ(spans[0].text, "red text");
+  ASSERT_TRUE(spans[0].foregroundColor.has_value());
+  EXPECT_EQ(spans[0].foregroundColor->r, 187);
+  EXPECT_EQ(spans[0].foregroundColor->g, 86);
+  EXPECT_EQ(spans[0].foregroundColor->b, 83);
+
+  EXPECT_EQ(spans[1].text, " normal");
+  EXPECT_FALSE(spans[1].foregroundColor.has_value());
+}
+
+TEST(AnsiParserTest, ParsesMultipleColors) {
+  auto spans = parseAnsi("\x1b[32mgreen\x1b[34mblue\x1b[0m");
+  ASSERT_EQ(spans.size(), 2);
+  EXPECT_EQ(spans[0].text, "green");
+  EXPECT_EQ(spans[0].foregroundColor->r, 144);
+  EXPECT_EQ(spans[1].text, "blue");
+  EXPECT_EQ(spans[1].foregroundColor->r, 125);
+}
+
+TEST(AnsiParserTest, ParsesBrightColors) {
+  auto spans = parseAnsi("\x1b[93myellow\x1b[0m");
+  ASSERT_EQ(spans.size(), 1);
+  EXPECT_EQ(spans[0].text, "yellow");
+  ASSERT_TRUE(spans[0].foregroundColor.has_value());
+  EXPECT_EQ(spans[0].foregroundColor->r, 234);
+}
+
+TEST(AnsiParserTest, ParsesBackgroundColor) {
+  auto spans = parseAnsi("\x1b[41mred bg\x1b[0m");
+  ASSERT_EQ(spans.size(), 1);
+  EXPECT_EQ(spans[0].text, "red bg");
+  EXPECT_FALSE(spans[0].foregroundColor.has_value());
+  ASSERT_TRUE(spans[0].backgroundColor.has_value());
+  EXPECT_EQ(spans[0].backgroundColor->r, 187);
+  EXPECT_EQ(spans[0].backgroundColor->g, 86);
+  EXPECT_EQ(spans[0].backgroundColor->b, 83);
+}
+
+TEST(AnsiParserTest, ResetClearsBackground) {
+  auto spans = parseAnsi("\x1b[31;42mcolored\x1b[49mfg only\x1b[0m");
+  ASSERT_EQ(spans.size(), 2);
+  ASSERT_TRUE(spans[0].foregroundColor.has_value());
+  ASSERT_TRUE(spans[0].backgroundColor.has_value());
+  ASSERT_TRUE(spans[1].foregroundColor.has_value());
+  EXPECT_FALSE(spans[1].backgroundColor.has_value());
+}
+
+TEST(AnsiParserTest, ResetShorthandClearsColors) {
+  auto spans = parseAnsi("\x1b[31mred\x1b[mplain");
+  ASSERT_EQ(spans.size(), 2);
+  EXPECT_EQ(spans[0].text, "red");
+  ASSERT_TRUE(spans[0].foregroundColor.has_value());
+  EXPECT_EQ(spans[1].text, "plain");
+  EXPECT_FALSE(spans[1].foregroundColor.has_value());
+  EXPECT_FALSE(spans[1].backgroundColor.has_value());
+}
+
+TEST(AnsiParserTest, StripsAnsi) {
+  auto result = stripAnsi("\x1b[31mred\x1b[0m and \x1b[32mgreen\x1b[0m");
+  EXPECT_EQ(result, "red and green");
+}
+
+TEST(AnsiParserTest, HandlesEmptyString) {
+  auto spans = parseAnsi("");
+  EXPECT_TRUE(spans.empty());
+}
+
+TEST(AnsiParserTest, HandlesSemicolonSeparatedCodes) {
+  auto spans = parseAnsi("\x1b[1;31mtext\x1b[0m");
+  ASSERT_EQ(spans.size(), 1);
+  EXPECT_EQ(spans[0].text, "text");
+  ASSERT_TRUE(spans[0].foregroundColor.has_value());
+  EXPECT_EQ(spans[0].foregroundColor->r, 187);
+}

--- a/packages/react-native/ReactCommon/react/debug/redbox/tests/JscSafeUrlTest.cpp
+++ b/packages/react-native/ReactCommon/react/debug/redbox/tests/JscSafeUrlTest.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/debug/redbox/JscSafeUrl.h>
+
+using namespace facebook::react::unstable_redbox;
+
+// --- toNormalUrl ---
+
+// Rewrites urls treating //& in paths as ?
+TEST(JscSafeUrlTest, ToNormalUrl_RewritesMarkerInAbsolutePath) {
+  EXPECT_EQ(
+      toNormalUrl("/path1/path2//&foo=bar?bar=baz#frag?"),
+      "/path1/path2?foo=bar&bar=baz#frag?");
+  // Idempotent
+  EXPECT_EQ(
+      toNormalUrl("/path1/path2?foo=bar&bar=baz#frag?"),
+      "/path1/path2?foo=bar&bar=baz#frag?");
+}
+
+TEST(JscSafeUrlTest, ToNormalUrl_RewritesMarkerInRelativePathWithEncoding) {
+  EXPECT_EQ(
+      toNormalUrl("relative/path/with%3B%26/encoded//&foo=bar?bar=baz#frag?"),
+      "relative/path/with%3B%26/encoded?foo=bar&bar=baz#frag?");
+  EXPECT_EQ(
+      toNormalUrl("relative/path/with%3B%26/encoded?foo=bar&bar=baz#frag?"),
+      "relative/path/with%3B%26/encoded?foo=bar&bar=baz#frag?");
+}
+
+TEST(JscSafeUrlTest, ToNormalUrl_RewritesMarkerInFullUrl) {
+  EXPECT_EQ(
+      toNormalUrl(
+          "https://user:password@mydomain.com:8080/path1/path2//&foo=bar?bar=baz#frag?"),
+      "https://user:password@mydomain.com:8080/path1/path2?foo=bar&bar=baz#frag?");
+  EXPECT_EQ(
+      toNormalUrl(
+          "https://user:password@mydomain.com:8080/path1/path2?foo=bar&bar=baz#frag?"),
+      "https://user:password@mydomain.com:8080/path1/path2?foo=bar&bar=baz#frag?");
+}
+
+TEST(JscSafeUrlTest, ToNormalUrl_RewritesMarkerWithoutFragment) {
+  EXPECT_EQ(
+      toNormalUrl("http://127.0.0.1/path1/path2//&foo=bar&bar=baz"),
+      "http://127.0.0.1/path1/path2?foo=bar&bar=baz");
+  EXPECT_EQ(
+      toNormalUrl("http://127.0.0.1/path1/path2?foo=bar&bar=baz"),
+      "http://127.0.0.1/path1/path2?foo=bar&bar=baz");
+}
+
+// Returns other strings exactly as given
+TEST(JscSafeUrlTest, ToNormalUrl_PassthroughForQueryWithMarkerAfter) {
+  auto url = "http://user:password/@mydomain.com/foo?bar=zoo?baz=quux//&";
+  EXPECT_EQ(toNormalUrl(url), url);
+}
+
+TEST(JscSafeUrlTest, ToNormalUrl_PassthroughForSimpleQuery) {
+  auto url = "/foo?bar=zoo?baz=quux";
+  EXPECT_EQ(toNormalUrl(url), url);
+}
+
+TEST(JscSafeUrlTest, ToNormalUrl_PassthroughForOpaqueUri) {
+  auto url = "proto:arbitrary_bad_url";
+  EXPECT_EQ(toNormalUrl(url), url);
+}
+
+TEST(JscSafeUrlTest, ToNormalUrl_PassthroughForStar) {
+  EXPECT_EQ(toNormalUrl("*"), "*");
+}
+
+TEST(JscSafeUrlTest, ToNormalUrl_PassthroughForRelativePath) {
+  auto url = "relative/path";
+  EXPECT_EQ(toNormalUrl(url), url);
+}
+
+// --- toJscSafeUrl ---
+
+// Replaces the first ? with a JSC-friendly delimiter, url-encodes subsequent
+// ?, and is idempotent
+TEST(JscSafeUrlTest, ToJscSafeUrl_FullUrlWithEncodedQuestionMark) {
+  auto input =
+      "https://user:password@mydomain.com:8080/path1/path2?foo=bar&bar=question?#frag?";
+  auto output =
+      "https://user:password@mydomain.com:8080/path1/path2//&foo=bar&bar=question%3F#frag?";
+  EXPECT_EQ(toJscSafeUrl(input), output);
+  EXPECT_EQ(toJscSafeUrl(output), output);
+}
+
+TEST(JscSafeUrlTest, ToJscSafeUrl_SimpleUrl) {
+  auto input = "http://127.0.0.1/path1/path2?foo=bar";
+  auto output = "http://127.0.0.1/path1/path2//&foo=bar";
+  EXPECT_EQ(toJscSafeUrl(input), output);
+  EXPECT_EQ(toJscSafeUrl(output), output);
+}
+
+TEST(JscSafeUrlTest, ToJscSafeUrl_PassthroughForStar) {
+  EXPECT_EQ(toJscSafeUrl("*"), "*");
+  EXPECT_EQ(toJscSafeUrl("*"), "*");
+}
+
+TEST(JscSafeUrlTest, ToJscSafeUrl_PassthroughForAbsolutePath) {
+  EXPECT_EQ(toJscSafeUrl("/absolute/path"), "/absolute/path");
+  EXPECT_EQ(toJscSafeUrl("/absolute/path"), "/absolute/path");
+}
+
+TEST(JscSafeUrlTest, ToJscSafeUrl_PassthroughForRelativePath) {
+  EXPECT_EQ(toJscSafeUrl("relative/path"), "relative/path");
+  EXPECT_EQ(toJscSafeUrl("relative/path"), "relative/path");
+}
+
+TEST(JscSafeUrlTest, ToJscSafeUrl_EmptyQueryDropped) {
+  EXPECT_EQ(toJscSafeUrl("/?"), "/");
+  EXPECT_EQ(toJscSafeUrl("/"), "/");
+}
+
+TEST(JscSafeUrlTest, ToJscSafeUrl_PassthroughForUrlWithoutQuery) {
+  auto url = "http://127.0.0.1/path1/path";
+  EXPECT_EQ(toJscSafeUrl(url), url);
+  EXPECT_EQ(toJscSafeUrl(url), url);
+}
+
+TEST(JscSafeUrlTest, ToJscSafeUrl_AbsolutePathWithEncodedQuestionMark) {
+  auto input = "/path1/path2?foo=bar&bar=question?#frag?";
+  auto output = "/path1/path2//&foo=bar&bar=question%3F#frag?";
+  EXPECT_EQ(toJscSafeUrl(input), output);
+  EXPECT_EQ(toJscSafeUrl(output), output);
+}
+
+TEST(JscSafeUrlTest, ToJscSafeUrl_RelativePathWithEncodedQuestionMark) {
+  auto input = "relative/path?foo=bar&bar=question?#frag?";
+  auto output = "relative/path//&foo=bar&bar=question%3F#frag?";
+  EXPECT_EQ(toJscSafeUrl(input), output);
+  EXPECT_EQ(toJscSafeUrl(output), output);
+}
+
+TEST(JscSafeUrlTest, ToJscSafeUrl_AlreadySafeWithExtraQuery) {
+  auto input = "/path1/path2//&foo=bar&bar=question%3F?extra=query#frag?";
+  auto output = "/path1/path2//&foo=bar&bar=question%3F&extra=query#frag?";
+  EXPECT_EQ(toJscSafeUrl(input), output);
+  EXPECT_EQ(toJscSafeUrl(output), output);
+}
+
+// Throws on a URL with an empty path and a query string
+TEST(JscSafeUrlTest, ToJscSafeUrl_ThrowsForEmptyPathWithQuery) {
+  EXPECT_THROW(toJscSafeUrl("http://127.0.0.1?foo=bar"), std::invalid_argument);
+  EXPECT_THROW(toJscSafeUrl("http://127.0.0.1?q#hash"), std::invalid_argument);
+  EXPECT_THROW(toJscSafeUrl("?foo=bar"), std::invalid_argument);
+  EXPECT_THROW(toJscSafeUrl("?foo=/bar#hash"), std::invalid_argument);
+  EXPECT_THROW(toJscSafeUrl("/?bar=baz/"), std::invalid_argument);
+}
+
+// --- isJscSafeUrl ---
+
+TEST(JscSafeUrlTest, IsJscSafeUrl_TrueForSafeUrls) {
+  EXPECT_TRUE(isJscSafeUrl("http://example.com//&foo=bar//#frag=//"));
+  EXPECT_TRUE(isJscSafeUrl("http://example.com/with/path//&foo=bar//#frag=//"));
+  EXPECT_TRUE(isJscSafeUrl("//&foo=bar//#frag=//"));
+  EXPECT_TRUE(isJscSafeUrl("relative/path///&foo=bar//&#frag=//&"));
+  EXPECT_TRUE(isJscSafeUrl("/absolute/path//&foo=bar//&#frag=//&"));
+}
+
+TEST(JscSafeUrlTest, IsJscSafeUrl_FalseForNormalUrls) {
+  EXPECT_FALSE(isJscSafeUrl("http://example.com?foo=bar//&#frag=//"));
+  EXPECT_FALSE(
+      isJscSafeUrl("http://example.com/with/path/?foo=bar//&#frag=//"));
+  EXPECT_FALSE(isJscSafeUrl("?foo=bar//&#frag=//&"));
+  EXPECT_FALSE(isJscSafeUrl("relative/path/?foo=bar//#frag=//"));
+  EXPECT_FALSE(isJscSafeUrl("/absolute/path/?foo=bar//&#frag=//"));
+}

--- a/packages/react-native/ReactCommon/react/debug/redbox/tests/RedBoxErrorParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/debug/redbox/tests/RedBoxErrorParserTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/debug/redbox/RedBoxErrorParser.h>
+
+using namespace facebook::react::unstable_redbox;
+
+TEST(RedBoxErrorParserTest, ParsesBabelTransformError) {
+  auto result = parseErrorMessage(
+      "SyntaxError: /path/to/file.js: Unexpected token (10:5)\n\n"
+      "> 10 |   const x = {\n"
+      "     |              ^");
+
+  EXPECT_EQ(result.title, "Syntax Error");
+  EXPECT_EQ(result.message, "Unexpected token");
+  ASSERT_TRUE(result.codeFrame.has_value());
+  EXPECT_EQ(result.codeFrame->fileName, "/path/to/file.js");
+  EXPECT_EQ(result.codeFrame->row, 10);
+  EXPECT_EQ(result.codeFrame->column, 5);
+  EXPECT_TRUE(result.isCompileError);
+  EXPECT_TRUE(result.isRetryable);
+}
+
+TEST(RedBoxErrorParserTest, ParsesMetroError) {
+  auto result = parseErrorMessage(
+      "InternalError Metro has encountered an error: "
+      "BundleError: Unable to resolve module (1:0)\n\n"
+      "code frame here");
+
+  EXPECT_EQ(result.title, "BundleError");
+  EXPECT_EQ(result.message, "Unable to resolve module");
+  ASSERT_TRUE(result.codeFrame.has_value());
+  EXPECT_EQ(result.codeFrame->row, 1);
+  EXPECT_TRUE(result.isCompileError);
+}
+
+TEST(RedBoxErrorParserTest, ParsesBundleLoadError_SyntaxError) {
+  auto result = parseErrorMessage(
+      "SyntaxError in /app/index.js: Unexpected token (3:10)\ncode frame");
+
+  EXPECT_EQ(result.title, "Syntax Error");
+  EXPECT_EQ(result.message, "Unexpected token");
+  ASSERT_TRUE(result.codeFrame.has_value());
+  EXPECT_EQ(result.codeFrame->fileName, "/app/index.js");
+  EXPECT_EQ(result.codeFrame->row, 3);
+  EXPECT_EQ(result.codeFrame->column, 10);
+  EXPECT_TRUE(result.isCompileError);
+}
+
+TEST(RedBoxErrorParserTest, ParsesBundleLoadError_UnableToResolve) {
+  auto result = parseErrorMessage(
+      "UnableToResolveError in /app/index.js: Cannot find module (1:0)");
+
+  EXPECT_EQ(result.title, "Module Not Found");
+  EXPECT_TRUE(result.isCompileError);
+}
+
+TEST(RedBoxErrorParserTest, ParsesGenericTransformError) {
+  auto result = parseErrorMessage("TransformError some error message");
+
+  EXPECT_EQ(result.title, "Syntax Error");
+  EXPECT_EQ(result.message, "TransformError some error message");
+  EXPECT_FALSE(result.codeFrame.has_value());
+  EXPECT_TRUE(result.isCompileError);
+}
+
+TEST(RedBoxErrorParserTest, DefaultsToUncaughtError) {
+  auto result = parseErrorMessage("TypeError: undefined is not a function");
+
+  EXPECT_EQ(result.title, "Uncaught Error");
+  EXPECT_EQ(result.message, "TypeError: undefined is not a function");
+  EXPECT_FALSE(result.codeFrame.has_value());
+  EXPECT_FALSE(result.isCompileError);
+  EXPECT_TRUE(result.isRetryable);
+}
+
+TEST(RedBoxErrorParserTest, UsesNameForTitle) {
+  auto result = parseErrorMessage("something broke", "CustomError");
+
+  EXPECT_EQ(result.title, "CustomError");
+}
+
+TEST(RedBoxErrorParserTest, UsesRenderErrorForComponentStack) {
+  auto result =
+      parseErrorMessage("something broke", "", "in MyComponent\nin App");
+
+  EXPECT_EQ(result.title, "Render Error");
+}
+
+TEST(RedBoxErrorParserTest, NonFatalDefaultsToError) {
+  auto result = parseErrorMessage("warning message", "", "", false);
+
+  EXPECT_EQ(result.title, "Error");
+}
+
+TEST(RedBoxErrorParserTest, HandlesEmptyMessage) {
+  auto result = parseErrorMessage("");
+
+  EXPECT_EQ(result.title, "Uncaught Error");
+  EXPECT_EQ(result.message, "");
+  EXPECT_FALSE(result.codeFrame.has_value());
+}

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<08a361f2ffac6a0496adac1d4c3e4726>>
+ * @generated SignedSource<<c650baa3dc511310aad1125ea96cd35f>>
  */
 
 /**
@@ -288,6 +288,14 @@ double ReactNativeFeatureFlags::preparedTextCacheSize() {
 
 bool ReactNativeFeatureFlags::preventShadowTreeCommitExhaustion() {
   return getAccessor().preventShadowTreeCommitExhaustion();
+}
+
+bool ReactNativeFeatureFlags::redBoxV2Android() {
+  return getAccessor().redBoxV2Android();
+}
+
+bool ReactNativeFeatureFlags::redBoxV2IOS() {
+  return getAccessor().redBoxV2IOS();
 }
 
 bool ReactNativeFeatureFlags::shouldPressibilityUseW3CPointerEventsForHover() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0bbe4d41581432dfad7adbc2db133d00>>
+ * @generated SignedSource<<124bb3aa9b7795df019e14d3b8212166>>
  */
 
 /**
@@ -368,6 +368,16 @@ class ReactNativeFeatureFlags {
    * Enables a new mechanism in ShadowTree to prevent problems caused by multiple threads trying to commit concurrently. If a thread tries to commit a few times unsuccessfully, it will acquire a lock and try again.
    */
   RN_EXPORT static bool preventShadowTreeCommitExhaustion();
+
+  /**
+   * Use the redesigned RedBox error overlay on Android, styled to match the LogBox visual language.
+   */
+  RN_EXPORT static bool redBoxV2Android();
+
+  /**
+   * Use the redesigned RedBox error overlay on iOS, styled to match the LogBox visual language.
+   */
+  RN_EXPORT static bool redBoxV2IOS();
 
   /**
    * Function used to enable / disable Pressibility from using W3C Pointer Events for its hover callbacks

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3dd9492ca660ad6350ce6ee4a9b5e310>>
+ * @generated SignedSource<<f50369f93c010f061c2c760cb0969038>>
  */
 
 /**
@@ -1217,6 +1217,42 @@ bool ReactNativeFeatureFlagsAccessor::preventShadowTreeCommitExhaustion() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::redBoxV2Android() {
+  auto flagValue = redBoxV2Android_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(66, "redBoxV2Android");
+
+    flagValue = currentProvider_->redBoxV2Android();
+    redBoxV2Android_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
+bool ReactNativeFeatureFlagsAccessor::redBoxV2IOS() {
+  auto flagValue = redBoxV2IOS_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(67, "redBoxV2IOS");
+
+    flagValue = currentProvider_->redBoxV2IOS();
+    redBoxV2IOS_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::shouldPressibilityUseW3CPointerEventsForHover() {
   auto flagValue = shouldPressibilityUseW3CPointerEventsForHover_.load();
 
@@ -1226,7 +1262,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldPressibilityUseW3CPointerEventsForHo
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(66, "shouldPressibilityUseW3CPointerEventsForHover");
+    markFlagAsAccessed(68, "shouldPressibilityUseW3CPointerEventsForHover");
 
     flagValue = currentProvider_->shouldPressibilityUseW3CPointerEventsForHover();
     shouldPressibilityUseW3CPointerEventsForHover_ = flagValue;
@@ -1244,7 +1280,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldTriggerResponderTransferOnScrollAndr
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(67, "shouldTriggerResponderTransferOnScrollAndroid");
+    markFlagAsAccessed(69, "shouldTriggerResponderTransferOnScrollAndroid");
 
     flagValue = currentProvider_->shouldTriggerResponderTransferOnScrollAndroid();
     shouldTriggerResponderTransferOnScrollAndroid_ = flagValue;
@@ -1262,7 +1298,7 @@ bool ReactNativeFeatureFlagsAccessor::skipActivityIdentityAssertionOnHostPause()
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(68, "skipActivityIdentityAssertionOnHostPause");
+    markFlagAsAccessed(70, "skipActivityIdentityAssertionOnHostPause");
 
     flagValue = currentProvider_->skipActivityIdentityAssertionOnHostPause();
     skipActivityIdentityAssertionOnHostPause_ = flagValue;
@@ -1280,7 +1316,7 @@ bool ReactNativeFeatureFlagsAccessor::syncAndroidClipToPaddingWithOverflow() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(69, "syncAndroidClipToPaddingWithOverflow");
+    markFlagAsAccessed(71, "syncAndroidClipToPaddingWithOverflow");
 
     flagValue = currentProvider_->syncAndroidClipToPaddingWithOverflow();
     syncAndroidClipToPaddingWithOverflow_ = flagValue;
@@ -1298,7 +1334,7 @@ bool ReactNativeFeatureFlagsAccessor::traceTurboModulePromiseRejectionsOnAndroid
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(70, "traceTurboModulePromiseRejectionsOnAndroid");
+    markFlagAsAccessed(72, "traceTurboModulePromiseRejectionsOnAndroid");
 
     flagValue = currentProvider_->traceTurboModulePromiseRejectionsOnAndroid();
     traceTurboModulePromiseRejectionsOnAndroid_ = flagValue;
@@ -1316,7 +1352,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommit(
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(71, "updateRuntimeShadowNodeReferencesOnCommit");
+    markFlagAsAccessed(73, "updateRuntimeShadowNodeReferencesOnCommit");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommit();
     updateRuntimeShadowNodeReferencesOnCommit_ = flagValue;
@@ -1334,7 +1370,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommitT
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(72, "updateRuntimeShadowNodeReferencesOnCommitThread");
+    markFlagAsAccessed(74, "updateRuntimeShadowNodeReferencesOnCommitThread");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommitThread();
     updateRuntimeShadowNodeReferencesOnCommitThread_ = flagValue;
@@ -1352,7 +1388,7 @@ bool ReactNativeFeatureFlagsAccessor::useAlwaysAvailableJSErrorHandling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(73, "useAlwaysAvailableJSErrorHandling");
+    markFlagAsAccessed(75, "useAlwaysAvailableJSErrorHandling");
 
     flagValue = currentProvider_->useAlwaysAvailableJSErrorHandling();
     useAlwaysAvailableJSErrorHandling_ = flagValue;
@@ -1370,7 +1406,7 @@ bool ReactNativeFeatureFlagsAccessor::useFabricInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(74, "useFabricInterop");
+    markFlagAsAccessed(76, "useFabricInterop");
 
     flagValue = currentProvider_->useFabricInterop();
     useFabricInterop_ = flagValue;
@@ -1388,7 +1424,7 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(75, "useNativeViewConfigsInBridgelessMode");
+    markFlagAsAccessed(77, "useNativeViewConfigsInBridgelessMode");
 
     flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
     useNativeViewConfigsInBridgelessMode_ = flagValue;
@@ -1406,7 +1442,7 @@ bool ReactNativeFeatureFlagsAccessor::useNestedScrollViewAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(76, "useNestedScrollViewAndroid");
+    markFlagAsAccessed(78, "useNestedScrollViewAndroid");
 
     flagValue = currentProvider_->useNestedScrollViewAndroid();
     useNestedScrollViewAndroid_ = flagValue;
@@ -1424,7 +1460,7 @@ bool ReactNativeFeatureFlagsAccessor::useSharedAnimatedBackend() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(77, "useSharedAnimatedBackend");
+    markFlagAsAccessed(79, "useSharedAnimatedBackend");
 
     flagValue = currentProvider_->useSharedAnimatedBackend();
     useSharedAnimatedBackend_ = flagValue;
@@ -1442,7 +1478,7 @@ bool ReactNativeFeatureFlagsAccessor::useTraitHiddenOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(78, "useTraitHiddenOnAndroid");
+    markFlagAsAccessed(80, "useTraitHiddenOnAndroid");
 
     flagValue = currentProvider_->useTraitHiddenOnAndroid();
     useTraitHiddenOnAndroid_ = flagValue;
@@ -1460,7 +1496,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(79, "useTurboModuleInterop");
+    markFlagAsAccessed(81, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -1478,7 +1514,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModules() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(80, "useTurboModules");
+    markFlagAsAccessed(82, "useTurboModules");
 
     flagValue = currentProvider_->useTurboModules();
     useTurboModules_ = flagValue;
@@ -1496,7 +1532,7 @@ bool ReactNativeFeatureFlagsAccessor::useUnorderedMapInDifferentiator() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(81, "useUnorderedMapInDifferentiator");
+    markFlagAsAccessed(83, "useUnorderedMapInDifferentiator");
 
     flagValue = currentProvider_->useUnorderedMapInDifferentiator();
     useUnorderedMapInDifferentiator_ = flagValue;
@@ -1514,7 +1550,7 @@ double ReactNativeFeatureFlagsAccessor::viewCullingOutsetRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(82, "viewCullingOutsetRatio");
+    markFlagAsAccessed(84, "viewCullingOutsetRatio");
 
     flagValue = currentProvider_->viewCullingOutsetRatio();
     viewCullingOutsetRatio_ = flagValue;
@@ -1532,7 +1568,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(83, "viewTransitionEnabled");
+    markFlagAsAccessed(85, "viewTransitionEnabled");
 
     flagValue = currentProvider_->viewTransitionEnabled();
     viewTransitionEnabled_ = flagValue;
@@ -1550,7 +1586,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(84, "virtualViewPrerenderRatio");
+    markFlagAsAccessed(86, "virtualViewPrerenderRatio");
 
     flagValue = currentProvider_->virtualViewPrerenderRatio();
     virtualViewPrerenderRatio_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2cb2c124f044468f96262086bfac5aad>>
+ * @generated SignedSource<<cc482860e515022a7c64b0f51ce9a1fb>>
  */
 
 /**
@@ -98,6 +98,8 @@ class ReactNativeFeatureFlagsAccessor {
   bool perfMonitorV2Enabled();
   double preparedTextCacheSize();
   bool preventShadowTreeCommitExhaustion();
+  bool redBoxV2Android();
+  bool redBoxV2IOS();
   bool shouldPressibilityUseW3CPointerEventsForHover();
   bool shouldTriggerResponderTransferOnScrollAndroid();
   bool skipActivityIdentityAssertionOnHostPause();
@@ -128,7 +130,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 85> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 87> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> cdpInteractionMetricsEnabled_;
@@ -196,6 +198,8 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> perfMonitorV2Enabled_;
   std::atomic<std::optional<double>> preparedTextCacheSize_;
   std::atomic<std::optional<bool>> preventShadowTreeCommitExhaustion_;
+  std::atomic<std::optional<bool>> redBoxV2Android_;
+  std::atomic<std::optional<bool>> redBoxV2IOS_;
   std::atomic<std::optional<bool>> shouldPressibilityUseW3CPointerEventsForHover_;
   std::atomic<std::optional<bool>> shouldTriggerResponderTransferOnScrollAndroid_;
   std::atomic<std::optional<bool>> skipActivityIdentityAssertionOnHostPause_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7f1c4037925fc37dcdcba51df968d503>>
+ * @generated SignedSource<<88fd9552bcbdc1aee651c753256844dc>>
  */
 
 /**
@@ -160,7 +160,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableImperativeFocus() override {
-    return false;
+    return true;
   }
 
   bool enableInteropViewManagerClassLookUpOptimizationIOS() override {
@@ -288,6 +288,14 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool preventShadowTreeCommitExhaustion() override {
+    return false;
+  }
+
+  bool redBoxV2Android() override {
+    return false;
+  }
+
+  bool redBoxV2IOS() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<db6a2d2e1d96e088574d91ae2825fe5e>>
+ * @generated SignedSource<<13a5a6dba2b8a50c4cb7fd51ccd3d101>>
  */
 
 /**
@@ -637,6 +637,24 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::preventShadowTreeCommitExhaustion();
+  }
+
+  bool redBoxV2Android() override {
+    auto value = values_["redBoxV2Android"];
+    if (!value.isNull()) {
+      return value.getBool();
+    }
+
+    return ReactNativeFeatureFlagsDefaults::redBoxV2Android();
+  }
+
+  bool redBoxV2IOS() override {
+    auto value = values_["redBoxV2IOS"];
+    if (!value.isNull()) {
+      return value.getBool();
+    }
+
+    return ReactNativeFeatureFlagsDefaults::redBoxV2IOS();
   }
 
   bool shouldPressibilityUseW3CPointerEventsForHover() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<43e301c5028a2ed195e2a3d0a4cd0ab3>>
+ * @generated SignedSource<<ab98aa9cac98d0ded532a4e0a82cae4f>>
  */
 
 /**
@@ -91,6 +91,8 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool perfMonitorV2Enabled() = 0;
   virtual double preparedTextCacheSize() = 0;
   virtual bool preventShadowTreeCommitExhaustion() = 0;
+  virtual bool redBoxV2Android() = 0;
+  virtual bool redBoxV2IOS() = 0;
   virtual bool shouldPressibilityUseW3CPointerEventsForHover() = 0;
   virtual bool shouldTriggerResponderTransferOnScrollAndroid() = 0;
   virtual bool skipActivityIdentityAssertionOnHostPause() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<006c43555032f785207c6c013f1974f5>>
+ * @generated SignedSource<<c68dd91cfd1be504ee1bf7e95f02fe01>>
  */
 
 /**
@@ -372,6 +372,16 @@ double NativeReactNativeFeatureFlags::preparedTextCacheSize(
 bool NativeReactNativeFeatureFlags::preventShadowTreeCommitExhaustion(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::preventShadowTreeCommitExhaustion();
+}
+
+bool NativeReactNativeFeatureFlags::redBoxV2Android(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::redBoxV2Android();
+}
+
+bool NativeReactNativeFeatureFlags::redBoxV2IOS(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::redBoxV2IOS();
 }
 
 bool NativeReactNativeFeatureFlags::shouldPressibilityUseW3CPointerEventsForHover(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<525d64b15e1b72440743363280116c6a>>
+ * @generated SignedSource<<37ddc2842f3cac7b88196230108dfad0>>
  */
 
 /**
@@ -167,6 +167,10 @@ class NativeReactNativeFeatureFlags
   double preparedTextCacheSize(jsi::Runtime& runtime);
 
   bool preventShadowTreeCommitExhaustion(jsi::Runtime& runtime);
+
+  bool redBoxV2Android(jsi::Runtime& runtime);
+
+  bool redBoxV2IOS(jsi::Runtime& runtime);
 
   bool shouldPressibilityUseW3CPointerEventsForHover(jsi::Runtime& runtime);
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -754,6 +754,28 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'experimental',
     },
+    redBoxV2Android: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2026-03-25',
+        description:
+          'Use the redesigned RedBox error overlay on Android, styled to match the LogBox visual language.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
+    redBoxV2IOS: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2026-03-25',
+        description:
+          'Use the redesigned RedBox error overlay on iOS, styled to match the LogBox visual language.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     shouldPressibilityUseW3CPointerEventsForHover: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<03688450419694f6d3f4fc709df4de9a>>
+ * @generated SignedSource<<ac46589d5cabee107c4faf9672fef10c>>
  * @flow strict
  * @noformat
  */
@@ -114,6 +114,8 @@ export type ReactNativeFeatureFlags = $ReadOnly<{
   perfMonitorV2Enabled: Getter<boolean>,
   preparedTextCacheSize: Getter<number>,
   preventShadowTreeCommitExhaustion: Getter<boolean>,
+  redBoxV2Android: Getter<boolean>,
+  redBoxV2IOS: Getter<boolean>,
   shouldPressibilityUseW3CPointerEventsForHover: Getter<boolean>,
   shouldTriggerResponderTransferOnScrollAndroid: Getter<boolean>,
   skipActivityIdentityAssertionOnHostPause: Getter<boolean>,
@@ -339,7 +341,7 @@ export const enableImmediateUpdateModeForContentOffsetChanges: Getter<boolean> =
 /**
  * Enable ref.focus() and ref.blur() for all views, not just TextInput.
  */
-export const enableImperativeFocus: Getter<boolean> = createNativeFlagGetter('enableImperativeFocus', false);
+export const enableImperativeFocus: Getter<boolean> = createNativeFlagGetter('enableImperativeFocus', true);
 /**
  * This is to fix the issue with interop view manager where component descriptor lookup is causing ViewManager to preload.
  */
@@ -468,6 +470,14 @@ export const preparedTextCacheSize: Getter<number> = createNativeFlagGetter('pre
  * Enables a new mechanism in ShadowTree to prevent problems caused by multiple threads trying to commit concurrently. If a thread tries to commit a few times unsuccessfully, it will acquire a lock and try again.
  */
 export const preventShadowTreeCommitExhaustion: Getter<boolean> = createNativeFlagGetter('preventShadowTreeCommitExhaustion', false);
+/**
+ * Use the redesigned RedBox error overlay on Android, styled to match the LogBox visual language.
+ */
+export const redBoxV2Android: Getter<boolean> = createNativeFlagGetter('redBoxV2Android', false);
+/**
+ * Use the redesigned RedBox error overlay on iOS, styled to match the LogBox visual language.
+ */
+export const redBoxV2IOS: Getter<boolean> = createNativeFlagGetter('redBoxV2IOS', false);
 /**
  * Function used to enable / disable Pressibility from using W3C Pointer Events for its hover callbacks
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2955ab3f744af8b5cdf587312ba423d7>>
+ * @generated SignedSource<<f7ce367c07c289c4e4f8f76f144b94cc>>
  * @flow strict
  * @noformat
  */
@@ -91,6 +91,8 @@ export interface Spec extends TurboModule {
   +perfMonitorV2Enabled?: () => boolean;
   +preparedTextCacheSize?: () => number;
   +preventShadowTreeCommitExhaustion?: () => boolean;
+  +redBoxV2Android?: () => boolean;
+  +redBoxV2IOS?: () => boolean;
   +shouldPressibilityUseW3CPointerEventsForHover?: () => boolean;
   +shouldTriggerResponderTransferOnScrollAndroid?: () => boolean;
   +skipActivityIdentityAssertionOnHostPause?: () => boolean;


### PR DESCRIPTION
## Summary

Targets `0.85-merge` with two focused commits:

1. Sync the upstream React Native 0.85 RedBox 2.0 aggregate from
   facebook/react-native#56640.
2. Port the RedBox 2.0 controller to AppKit without changing iOS, tvOS, or
   visionOS behavior.

This draft introduces the canonical RedBox2/AppKit implementation before the
0.86 fork merge. It does not rebase any existing stack branch.

## Structural sync

The upstream aggregate adds the RedBox feature flags, extracted controllers,
C++ ANSI/error/JscSafeUrl support and tests, HMR support, CocoaPods ownership,
SwiftPM ownership, and feature-flag generated output.

The duplicate produced 20 conflicted paths: `RCTRedBox.mm` plus 19 generated
feature-flag files. The coordinator/controller resolution follows the existing
0.85 stable structural precedent, while generated outputs were regenerated
from `ReactNativeFeatureFlags.config.js`.

## AppKit delta

The AppKit commit changes five files. It:

- enables `redBoxV2IOS()` selection on macOS while retaining the legacy
  controller when the flag is false;
- adds the `NSTableView` RedBox2 UI, AppKit footer buttons/key equivalents,
  `NSPasteboard` copy support, and sheet lifecycle;
- activates the target-version ANSI adapter on macOS;
- preserves the upstream iOS projection byte-for-byte after removing macOS
  blocks and additive clauses.

The old `a87eee7` legacy-controller blob and stale ANSI adapter blob are
excluded. The target-version C++ parser, ErrorParser, HMR client, JscSafeUrl,
and later-compatible legacy-controller carve-outs remain authoritative.

## Validation

Passed:

- exact S 47-path aggregate and bilateral conflict/provenance audit;
- generated feature flags and focused Jest tests (11/11);
- balanced `[macOS]` diff tags and iOS projection parity (5/5);
- CocoaPods and SwiftPM source ownership;
- RNTester Debug builds for macOS, iOS simulator, and visionOS simulator;
- all four affected RedBox sources compiled on all three platforms with zero
  source-attributed diagnostics;
- conflict-marker scan, `git diff --check`, graph/ref freeze, and clean
  Jujutsu working copy.

Native validation used a fresh no-local Git clone at exact AppKit commit
`4ed3fb225714a6809cc69b8afdeffb88c0f8c80f`. CocoaPods codegen ran first and
generated the required FBReactNativeSpec/AppSpecs headers.

The API comparison tool reports a pre-existing unrelated VirtualizedList delta
even for byte-identical base/candidate snapshots; the RedBox change contains no
JavaScript API delta.

## Manual merge gate

Before merging this draft, manually enable `redBoxV2IOS`, trigger a JavaScript
error, and verify:

- the RedBox2 sheet and `NSTableView` rows/source/call stack;
- Copy and Option-Command-C copy through `NSPasteboard`;
- Reload and Command-R;
- Dismiss and Escape;
- sheet close/reopen lifecycle.

The feature defaults to false and RNTester has no native override, so this GUI
smoke was not performed by the validation-only executor.

## Stack follow-up

After the manual GUI gate and explicit approval:

- recreate the 0.86/0.87 mainline subtree with merge-preserving Jujutsu
  rebases;
- add version-appropriate AppKit commits on top of 0.83 and 0.85 stable lines;
- leave 0.84 unchanged.

All current `stack/*` bookmarks remain unchanged by this PR.
