### PR TITLE
fix: vertically center single-line TextInput content

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -33,7 +33,13 @@
 
 - (NSRect)titleRectForBounds:(NSRect)rect
 {
-  return UIEdgeInsetsInsetRect([super titleRectForBounds:rect], self.textContainerInset);
+  NSRect titleRect = UIEdgeInsetsInsetRect([super titleRectForBounds:rect], self.textContainerInset);
+  CGFloat contentHeight = self.cellSize.height;
+  if (contentHeight < titleRect.size.height) {
+    titleRect.origin.y += (titleRect.size.height - contentHeight) / 2;
+    titleRect.size.height = contentHeight;
+  }
+  return titleRect;
 }
 
 - (void)editWithFrame:(NSRect)rect inView:(NSView *)controlView editor:(NSText *)textObj delegate:(id)delegate event:(NSEvent *)event

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -34,6 +34,7 @@
 - (NSRect)titleRectForBounds:(NSRect)rect
 {
   NSRect titleRect = UIEdgeInsetsInsetRect([super titleRectForBounds:rect], self.textContainerInset);
+  // Center the intrinsic text height within the padded control bounds.
   CGFloat contentHeight = self.cellSize.height;
   if (contentHeight < titleRect.size.height) {
     titleRect.origin.y += (titleRect.size.height - contentHeight) / 2;

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/macOS/RCTUISecureTextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/macOS/RCTUISecureTextField.mm
@@ -31,6 +31,7 @@
 - (NSRect)titleRectForBounds:(NSRect)rect
 {
   NSRect titleRect = UIEdgeInsetsInsetRect([super titleRectForBounds:rect], self.textContainerInset);
+  // Center the intrinsic text height within the padded control bounds.
   CGFloat contentHeight = self.cellSize.height;
   if (contentHeight < titleRect.size.height) {
     titleRect.origin.y += (titleRect.size.height - contentHeight) / 2;

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/macOS/RCTUISecureTextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/macOS/RCTUISecureTextField.mm
@@ -30,7 +30,13 @@
 
 - (NSRect)titleRectForBounds:(NSRect)rect
 {
-  return UIEdgeInsetsInsetRect([super titleRectForBounds:rect], self.textContainerInset);
+  NSRect titleRect = UIEdgeInsetsInsetRect([super titleRectForBounds:rect], self.textContainerInset);
+  CGFloat contentHeight = self.cellSize.height;
+  if (contentHeight < titleRect.size.height) {
+    titleRect.origin.y += (titleRect.size.height - contentHeight) / 2;
+    titleRect.size.height = contentHeight;
+  }
+  return titleRect;
 }
 
 - (void)editWithFrame:(NSRect)rect inView:(NSView *)controlView editor:(NSText *)textObj delegate:(id)delegate event:(NSEvent *)event


### PR DESCRIPTION
## Summary:

Vertically center single-line `TextInput` content on macOS to match iOS, SwiftUI, and AppKit defaults.

The macOS text field cell previously used the full control height as its title rectangle. This placed text, placeholders, carets, and secure text at the top of controls with an explicit height. The updated title rectangle uses the intrinsic cell height and centers it within the padded bounds. Explicit padding remains applied, and multiline behavior is unchanged.

## Test Plan:

- Built the `RNTester-macOS` Release scheme with the JavaScript bundle embedded.
- Verified placeholder text, entered text, caret position, asymmetric padding, and secure text in RNTester Playground.
- Compared the result with native SwiftUI `TextField`/`SecureField` and AppKit `NSTextField`/`NSSecureTextField` controls.

| Before | After |
| --- | --- |
| <img src="https://gist.githubusercontent.com/Saadnajmi/754f436ad0795428ead8da51e44de1b6/raw/acb9d5a27dda58e4176c6e3b532fc71e183ffbad/textinput-before.svg" width="600" alt="Single-line TextInput content aligned to the top before the fix"> | <img src="https://gist.githubusercontent.com/Saadnajmi/754f436ad0795428ead8da51e44de1b6/raw/ef5b0913a5f07162e933cfe32056eb77e2636278/textinput-after.svg" width="600" alt="Single-line TextInput content vertically centered after the fix"> |
