### PR TITLE
fix(codegen): accept React.ComponentRef in command first-arg

### DIFF
--- a/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
@@ -1062,17 +1062,17 @@ export interface ModuleProps extends ViewProps {
 type NativeType = HostComponent<ModuleProps>;
 
  interface NativeCommands {
-   readonly handleRootTag: (viewRef: React.ElementRef<NativeType>, rootTag: RootTag) => void;
-   readonly hotspotUpdate: (viewRef: React.ElementRef<NativeType>, x: Int32, y: Int32) => void;
+   readonly handleRootTag: (viewRef: React.ComponentRef<NativeType>, rootTag: RootTag) => void;
+   readonly hotspotUpdate: (viewRef: React.ComponentRef<NativeType>, x: Int32, y: Int32) => void;
    scrollTo(
-     viewRef: React.ElementRef<NativeType>,
+     viewRef: React.ComponentRef<NativeType>,
      x: Float,
      y: Int32,
      z: Double,
      animated: boolean,
    ): void;
    readonly arrayArgs: (
-    viewRef: React.ElementRef<NativeType>,
+    viewRef: React.ComponentRef<NativeType>,
     booleanArray: ReadOnlyArray<boolean>,
     stringArray: ReadOnlyArray<string>,
     floatArray: ReadOnlyArray<Float>,
@@ -1122,12 +1122,12 @@ export interface ModuleProps extends ViewProps {
 type NativeType = HostComponent<ModuleProps>;
 
 export type ScrollTo = (
-  viewRef: React.ElementRef<NativeType>,
+  viewRef: React.ComponentRef<NativeType>,
   y: Int,
   animated: Boolean,
 ) => Void;
 export type AddOverlays = (
-  viewRef: React.ElementRef<NativeType>,
+  viewRef: React.ComponentRef<NativeType>,
   overlayColorsReadOnly: ReadOnlyArray<string>,
   overlayColorsArray: Array<string>,
   overlayColorsArrayAnnotation: string[],
@@ -1193,7 +1193,7 @@ export interface ModuleNativeState {
 
 type NativeType = HostComponent<ModuleProps>;
 
-export type ScrollTo = (viewRef: React.ElementRef<NativeType>, y: Int, animated: Boolean) => Void;
+export type ScrollTo = (viewRef: React.ComponentRef<NativeType>, y: Int, animated: Boolean) => Void;
 
 interface NativeCommands {
   readonly scrollTo: ScrollTo;
@@ -2184,17 +2184,17 @@ export interface ModuleProps extends ViewProps {
 type NativeType = HostComponent<ModuleProps>;
 
  interface NativeCommands {
-   readonly handleRootTag: (viewRef: React.ElementRef<NativeType>, rootTag: RootTag) => void;
-   readonly hotspotUpdate: (viewRef: React.ElementRef<NativeType>, x: CodegenTypes.Int32, y: CodegenTypes.Int32) => void;
+   readonly handleRootTag: (viewRef: React.ComponentRef<NativeType>, rootTag: RootTag) => void;
+   readonly hotspotUpdate: (viewRef: React.ComponentRef<NativeType>, x: CodegenTypes.Int32, y: CodegenTypes.Int32) => void;
    scrollTo(
-     viewRef: React.ElementRef<NativeType>,
+     viewRef: React.ComponentRef<NativeType>,
      x: CodegenTypes.Float,
      y: CodegenTypes.Int32,
      z: CodegenTypes.Double,
      animated: boolean,
    ): void;
    readonly arrayArgs: (
-    viewRef: React.ElementRef<NativeType>,
+    viewRef: React.ComponentRef<NativeType>,
     booleanArray: ReadOnlyArray<boolean>,
     stringArray: ReadOnlyArray<string>,
     floatArray: ReadOnlyArray<CodegenTypes.Float>,
@@ -2243,12 +2243,12 @@ export interface ModuleProps extends ViewProps {
 type NativeType = HostComponent<ModuleProps>;
 
 export type ScrollTo = (
-  viewRef: React.ElementRef<NativeType>,
+  viewRef: React.ComponentRef<NativeType>,
   y: Int,
   animated: Boolean,
 ) => Void;
 export type AddOverlays = (
-  viewRef: React.ElementRef<NativeType>,
+  viewRef: React.ComponentRef<NativeType>,
   overlayColorsReadOnly: ReadOnlyArray<string>,
   overlayColorsArray: Array<string>,
   overlayColorsArrayAnnotation: string[],
@@ -2310,7 +2310,7 @@ export interface ModuleNativeState {
 
 type NativeType = HostComponent<ModuleProps>;
 
-export type ScrollTo = (viewRef: React.ElementRef<NativeType>, y: Int, animated: Boolean) => Void;
+export type ScrollTo = (viewRef: React.ComponentRef<NativeType>, y: Int, animated: Boolean) => Void;
 
 interface NativeCommands {
   readonly scrollTo: ScrollTo;

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
@@ -6,11 +6,11 @@ exports[`RN Codegen TypeScript Parser Fails with error message COMMANDS_DEFINED_
 
 exports[`RN Codegen TypeScript Parser Fails with error message COMMANDS_DEFINED_WITH_MISMATCHED_METHOD_NAMES 1`] = `"codegenNativeCommands expected the same supportedCommands specified in the NativeCommands interface: hotspotUpdate, scrollTo"`;
 
-exports[`RN Codegen TypeScript Parser Fails with error message COMMANDS_DEFINED_WITH_NULLABLE_REF 1`] = `"The first argument of method hotspotUpdate must be of type React.ElementRef<>"`;
+exports[`RN Codegen TypeScript Parser Fails with error message COMMANDS_DEFINED_WITH_NULLABLE_REF 1`] = `"The first argument of method hotspotUpdate must be of type React.ElementRef<> or React.ComponentRef<>"`;
 
 exports[`RN Codegen TypeScript Parser Fails with error message COMMANDS_DEFINED_WITHOUT_METHOD_NAMES 1`] = `"codegenNativeCommands must be passed options including the supported commands"`;
 
-exports[`RN Codegen TypeScript Parser Fails with error message COMMANDS_DEFINED_WITHOUT_REF 1`] = `"The first argument of method hotspotUpdate must be of type React.ElementRef<>"`;
+exports[`RN Codegen TypeScript Parser Fails with error message COMMANDS_DEFINED_WITHOUT_REF 1`] = `"The first argument of method hotspotUpdate must be of type React.ElementRef<> or React.ComponentRef<>"`;
 
 exports[`RN Codegen TypeScript Parser Fails with error message NON_OPTIONAL_KEY_WITH_DEFAULT_VALUE 1`] = `"key required_key_with_default must be optional if used with WithDefault<> annotation"`;
 

--- a/packages/react-native-codegen/src/parsers/typescript/components/commands.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/commands.js
@@ -38,11 +38,12 @@ function buildCommandSchemaInternal(
       firstParam.typeAnnotation != null &&
       firstParam.typeAnnotation.type === 'TSTypeReference' &&
       firstParam.typeAnnotation.typeName.left?.name === 'React' &&
-      firstParam.typeAnnotation.typeName.right?.name === 'ElementRef'
+      (firstParam.typeAnnotation.typeName.right?.name === 'ElementRef' ||
+        firstParam.typeAnnotation.typeName.right?.name === 'ComponentRef')
     )
   ) {
     throw new Error(
-      `The first argument of method ${name} must be of type React.ElementRef<>`,
+      `The first argument of method ${name} must be of type React.ElementRef<> or React.ComponentRef<>`,
     );
   }
 


### PR DESCRIPTION
## Summary

Backport of facebook/react-native#54274.

React 19 renamed `React.ElementRef` to `React.ComponentRef`, and the TypeScript commands parser here only accepts `ElementRef`, so a command typed with `ComponentRef` fails codegen. `react-native` main already accepts both, but `react-native-macos` 0.81 does not.

This shows up with `react-native-screens@4.26`, which types a command's first argument as `React.ComponentRef<>`. `ElementRef` still works, so existing command specs continue to pass.

## Test plan

- `yarn jest packages/react-native-codegen --watchman=false` (66 suites, 2,949 tests, and 1,128 snapshots pass)
- Prettier check on the modified JavaScript files
- ESLint on the modified JavaScript files
- `git diff --check origin/0.81-stable...HEAD`
